### PR TITLE
feat: symphony-oneshot skill — OneShot pattern on the Symphony Kanban

### DIFF
--- a/.claude/skills/symphony-oneshot/SKILL.md
+++ b/.claude/skills/symphony-oneshot/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: symphony-oneshot
+description: Use when the user wants a single prompt — a feature, a bugfix, a refactor, or a whole product — driven end-to-end through a rigorous decompose-build-verify-QA-deliver pipeline with a shared `.oneshot/vault/` for cross-agent knowledge and mechanical bash gates that refuse to close without proof. For browser apps, the QA gate produces Playwright + screenshots + a signed PDF report. Distinct from `using-symphony` (which is the bare CLI for ad-hoc tickets). Triggers on phrases like "one-shot this", "OneShot pattern", "decompose and dispatch with proof", "build with verification gates", "Playwright sign-off PDF", "fix this bug end-to-end", "ship this feature with QA evidence".
+---
+
+# Symphony OneShot
+
+Turn one user prompt into a delivered product. Adapts the [OneShot
+pattern](https://github.com/oneshot-repo/OneShot) (orchestrator-only-spawns +
+shared `vault/` + autonomous loop until done) onto Symphony's Kanban
+orchestrator (`using-symphony`). Production-grade verification is the gate;
+for browser apps the final gate is a Playwright-driven QA PDF.
+
+> **Hard precondition**: this skill runs *inside* the `symphony-multi-agent`
+> repo. If `which symphony` fails or `WORKFLOW.md` is missing, run
+> `using-symphony` setup first.
+
+## What's different from `using-symphony`
+
+`using-symphony` is the bare CLI; `symphony-oneshot` is one specific
+opinionated workflow built on top. They are not redundant — pick the one
+that fits the scope:
+
+| `using-symphony`                          | `symphony-oneshot`                                |
+|-------------------------------------------|---------------------------------------------------|
+| You write the ticket; one ticket = one task | You write a *prompt*; the skill produces N tickets — works for a one-line bugfix as much as a whole product |
+| One lane (Todo→Done) is fine               | Multi-lane: Brief→Plan→Build→Verify→QA→Polish→Deliver — tiny scopes collapse most of these (see "Scope" below) |
+| No shared knowledge across tickets         | All tickets read/write `.oneshot/vault/`          |
+| Verification is the operator's job         | Verification is a hard gate before Deliver       |
+| Browser apps: ad-hoc                       | Browser apps: Playwright + screenshots + PDF required |
+
+### Scope — the lanes scale down
+
+The 7-lane pipeline is the *full* shape. Tiny scopes elide lanes:
+
+| Scope                  | Typical ticket map                                                  |
+|------------------------|----------------------------------------------------------------------|
+| One-line bugfix        | Brief → Plan → 1 Build → Verify → Deliver (no QA, no Polish)         |
+| Single feature         | Brief → Plan → 1–3 Build → Verify → (QA if web) → Deliver            |
+| Refactor               | Brief → Plan → N Build → Verify → Deliver                            |
+| Whole product          | All 7 lanes; multiple Build slices in parallel                       |
+
+The Plan lane decides which lanes to instantiate. It MAY skip QA when
+`.oneshot/vault/.is_browser_app` is absent and MAY collapse Polish into
+Deliver when no findings exist. The vault, the gates, and the
+orchestrator-only-spawns rule do not change with scope.
+
+## Mental model in 30 seconds
+
+```
+ONE PROMPT
+   │
+   ▼
+┌─────────────────┐    writes    ┌──────────────────┐
+│  Orchestrator   │─────────────▶│  .oneshot/vault/ │  shared knowledge
+│ (this session)  │              │  brief / plan /  │  (append-only ledgers)
+│  ONLY spawns    │              │  decisions /     │
+│  — never codes  │              │  claims / verify │
+└─────────────────┘              └──────────────────┘
+   │ creates                              ▲
+   ▼                                      │ each worker
+┌─────────────────┐  dispatches  ┌──────────────────┐  reads + appends
+│ symphony tui /  │─────────────▶│  Per-lane workers│  (fresh context
+│ symphony srv    │              │  Brief / Plan /  │   per ticket)
+│ (file tracker)  │              │  Build / Verify /│
+└─────────────────┘              │  QA / Polish /   │
+                                 │  Deliver         │
+                                 └──────────────────┘
+                                          │
+                                          ▼
+                            Deliver lane WILL NOT close
+                            until verify.md is green AND
+                            (for web) qa-report.pdf exists.
+```
+
+**Three invariants borrowed from OneShot:**
+1. The orchestrator NEVER writes implementation, plans, or verification inline. It only spawns Symphony tickets. If you catch yourself coding, stop and dispatch a ticket instead.
+2. The `.oneshot/vault/` is the only persistent state. Per-ticket workspaces are throwaway.
+3. The loop continues until **delivery proof exists**, not until tickets are "Done." Done without proof = re-open.
+
+## When to use
+
+- "Build me X end-to-end from this spec" — full product from one prompt.
+- Ambitious multi-component work where parallelism + isolated contexts win.
+- Any deliverable where the user expects *evidence* (tests, screenshots, PDF) not just code.
+
+## When NOT to use
+
+- Single-file change → use `using-symphony` directly.
+- Pure exploration / research → use `explore` skill.
+- The user wants to drive each ticket themselves → `using-symphony` is the right granularity.
+- You're not in the `symphony-multi-agent` repo (or in a project that vendored it).
+
+## Top-level recipe
+
+```bash
+# 0. Preflight
+symphony doctor ./WORKFLOW.md           # must be green
+
+# 1. Bootstrap vault + workflow + intake ticket from the user's prompt
+bash .claude/skills/symphony-oneshot/templates/bootstrap.sh \
+  "<user's one-shot prompt>"            # writes .oneshot/, copies WORKFLOW.oneshot.md → WORKFLOW.md, creates INTAKE-1
+
+# 2. Launch headless (orchestrator session has no TTY)
+symphony ./WORKFLOW.md --port 9999 2>> log/symphony.log &
+
+# 3. Watch the lanes flow. Poll, don't tight-loop. Loop terminates when DELIVER reaches Delivered.
+while true; do
+  state=$(curl -s http://127.0.0.1:9999/api/v1/state | jq -r '.issues[] | select(.identifier|startswith("DELIVER")) | .state' | head -1)
+  curl -s http://127.0.0.1:9999/api/v1/state | jq '.counts'
+  case "$state" in
+    Delivered) echo "✓ delivered"; break ;;
+    Blocked|Cancelled) echo "⚠ stopped: $state — see kanban/DELIVER-*.md ## Blocker"; break ;;
+  esac
+  sleep 30
+done
+
+# 4. Inspect proof
+ls .oneshot/vault/artifacts/                  # qa-report.pdf, screenshots/, test-results/
+cat .oneshot/vault/verification.md           # what was actually run
+cat .oneshot/vault/delivery.md               # final manifest
+```
+
+The `bootstrap.sh` and the lane prompts do all the heavy lifting — see
+references below for the *why*.
+
+## Decision: which reference do I open?
+
+| Need                                                           | Read                                |
+|----------------------------------------------------------------|-------------------------------------|
+| What lives in the vault and who owns each file                 | `reference/vault.md`                |
+| The actual lane definitions + per-lane prompts (Liquid body)   | `reference/lanes.md`                |
+| Browser-app QA: Playwright spec, screenshot policy, PDF gate   | `reference/qa-browser.md`           |
+| Decomposition heuristics — splitting the one-shot prompt       | `reference/decomposition.md`        |
+| Stuck/blocked/loop-not-terminating — diagnosis                 | `reference/troubleshooting.md`      |
+
+## Templates (ready to copy)
+
+| File                                          | Purpose                                          |
+|-----------------------------------------------|--------------------------------------------------|
+| `templates/bootstrap.sh`                      | One-shot prompt → vault + WORKFLOW.md + INTAKE-1 |
+| `templates/WORKFLOW.oneshot.md`               | Drop-in WORKFLOW.md with all 7 lanes wired       |
+| `templates/SYSTEM.md`                         | Orchestrator constitution (copied into vault)    |
+| `templates/playwright-qa.spec.ts`             | Stub Playwright QA test (golden + edge + a11y)   |
+| `templates/qa-pdf.sh`                         | Markdown QA report + screenshots → PDF (Playwright-rendered) |
+| `templates/vault-skeleton/`                   | Starter `brief.md`, `plan.md`, ledgers           |
+
+## Production-grade verification — the iron rule
+
+> **A ticket is only Done when its claim has been independently verified.**
+
+The Verify lane runs *after* Build and treats `claims.md` as untrusted input.
+It re-runs the tests, re-types the code, re-lints, and writes the actual
+results to `verification.md`. **Discrepancy between claims and verification
+forces the Build ticket back open.** This mirrors OneShot's "proof trail."
+
+For browser apps, the QA lane adds a second independent gate: it doesn't
+read the code, it drives the running app via Playwright. If the QA spec
+fails, or `qa-report.pdf` cannot be produced, the Deliver lane is
+mechanically blocked — there's a literal `[ -f .oneshot/vault/artifacts/qa-report.pdf ] || exit 1`
+in the Deliver prompt's bash gate.
+
+See `reference/lanes.md` for the exact gate logic and `reference/qa-browser.md`
+for how the PDF is produced (Playwright renders Markdown→HTML→PDF, no
+external pandoc/wkhtmltopdf dependency).
+
+## Common mistakes
+
+| Symptom                                                | Cause                                                  | Fix                                              |
+|--------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------|
+| Orchestrator session starts coding                      | Forgot it's spawn-only                                 | Stop. Re-read SKILL.md invariant #1. Dispatch.   |
+| Tickets duplicate work                                  | Workers didn't read the vault                          | Lane prompts MUST `cat .oneshot/vault/plan.md` first; see `reference/lanes.md` |
+| Verify lane passes but app is broken                    | Build claimed without running                          | Verify must `npm test` from scratch, not trust   |
+| `qa-report.pdf` missing but Deliver closed             | Skipped the bash gate                                  | Re-paste lane prompt — gate is the last line     |
+| Vault grows unbounded                                   | Ledgers being rewritten instead of appended            | Enforce: claims/decisions/verification are append-only |
+
+## Cross-references
+
+- **REQUIRES**: `using-symphony` (you must understand the underlying CLI first)
+- **COMPOSES WITH**: `qa-engineer` (browser sign-off — invoked by QA lane prompt)
+- **ALTERNATIVE**: `codex-goal-handoff` (similar long-horizon pattern but via Codex's `/goal` Ralph loop instead of Symphony's polling Kanban)

--- a/.claude/skills/symphony-oneshot/reference/decomposition.md
+++ b/.claude/skills/symphony-oneshot/reference/decomposition.md
@@ -1,0 +1,76 @@
+# Decomposition heuristics — turning one prompt into N tickets
+
+The Plan lane is the only lane that decides what tickets exist. Quality of
+decomposition is the upper bound on quality of delivery — if the Plan lane
+ships a bad ticket map, no amount of clever Build/Verify/QA work fixes it.
+
+## The decomposition checklist (Plan lane runs this)
+
+For each candidate ticket:
+
+1. **Is it independently testable?** — A ticket whose tests need another
+   un-built ticket should be merged with that ticket OR sequenced via
+   `blocked_by`.
+2. **Is its spec self-contained?** — Worker reads only the ticket's
+   description + vault. If a third file is needed, add it to the spec.
+3. **Does it fit one context window?** — Rough rule: a Build ticket should
+   touch ≤5 files and ≤500 net lines. Bigger → split.
+4. **Does it own one contract?** — Each Build ticket owns one section of
+   `contracts.md`. Two tickets owning the same contract is a merge conflict
+   waiting to happen.
+
+## Common slice patterns by product type
+
+### CRUD web app
+```
+BUILD-1  Schema + migrations            (no deps)
+BUILD-2  Auth: signup/login/session     (deps: BUILD-1)
+BUILD-3  API: <resource> CRUD           (deps: BUILD-1, BUILD-2)
+BUILD-4  Web UI: list + detail + form   (deps: BUILD-3)
+BUILD-5  Web UI: signup/login pages     (deps: BUILD-2)
+VERIFY-1 Full suite + integration       (deps: BUILD-*)
+QA-1     Playwright golden + edge       (deps: BUILD-4, BUILD-5)
+DELIVER-1 Package + README + tag        (deps: VERIFY-1, QA-1)
+```
+
+### CLI tool
+```
+BUILD-1  Core domain logic + unit tests   (no deps)
+BUILD-2  CLI surface (argparse/clap/etc)  (deps: BUILD-1)
+BUILD-3  Output formatting                (deps: BUILD-1)
+BUILD-4  Config loading (env/file)        (deps: BUILD-2)
+VERIFY-1 Integration tests + golden CLI   (deps: BUILD-*)
+DELIVER-1 README + man page + binary      (deps: VERIFY-1)
+```
+(no QA lane — `.is_browser_app` not set)
+
+### Static landing page
+```
+BUILD-1  Hero + nav + footer (semantic HTML)   (no deps)
+BUILD-2  Section components                    (deps: BUILD-1)
+BUILD-3  Styling + responsive                  (deps: BUILD-2)
+BUILD-4  Build pipeline (vite/astro/etc)       (deps: BUILD-3)
+VERIFY-1 Lighthouse + HTML validation          (deps: BUILD-*)
+QA-1     Playwright cross-viewport + a11y      (deps: BUILD-*)
+DELIVER-1 Deploy script + DNS notes            (deps: VERIFY-1, QA-1)
+```
+
+## Anti-patterns
+
+| Anti-pattern | Why it breaks | Fix |
+|--------------|---------------|-----|
+| One giant BUILD-1 "implement everything" | No parallelism; verify lane has nothing to compare against | Split per layer or per route |
+| Build tickets call each other's internals | Re-introduces sequential dependency | Talk only via `contracts.md` |
+| QA ticket created before any Build ticket | Nothing to test; QA worker idles or hallucinates | QA `blocked_by` all relevant Build tickets |
+| Verify ticket per Build ticket | Ledger fragmentation; can't see integration failures | One Verify ticket per release; runs full suite |
+| "Polish" used as catchall for missed work | Polish balloons; brief.md gets re-litigated | Polish only addresses verified findings; new scope → new ticket |
+
+## Sizing the Plan
+
+If decomposition produces >12 Build tickets, the Plan lane should *itself*
+split: produce a `plan-phase-1.md`, `plan-phase-2.md` and only spawn
+phase 1 tickets now. The Deliver gate of phase 1 then triggers a fresh
+Plan ticket for phase 2 (set `blocked_by` accordingly).
+
+This caps the in-flight surface area at ~10 active tickets, which is
+roughly the most a single Verify lane can hold in its head.

--- a/.claude/skills/symphony-oneshot/reference/lanes.md
+++ b/.claude/skills/symphony-oneshot/reference/lanes.md
@@ -1,0 +1,256 @@
+> **Authoritative source**: `templates/WORKFLOW.oneshot.md` is the single
+> source of truth for lane prompts. This file explains the *why* and
+> shows the lane semantics in summary form. If anything here disagrees
+> with the template, the template wins.
+
+# The seven lanes — definitions + per-state prompts
+
+This skill uses Symphony's `tracker.active_states` + Liquid prompt branching
+to give each lane its own *implicit system prompt*. Workers see only the
+prompt for their current state, so context stays minimal and roles stay
+separate.
+
+## Lane order
+
+```
+Brief → Plan → Build → Verify → QA → Polish → Deliver
+                ▲                         │
+                └─── Polish reopens ──────┘
+```
+
+Polish can re-open Build tickets when QA finds issues. Verify can re-open
+Build tickets when claims don't reproduce. Everything else flows forward.
+
+## Lane responsibilities
+
+| Lane     | Reads (vault)                                              | Writes (vault)                  | Closes by setting state to | Hard gate before closing |
+|----------|------------------------------------------------------------|---------------------------------|----------------------------|--------------------------|
+| Brief    | `prompt.md`                                                | `brief.md`                      | `Plan`                     | brief.md has all required sections |
+| Plan     | `prompt.md`, `brief.md`                                    | `plan.md`, `architecture.md`, `contracts.md`, *spawns N Build/Verify/QA/Deliver tickets* | `Done` (this ticket) | plan.md ticket table is complete |
+| Build    | `brief.md`, `plan.md`, `architecture.md`, `contracts.md`, `decisions.log` | code in workspace + append to `claims.md` | `Verify` | tests pass locally + claim entry written |
+| Verify   | `plan.md`, `claims.md`                                     | append to `verification.md`     | `QA` (if web) or `Polish` (if not) **OR** reopen Build → `Build` | every claim re-run; verdict written |
+| QA       | `brief.md`, running app                                    | `qa-report.md`, `artifacts/screenshots/*`, `artifacts/qa-report.pdf` | `Polish` **OR** reopen Build → `Build` | qa-report.pdf exists + sha256 logged |
+| Polish   | `verification.md`, `qa-report.md`                          | append to `decisions.log`; may spawn fixup tickets | `Deliver` | no open critical findings |
+| Deliver  | everything                                                 | `delivery.md`                   | `Delivered`                | bash gate (see below) |
+
+## The Deliver gate (literal bash)
+
+```bash
+set -e
+test -s .oneshot/vault/brief.md
+test -s .oneshot/vault/plan.md
+test -s .oneshot/vault/verification.md
+grep -q '^verdict: GREEN' .oneshot/vault/verification.md || { echo "verify not green"; exit 1; }
+if [ -f .oneshot/vault/.is_browser_app ]; then
+  test -s .oneshot/vault/artifacts/qa-report.pdf
+  grep -q '^Verdict: APPROVED FOR DELIVERY' .oneshot/vault/qa-report.md
+fi
+```
+
+Pasting this into the Deliver lane's prompt (see `templates/WORKFLOW.oneshot.md`)
+makes the gate mechanical. The agent literally cannot mark Delivered if the
+shell exits non-zero — Symphony will retry the ticket until either the gate
+passes or `agent.max_turns` exhausts.
+
+## Per-lane prompts (Liquid body)
+
+This is the body of `WORKFLOW.md` — pasted here as a *reference*; the
+copy-and-edit version is `templates/WORKFLOW.oneshot.md`. The orchestrator
+re-renders this every turn with the current ticket's `issue.state`.
+
+```liquid
+You are Symphony OneShot worker for ticket {{ issue.identifier }}: {{ issue.title }}.
+Current lane: {{ issue.state }}.
+
+ALWAYS START BY:
+  cat .oneshot/SYSTEM.md            # 3 invariants — re-anchor every turn
+  cat .oneshot/vault/brief.md 2>/dev/null || true
+
+The vault is at .oneshot/vault/ in the project root (NOT inside this workspace).
+Append-only files: claims.md, verification.md, decisions.log. Use `>>` redirect.
+
+----- LANE-SPECIFIC INSTRUCTIONS -----
+
+{% if issue.state == "Brief" %}
+You are the Brief lane. Convert the raw user prompt into a structured brief.
+Inputs:  .oneshot/prompt.md
+Outputs: .oneshot/vault/brief.md (with sections: Goal, Audience, Done criteria, Constraints, Out of scope, Proof requirements)
+Done criteria MUST be objective (commands that can be run, files that must exist, behaviors that can be checked).
+For browser apps, the Proof requirements section MUST include a Playwright spec covering the primary user flow.
+If the app appears to be a web/browser app (HTML, React, Vue, Svelte, Next, etc.), `touch .oneshot/vault/.is_browser_app`.
+When done: set this ticket's state to `Plan` AND create the next ticket:
+  symphony board new PLAN-1 "Decompose into work tickets" --priority 1
+Then transition: edit kanban/{{ issue.identifier }}.md → state: Done, append `## Resolution`.
+
+{% elsif issue.state == "Plan" %}
+You are the Plan lane. ONLY job: produce a complete decomposition.
+Inputs:  .oneshot/vault/brief.md, .oneshot/vault/prompt.md
+Outputs:
+  .oneshot/vault/plan.md          # ticket table + per-ticket spec sections
+  .oneshot/vault/architecture.md  # system design, components, data model
+  .oneshot/vault/contracts.md     # interface contracts between Build slices
+For each Build/Verify/QA/Deliver ticket in plan.md, create it via:
+  symphony board new BUILD-N "<title>" --priority 2 \
+    --description "$(cat <<'EOF'
+read .oneshot/vault/plan.md §BUILD-N for the spec
+EOF
+)"
+For BUILD tickets that depend on others, set blocked_by in the kanban file's frontmatter.
+After all tickets are created, set this ticket's state to `Done` (Plan ticket itself terminates).
+Constraint: do NOT write any implementation code yourself. If you catch yourself implementing, stop.
+
+{% elsif issue.state == "Build" %}
+You are a Build lane worker for one slice.
+Inputs:  .oneshot/vault/brief.md, plan.md (read your §section only), architecture.md, contracts.md, decisions.log
+Outputs: code in this workspace + an append entry to .oneshot/vault/claims.md
+Workflow:
+  1. Read `plan.md` and find §{{ issue.identifier }}'s spec.
+  2. Implement. Follow contracts.md exactly — if you need a contract change, edit contracts.md AND open a ticket against the owning slice; do not silently mock.
+  3. Write tests for the slice you built. Run them. They must pass.
+  4. Run typecheck + lint if the project has them.
+  5. Append to claims.md with the run-to-prove command:
+       cat >> .oneshot/vault/claims.md <<EOF
+       ## $(date -u +%FT%TZ) {{ issue.identifier }} → ReadyToVerify
+       - <what you implemented>
+       - tests: <files added/modified>
+       - run-to-prove: \`<exact command(s)>\`
+       - last run: <PASS/FAIL + counts>
+       EOF
+  6. Set state to `Verify`. Do NOT close the Verify ticket — that's a separate worker.
+If you discover a design pivot, append to decisions.log first, then continue.
+
+{% elsif issue.state == "Verify" %}
+You are the Verify lane. You are an ADVERSARY to claims.md — re-prove every entry.
+Inputs:  .oneshot/vault/plan.md, .oneshot/vault/claims.md
+Outputs: append to .oneshot/vault/verification.md
+Workflow:
+  1. For each claim entry whose ticket is in state Verify, run its `run-to-prove` command from a clean workspace.
+  2. Additionally, exercise integration points across slices (e.g. start the dev server and curl it).
+  3. Run the full test suite (`npm test` / `pytest` / `go test ./...`) — not just the slice's tests.
+  4. Type-check and lint the whole project, not just the slice.
+  5. Append to verification.md:
+       cat >> .oneshot/vault/verification.md <<EOF
+       ## $(date -u +%FT%TZ) Verify ran <ticket list>
+       - claim re-runs: <results>
+       - integration probes: <results>
+       - full suite: <results>
+       verdict: <GREEN | RED>
+       EOF
+  6. If GREEN: for each verified Build ticket, set its state to `QA` (if .is_browser_app) or `Polish` (otherwise).
+  7. If RED: for each ticket whose claim didn't reproduce, set its state back to `Build` and append an `## Issues` section to its kanban/<ID>.md body explaining the discrepancy.
+Do NOT edit application code. Verify is read-only on the codebase.
+
+{% elsif issue.state == "QA" %}
+You are the QA lane (browser apps only). Drive the running app via Playwright.
+Inputs:  .oneshot/vault/brief.md (Done criteria + Proof requirements)
+Outputs:
+  .oneshot/vault/qa-report.md
+  .oneshot/vault/artifacts/screenshots/<flow>-<step>.png
+  .oneshot/vault/artifacts/qa-report.pdf
+Setup:
+  - Start the app per brief.md's "How to run" — capture the URL.
+  - If no Playwright config exists, copy the stub:
+      cp .claude/skills/symphony-oneshot/templates/playwright-qa.spec.ts tests/e2e/qa.spec.ts
+      npm i -D @playwright/test axe-playwright
+      npx playwright install chromium
+  - Edit qa.spec.ts to cover every flow listed in brief.md's Proof requirements.
+Run:
+  npx playwright test tests/e2e/qa.spec.ts \
+    --reporter=list,json --output=.oneshot/vault/artifacts/test-results
+  # Each test must call await page.screenshot({ path: '.oneshot/vault/artifacts/screenshots/<name>.png', fullPage: true });
+Build the markdown report:
+  - Coverage table (one row per flow + result + screenshot path)
+  - Findings (any flake, layout bug, a11y violation)
+  - Sign-off block ending with `Verdict: APPROVED FOR DELIVERY` or `Verdict: BLOCKED — see Findings`
+Render to PDF:
+  bash .claude/skills/symphony-oneshot/templates/qa-pdf.sh
+  # uses Playwright itself to render qa-report.md → qa-report.pdf — no pandoc/wkhtmltopdf needed
+Verify artifact exists + log sha256:
+  test -s .oneshot/vault/artifacts/qa-report.pdf || exit 1
+  shasum -a 256 .oneshot/vault/artifacts/qa-report.pdf >> .oneshot/vault/verification.md
+Transition:
+  - APPROVED → set state to `Polish`.
+  - BLOCKED  → set the underlying Build ticket(s) back to `Build` with reproduction steps.
+
+{% elsif issue.state == "Polish" %}
+You are the Polish lane. Read findings, decide what (if anything) to address.
+Inputs:  .oneshot/vault/verification.md, .oneshot/vault/qa-report.md
+Outputs: appended decisions to .oneshot/vault/decisions.log; possibly new fixup tickets
+Rules:
+  - If a finding is a P0/P1 (security, data loss, broken golden path): create a Build ticket for the fix, set its blocked_by to this Polish ticket, transition this Polish ticket to `Blocked` until the fix lands and re-flows through Verify+QA.
+  - If a finding is cosmetic and out-of-scope per brief.md: log the decision in decisions.log and proceed.
+  - If everything is acceptable: set state to `Deliver`.
+
+{% elsif issue.state == "Deliver" %}
+You are the Deliver lane. Final packaging + sign-off.
+Inputs: everything in .oneshot/vault/
+Outputs: .oneshot/vault/delivery.md
+Hard gate (run this FIRST — abort if non-zero):
+  set -e
+  test -s .oneshot/vault/brief.md
+  test -s .oneshot/vault/plan.md
+  test -s .oneshot/vault/verification.md
+  grep -q '^verdict: GREEN' .oneshot/vault/verification.md
+  if [ -f .oneshot/vault/.is_browser_app ]; then
+    test -s .oneshot/vault/artifacts/qa-report.pdf
+    grep -q '^Verdict: APPROVED FOR DELIVERY' .oneshot/vault/qa-report.md
+  fi
+If gate passes:
+  - Write .oneshot/vault/delivery.md (artifacts list with sha256s, run instructions, brief.md done-criteria checklist with ✓s and citations to verification.md timestamps).
+  - Tag the git commit: `git tag -a oneshot-delivered -m "..."`
+  - Set state to `Delivered`. Append `## Resolution` to this ticket pointing at delivery.md.
+If gate fails:
+  - Set state to `Blocked` with `## Blocker` listing exactly which check failed.
+
+{% else %}
+Unknown lane: {{ issue.state }}. Set state to `Blocked` with a `## Blocker` section noting the lane is not recognized.
+{% endif %}
+
+----- ALWAYS END BY -----
+echo "{{ issue.identifier }} turn complete: lane={{ issue.state }} at $(date -u +%FT%TZ)" >> log/oneshot.log
+```
+
+## Why each lane minimizes its vault reads
+
+Naive design: every worker reads the entire vault → context blows up by
+ticket #5.
+
+This design assigns each lane the *minimum sufficient* set:
+- Build doesn't read claims/verification (it's not its job to know what others did).
+- Verify doesn't read brief.md (it doesn't decide what's correct, only whether claims reproduce).
+- QA doesn't read code (drives the app as a black box, like a real QA engineer).
+- Polish only reads findings, not raw output.
+
+This is the OneShot insight: **role separation enforced by what you read,
+not just what you do.** A worker that doesn't load a file can't be tempted
+to second-guess that file's owner.
+
+## Concurrency
+
+Configure in WORKFLOW.md:
+```yaml
+agent:
+  max_concurrent_agents: 4
+  max_concurrent_agents_by_state:
+    Brief: 1        # only one brief
+    Plan: 1         # only one plan
+    Build: 4        # parallelize implementation
+    Verify: 1       # one verifier — avoids conflicting reruns
+    QA: 1           # one QA — avoids screenshot collisions in artifacts/
+    Polish: 1
+    Deliver: 1
+```
+The default `max_concurrent_agents: 4` makes Build the wide step. All other
+lanes are intentionally single-threaded.
+
+## Cross-reference
+
+When QA lane needs to invoke the user's existing `qa-engineer` skill (for
+deployed-environment sign-off rather than localhost), prepend this to the
+QA prompt body:
+```
+If the brief.md "How to run" indicates a deployed URL (https://*), invoke
+the qa-engineer skill rather than this lane's localhost flow. The skill
+produces its own evidence pack — copy its outputs into
+.oneshot/vault/artifacts/ before transitioning.
+```

--- a/.claude/skills/symphony-oneshot/reference/qa-browser.md
+++ b/.claude/skills/symphony-oneshot/reference/qa-browser.md
@@ -1,0 +1,182 @@
+# Browser-app QA — Playwright + screenshots + PDF gate
+
+For any product where `.oneshot/vault/.is_browser_app` exists, the QA lane
+runs a black-box, end-to-end Playwright sweep, captures a screenshot per
+flow step, and emits an *officially signed* QA report PDF as the gate
+artifact for the Deliver lane.
+
+> **Why a PDF gate?** Markdown can be hand-edited at the last second to
+> claim approval. A PDF rendered fresh from the markdown + screenshots is a
+> snapshot — its sha256 is logged in `verification.md`, so any later edit
+> to the markdown invalidates the gate. The bytes either exist with the
+> right hash or they don't.
+
+## What the QA lane produces
+
+```
+.oneshot/vault/
+├── qa-report.md                   # markdown source (human-readable, version-controlled)
+└── artifacts/
+    ├── qa-report.pdf              # GATE artifact — Deliver lane checks for this
+    ├── screenshots/
+    │   ├── signup-1-empty-form.png
+    │   ├── signup-2-validation-errors.png
+    │   ├── signup-3-success-redirect.png
+    │   ├── login-1-form.png
+    │   ├── login-2-dashboard.png
+    │   └── ...
+    └── test-results/
+        ├── results.json           # Playwright JSON reporter
+        └── trace.zip              # Playwright trace for failures
+```
+
+## The Playwright spec — what to cover
+
+The QA lane reads `brief.md` "Proof requirements" and "Done criteria" and
+turns each user-visible item into a Playwright test. Required coverage:
+
+1. **Golden path** — happy flow end-to-end for every primary persona in `brief.md`'s Audience section.
+2. **Critical edge cases** — at minimum: empty input, oversized input, duplicate submission, network failure mid-flow (use `route.abort()`), back-button mid-flow.
+3. **Authentication boundary** — if auth is in scope: unauthed access to protected routes redirects to login; logout actually invalidates the session.
+4. **Accessibility** — `axe-playwright` scan on every page in golden path; fail on `serious` or `critical` violations.
+5. **Visual evidence** — every test step that changes the rendered DOM calls `page.screenshot({ fullPage: true })` into `artifacts/screenshots/`.
+
+The stub at `templates/playwright-qa.spec.ts` shows all five categories
+wired up — adapt URLs/selectors to the product but don't drop categories.
+
+## Screenshot naming convention
+
+`<flow>-<step-number>-<short-description>.png`
+
+Examples: `signup-1-empty-form.png`, `checkout-3-stripe-modal.png`,
+`a11y-2-dashboard.png`. The QA report's coverage table cites these paths
+verbatim, so the convention matters — broken citations break the report.
+
+## How the PDF is rendered (no extra deps)
+
+`templates/qa-pdf.sh` uses Playwright itself (already installed because the
+QA spec runs on it) to render the markdown report to PDF. The pipeline:
+
+```
+qa-report.md  ─marked─▶  qa-report.html  ─Playwright page.pdf()─▶  qa-report.pdf
+                ▲
+                screenshots embedded as <img src="…"> with absolute paths
+```
+
+This avoids the typical PDF stack (`pandoc + wkhtmltopdf + LaTeX`) which
+is heavy and version-fragile. Playwright is already required for the QA
+spec, so the cost is zero new dependencies.
+
+The script writes PDF metadata (Title, Subject, Producer, CreationDate),
+embeds the screenshots inline, and uses A4 + 18mm margins by default.
+
+## The QA report format
+
+```markdown
+# QA Report — <product name from brief.md>
+
+| Field        | Value                                  |
+|--------------|----------------------------------------|
+| Date         | 2026-05-09T15:42Z                      |
+| Build SHA    | abc1234                                |
+| Branch       | main                                   |
+| QA Agent     | claude-opus-4-7 via symphony-oneshot   |
+| Spec file    | tests/e2e/qa.spec.ts                   |
+| Total tests  | 14                                     |
+| Passed       | 14                                     |
+| Failed       | 0                                      |
+
+## 1. Golden paths
+
+### 1.1 Signup → Dashboard (anonymous user)
+| Step | Action | Expected | Actual | Screenshot |
+|------|--------|----------|--------|------------|
+| 1 | Visit /signup | Empty form rendered | ✓ rendered | `signup-1-empty.png` |
+| 2 | Fill valid creds, submit | Redirect to /dashboard | ✓ 302 → /dashboard | `signup-2-success.png` |
+| 3 | Verify dashboard greeting | "Hi, <user>!" visible | ✓ visible | `signup-3-dashboard.png` |
+
+(repeat per golden path)
+
+## 2. Edge cases
+
+| Case | Expected | Actual | Screenshot |
+|------|----------|--------|------------|
+| Empty signup form | Validation errors shown | ✓ | `signup-edge-empty.png` |
+| Duplicate email | "Already registered" error | ✓ | `signup-edge-dup.png` |
+| Network drop mid-submit | Retry button shown | ✓ | `signup-edge-netfail.png` |
+
+## 3. Authentication boundary
+...
+
+## 4. Accessibility (axe-core)
+| Page         | Violations (serious+) | Notes |
+|--------------|-----------------------|-------|
+| /            | 0                     | clean |
+| /signup      | 0                     | clean |
+| /dashboard   | 1                     | one moderate (missing skip-link) — not blocking |
+
+## 5. Performance smoke (optional but recommended)
+| Page | LCP | CLS | TBT |
+|------|-----|-----|-----|
+| /    | 1.2s | 0.04 | 80ms |
+
+## Findings
+- (none / list)
+
+## Sign-off
+QA agent: claude-opus-4-7
+Verified against: <git sha>
+PDF rendered: 2026-05-09T15:43Z
+sha256: <hash will be computed by qa-pdf.sh and written to verification.md>
+
+Verdict: APPROVED FOR DELIVERY
+```
+
+The sign-off block's last line is the literal trigger the Deliver gate
+greps for: `^Verdict: APPROVED FOR DELIVERY`.
+
+## How the Deliver lane uses the PDF
+
+```bash
+# Inside Deliver lane prompt's gate
+if [ -f .oneshot/vault/.is_browser_app ]; then
+  test -s .oneshot/vault/artifacts/qa-report.pdf || { echo "QA PDF missing"; exit 1; }
+  expected=$(grep -o '[0-9a-f]\{64\}' .oneshot/vault/verification.md | tail -1)
+  actual=$(shasum -a 256 .oneshot/vault/artifacts/qa-report.pdf | awk '{print $1}')
+  [ "$expected" = "$actual" ] || { echo "QA PDF hash mismatch — possible tampering"; exit 1; }
+  grep -q '^Verdict: APPROVED FOR DELIVERY' .oneshot/vault/qa-report.md \
+    || { echo "QA verdict not APPROVED"; exit 1; }
+fi
+```
+
+If any check fails, the Deliver ticket goes to `Blocked` with a precise
+`## Blocker` section. Symphony retries on the next poll until either the
+gate passes or `agent.max_turns` exhausts.
+
+## When the user's `qa-engineer` skill should run instead
+
+The `qa-engineer` skill exists for *deployed* (dev/stg/prod) environments
+on the user's company stack. Use it instead of the localhost Playwright
+flow when:
+
+- `brief.md`'s "How to run" points at an `https://*.aidt.*` (or other
+  company-deployed) URL, not `localhost:*`.
+- The product is being shipped *to* a deployed environment, not just built.
+
+In that case the QA lane prompt should:
+1. Invoke the `qa-engineer` skill against the deployed URL.
+2. Copy the skill's outputs into `.oneshot/vault/artifacts/`.
+3. Render the same `qa-report.md` + `qa-report.pdf` from those outputs so
+   the Deliver gate logic remains unchanged.
+
+This keeps the gate uniform regardless of which evidence-collector ran.
+
+## Anti-patterns
+
+| Symptom                                        | Cause                                         | Fix                                              |
+|------------------------------------------------|-----------------------------------------------|--------------------------------------------------|
+| PDF exists but tests didn't actually run       | QA agent generated the markdown without running spec | qa-pdf.sh requires `artifacts/test-results/results.json`; refuse to render without it |
+| Screenshots are empty white                    | App not yet ready when screenshot taken       | Always `await expect(locator).toBeVisible()` BEFORE `page.screenshot()` |
+| Different screenshot dimensions per run        | Default viewport drifted                      | `playwright.config.ts`: `use: { viewport: { width: 1440, height: 900 } }` |
+| QA approves but feature is broken              | Spec covers happy path only                   | Mandatory edge-case section; reviewer rejects PR if missing |
+| Deliver gate keeps failing on hash             | qa-report.md was edited after PDF render      | Re-render PDF; never edit md after sign-off      |

--- a/.claude/skills/symphony-oneshot/reference/troubleshooting.md
+++ b/.claude/skills/symphony-oneshot/reference/troubleshooting.md
@@ -1,0 +1,145 @@
+# Troubleshooting
+
+## The orchestrator session keeps writing code
+
+**Symptom**: You (the Claude session that ran `bootstrap.sh`) start
+implementing files instead of dispatching tickets.
+
+**Cause**: SYSTEM.md invariant #1 not re-read.
+
+**Fix**: Stop. `cat .oneshot/SYSTEM.md`. Open `using-symphony` skill's
+delegation pattern. The orchestrator's only legal moves are:
+`symphony board new`, `symphony board mv`, `cat .oneshot/vault/*`, polling
+the API. If you need to change code, dispatch a Build ticket.
+
+## Tickets created but no worker picks them up
+
+```bash
+# Diagnose
+symphony doctor ./WORKFLOW.md
+ps aux | grep symphony
+curl -s http://127.0.0.1:9999/api/v1/state | jq '.counts, .running'
+tail -50 log/symphony.log
+```
+
+Common causes:
+- Server not running → `symphony ./WORKFLOW.md --port 9999 2>> log/symphony.log &`
+- Port collision → `lsof -ti :9999 | xargs -r kill` then restart
+- `agent.kind` mismatched to installed CLI → `which claude`/`which codex`
+- `tracker.active_states` doesn't include the lane name (e.g. typo `Build` vs `build`) → fix YAML
+
+## Worker exits with `worker_exit reason=error`
+
+```bash
+# Find the failing ticket and read its workspace logs
+curl -s http://127.0.0.1:9999/api/v1/state | jq '.errors'
+ls ~/symphony_workspaces/<TICKET-ID>/.symphony/
+```
+
+Top causes:
+- `after_create` hook failed (e.g. `git clone` against placeholder URL) → fix WORKFLOW.md hooks; the OneShot template uses `: noop` so this shouldn't apply unless you changed it
+- Agent CLI authentication missing (`claude` not logged in, `codex` no API key) → fix and restart
+- Workspace disk full → `du -sh ~/symphony_workspaces/*`
+
+## Vault grows unbounded / claims.md is huge
+
+**Cause**: Probably correct — append-only ledgers grow. If it's actually
+problematic (>50MB), workers are doing too many turns per ticket. Check:
+```bash
+wc -l .oneshot/vault/claims.md .oneshot/vault/verification.md
+```
+If a single ticket has >20 entries, raise `agent.max_turns` is the wrong
+fix — split the ticket via the Plan lane instead.
+
+## Verify lane keeps RED'ing the same Build ticket
+
+Look at `verification.md` — it must cite the *exact discrepancy*. If it
+just says "tests failed" without specifics, the Verify prompt isn't being
+followed. Re-paste the Verify lane prompt from `templates/WORKFLOW.oneshot.md`.
+
+If the discrepancy is real and the Build worker can't reproduce it: there's
+likely environment drift between Verify's workspace and Build's. Run:
+```bash
+diff <(ls ~/symphony_workspaces/BUILD-N) <(ls ~/symphony_workspaces/VERIFY-1)
+```
+The OneShot pattern assumes hooks bring both workspaces to the same
+baseline. If `before_run: git fetch && git reset --hard origin/main` is
+missing, add it.
+
+## QA lane produces PDF but Deliver gate fails on hash
+
+**Cause**: `qa-report.md` was edited after `qa-pdf.sh` ran, so the live
+hash no longer matches the one logged to `verification.md`.
+
+**Fix**: Re-run QA lane. Discipline: nobody edits `qa-report.md` after the
+PDF is generated. If a real issue is found, set the Build ticket back to
+`Build` and let it re-flow through QA.
+
+## Deliver lane says `verify not green` but verification.md looks fine
+
+```bash
+grep '^verdict:' .oneshot/vault/verification.md
+```
+The gate looks for a line starting with `verdict: GREEN` (case-sensitive,
+no leading whitespace). If your verifier wrote `Verdict: green` or
+indented it, the grep fails. Either fix verification.md to match or relax
+the gate (not recommended — strict gates are the point).
+
+## Loop terminates with tickets still in non-terminal states
+
+```bash
+symphony board ls
+```
+If anything is in `Blocked` or has been retrying past `agent.max_turns`,
+the loop won't make progress. Look at the kanban file's `## Blocker`
+section — that's the agent telling you why. Common: external blocker
+(needs API key, needs human decision). Resolve, then `symphony board mv
+<ID> Build` (or whatever lane is appropriate) to unblock.
+
+## Browser app QA — Playwright can't find the dev server
+
+```bash
+# Check the brief.md "How to run" section is correct
+grep -A5 'How to run' .oneshot/vault/brief.md
+# Test manually
+curl -I http://localhost:3000   # or whatever port
+```
+The QA lane prompt assumes the app is running on a known URL. If
+`brief.md` doesn't pin the URL, the QA worker either guesses wrong or
+starts the app in a way that races with its own tests. Fix `brief.md`
+(via the Brief lane re-running, or by hand) and re-flow.
+
+## Cost is exploding
+
+OneShot acknowledges: this pattern uses many tokens. Per-ticket fresh
+context windows + autonomous looping + verify reruns multiply costs.
+
+Mitigations:
+- `agent.max_turns: 10` (default 20) caps runaway loops.
+- Set `agent.kind: claude` with `claude.command` using Haiku for
+  Build/Verify lanes if your decomposition is fine-grained — Haiku 4.5 is
+  ~3× cheaper at ~90% Sonnet performance.
+- Cap `agent.max_concurrent_agents_by_state.Build` to limit parallel burn.
+- Stop the loop early once you're satisfied with delivery proof; the
+  pattern doesn't require Polish/Deliver if the artifacts already meet
+  your threshold.
+
+## I want to abort the run
+
+```bash
+lsof -ti :9999 | xargs -r kill   # stop orchestrator
+symphony board ls                 # see what's where
+# Optionally archive vault for later inspection
+mv .oneshot .oneshot.aborted-$(date +%s)
+```
+
+## Getting unstuck — escalation path
+
+1. Read `.oneshot/vault/decisions.log` — recent design pivots may explain.
+2. Read the failing ticket's kanban file's `## Blocker` / `## Issues`.
+3. Read `verification.md` for the most recent verdict.
+4. Read `qa-report.md` for the most recent QA findings.
+5. If still stuck, manually transition the offending ticket back to an
+   earlier lane and let it re-flow.
+6. Last resort: `symphony board mv <ID> Cancelled` and re-decompose via
+   a fresh Plan ticket.

--- a/.claude/skills/symphony-oneshot/reference/vault.md
+++ b/.claude/skills/symphony-oneshot/reference/vault.md
@@ -1,0 +1,215 @@
+# The `.oneshot/vault/` — shared knowledge contract
+
+The vault is the *only* persistent state across worker sessions. Every
+ticket spawned by Symphony gets a fresh LLM context window, so anything
+the next worker needs to know MUST live in the vault. The vault sits in the
+project root (NOT inside any per-ticket workspace), so all workers see the
+same view via the `workspace.root` mount or via a shared bind-mount.
+
+> **Why outside the workspace**: Symphony creates `~/symphony_workspaces/<ID>/`
+> per ticket and the `after_create` hook clones a repo there. If the vault
+> lived *inside* the workspace it would be cloned-from-template per ticket
+> and divergent. Putting it at `<project_root>/.oneshot/vault/` and giving
+> workers the path via the `WORKFLOW.md` prompt body keeps it singular.
+
+## Layout
+
+```
+.oneshot/
+├── SYSTEM.md                # orchestrator constitution (read-only after bootstrap)
+├── prompt.md                # the user's original one-shot prompt (read-only)
+└── vault/
+    ├── brief.md             # north star: goal, audience, done criteria
+    ├── plan.md              # decomposition + ticket map (frozen after Plan lane)
+    ├── architecture.md      # system design, data model, deps (living)
+    ├── contracts.md         # API/interface contracts between slices (living)
+    ├── decisions.log        # ADR-lite, append-only
+    ├── claims.md            # per-ticket "I did X" entries, append-only
+    ├── verification.md      # per-ticket "I re-ran X and saw Y", append-only
+    ├── qa-report.md         # human-readable QA findings (markdown source for PDF)
+    ├── delivery.md          # final manifest, written only at Deliver lane
+    └── artifacts/
+        ├── qa-report.pdf    # PDF gate artifact for browser apps
+        ├── screenshots/     # Playwright screenshots (PNG)
+        └── test-results/    # raw JUnit/Playwright JSON outputs
+```
+
+## File-by-file contract
+
+### `SYSTEM.md` — orchestrator constitution
+- Written once by `bootstrap.sh`. Read-only thereafter.
+- Encodes the three invariants from SKILL.md + the lane gates.
+- Every lane prompt opens with `cat .oneshot/SYSTEM.md` so workers re-anchor.
+
+### `prompt.md` — original user prompt
+- Verbatim copy of what the user typed.
+- Read-only. The Brief lane derives `brief.md` from it; later lanes refer to `brief.md`, not `prompt.md`.
+
+### `brief.md` — north star (Brief lane writes it once)
+Required sections:
+```markdown
+# Goal
+<one-paragraph what-and-why>
+
+# Audience
+<who uses this; what they expect>
+
+# Done criteria
+- [ ] <objective acceptance check #1>
+- [ ] <objective acceptance check #2>
+- ...
+
+# Constraints
+- <tech, time, license, deploy target>
+
+# Out of scope
+- <explicit non-goals>
+
+# Proof requirements
+- [ ] tests pass: <commands>
+- [ ] for browser apps: Playwright spec covers <flows> + qa-report.pdf produced
+- [ ] <other proofs the user named>
+```
+The Plan lane treats every box in *Done criteria* + *Proof requirements* as
+mandatory; nothing reaches Deliver until each is checked off in `verification.md`.
+
+### `plan.md` — decomposition (Plan lane writes; frozen after)
+```markdown
+# Architecture overview
+<2–4 paragraphs>
+
+# Tickets
+| ID         | Lane    | Title                         | Depends on  | Owner spec   |
+|------------|---------|-------------------------------|-------------|--------------|
+| BUILD-1    | Build   | Schema + migrations           | —           | §below       |
+| BUILD-2    | Build   | API: /users CRUD              | BUILD-1     | §below       |
+| BUILD-3    | Build   | Web UI: signup/login          | BUILD-2     | §below       |
+| VERIFY-1   | Verify  | Run full suite + fixtures     | BUILD-*     | §below       |
+| QA-1       | QA      | Playwright signup→logout flow | BUILD-3     | §below       |
+| DELIVER-1  | Deliver | Package + README + sign-off   | VERIFY-1, QA-1 | §below     |
+
+## BUILD-1 spec
+<self-contained spec — file pointers, acceptance, test commands>
+
+## BUILD-2 spec
+...
+```
+**Frozen after the Plan lane closes.** Re-planning happens by writing to
+`decisions.log` and creating new tickets, never by editing `plan.md` in place.
+
+### `architecture.md` — living design doc
+Updated whenever a Build ticket discovers a design change. Has a header
+table-of-contents so workers can `head -50` to find their section without
+loading the whole file.
+
+### `contracts.md` — interface contracts
+The boundary spec between Build tickets so they can run in parallel without
+waiting for each other to compile. E.g.:
+```
+## /api/users (BUILD-2 owns; BUILD-3 consumes)
+POST /api/users  body: {email, password}  → 201 {id, email}  | 400 {error}
+GET  /api/users/:id                       → 200 {id, email}  | 404
+```
+If BUILD-3 needs a contract change, it MUST edit `contracts.md` AND open a
+ticket against BUILD-2 — not silently mock locally.
+
+### `decisions.log` — ADR-lite, append-only
+```
+## 2026-05-09T14:22Z BUILD-2: switched from JWT to session cookies
+why: simpler CSRF story given target stack
+impact: BUILD-3 must use credentials:'include' in fetch calls
+```
+Every meaningful design pivot is one entry. Workers grep this before making
+their own decisions.
+
+### `claims.md` — what each ticket says it did (append-only)
+The Build/Polish lanes append here when transitioning to a verification-eligible
+state. **This is untrusted input** — Verify lane treats it as a checklist
+to re-prove, not as truth.
+```
+## 2026-05-09T14:55Z BUILD-2 → ReadyToVerify
+- implemented POST /api/users, GET /api/users/:id
+- tests added: tests/api/users.test.ts (4 cases)
+- type-check: passing
+- lint: 0 warnings
+- run-to-prove: `npm test -- users.test.ts` → 4 passed
+```
+
+### `verification.md` — what was actually re-run (append-only)
+The Verify lane re-executes every claim's `run-to-prove` and writes:
+```
+## 2026-05-09T15:02Z VERIFY-1 re-ran BUILD-2 claims
+- `npm test -- users.test.ts` → 4 passed ✓ (matches claim)
+- `npm run typecheck` → clean ✓
+- `npm run lint` → 0 warnings ✓
+- additional probe: `curl -X POST localhost:3000/api/users -d ...` → 201 ✓
+verdict: GREEN
+```
+On RED, the Verify lane reopens the offending Build ticket (sets it back to
+Build) and appends an `## Issues` section with the discrepancy.
+
+### `qa-report.md` — human-readable QA narrative
+Markdown source for the PDF. The QA lane writes:
+```
+# QA report — <product name>
+date: <iso>
+build sha: <git rev>
+
+## Coverage
+| Flow                     | Result | Screenshot                        |
+|--------------------------|--------|-----------------------------------|
+| signup happy path        | PASS   | artifacts/screenshots/signup-1.png |
+| signup duplicate email   | PASS   | artifacts/screenshots/signup-2.png |
+| login + logout           | PASS   | ...                                |
+| accessibility (axe-core) | PASS   | (no violations)                    |
+
+## Findings
+- ...
+
+## Sign-off
+QA agent: <model id>
+Verdict: APPROVED FOR DELIVERY
+```
+The PDF is rendered from this file by `templates/qa-pdf.sh`.
+
+### `delivery.md` — final manifest (Deliver lane only)
+```
+# Delivery — <product name>
+date: <iso>
+
+## Artifacts
+- source tree: <git sha + tag>
+- qa-report.pdf: <sha256>
+- test-results.json: <path>
+- screenshots: 12 images
+
+## Acceptance checklist
+<copy of brief.md "Done criteria" with each box ticked + verification.md ref>
+
+## How to run
+<commands the user types>
+```
+
+## Append-only enforcement
+
+Workers can rationalize "I'll just clean up this old claim entry."
+**No.** The Verify lane uses the full claims log as its work queue;
+deletions break the audit trail. Lane prompts say verbatim:
+
+> Append to `claims.md` with `>>` redirect, never `>`. If you find yourself
+> opening the file in an editor, stop — you don't need to.
+
+## Reading the vault efficiently (context discipline)
+
+Each lane's prompt names the *minimum* vault files that lane needs:
+- Brief lane:    `prompt.md`
+- Plan lane:     `prompt.md` + `brief.md`
+- Build lane:    `brief.md` + `plan.md` + `architecture.md` + `contracts.md` + `decisions.log` (NOT claims, NOT verification)
+- Verify lane:   `plan.md` + `claims.md` (the only lane that reads claims)
+- QA lane:       `brief.md` + (running app URL from `delivery.md` if present, else from build hooks)
+- Polish lane:   `verification.md` + `qa-report.md`
+- Deliver lane:  everything
+
+This minimization is what makes the pattern scalable to large products —
+Build workers don't drown in QA findings they can't act on, and the QA
+lane doesn't get dragged into refactoring debates.

--- a/.claude/skills/symphony-oneshot/templates/SYSTEM.md
+++ b/.claude/skills/symphony-oneshot/templates/SYSTEM.md
@@ -1,0 +1,121 @@
+# Symphony OneShot — orchestrator constitution
+
+This file is read at the start of EVERY worker turn. It encodes the
+non-negotiable invariants. Re-read it whenever you feel uncertain.
+
+## The three invariants (from OneShot)
+
+### 1. Orchestrator never implements
+The session that ran `bootstrap.sh` is the orchestrator. Its only legal
+moves are:
+- `symphony board new` (create tickets)
+- `symphony board mv` (force a transition only if necessary)
+- `symphony board ls / show` (read state)
+- `cat .oneshot/vault/*` (read the vault)
+- `curl http://127.0.0.1:9999/api/v1/...` (poll the API)
+
+If you find yourself running `npm`, editing `src/`, writing tests, or
+producing the QA report — STOP. You're a worker, not the orchestrator.
+Check your ticket state and follow the lane prompt for that state.
+
+If you ARE the orchestrator and find yourself in implementation mode —
+STOP. Dispatch a ticket instead.
+
+### 2. The vault is the only persistent state
+`.oneshot/vault/` is shared across all workers. Per-ticket workspaces
+under `~/symphony_workspaces/<ID>/` are throwaway between turns.
+
+- Anything the next worker needs to know MUST be in the vault.
+- The vault path is RELATIVE TO THE PROJECT ROOT (the repo holding
+  `WORKFLOW.md`), not relative to your workspace. Reference it as
+  `.oneshot/vault/` only after `cd`'ing to the project root, or use
+  `$SYMPHONY_PROJECT_ROOT/.oneshot/vault/` if the env var is set by your
+  workflow hooks.
+- Append-only files (claims.md, verification.md, decisions.log) MUST be
+  appended with `>>` redirect, never `>` overwrite, never opened in an
+  editor.
+
+### 3. The loop terminates only on delivery proof
+A ticket reaching `Done` is NOT delivery. A ticket reaching `Delivered`
+WITH `delivery.md` consistent with `verification.md` (and, for browser
+apps, `qa-report.pdf` matching its logged sha256) IS delivery.
+
+Never short-circuit the proof requirement. Never edit the gate to make it
+pass. If the gate keeps failing, fix the underlying issue or escalate to
+the human — don't relax the gate.
+
+## Lane reading discipline
+
+Workers read ONLY their lane's required vault files. Cross-lane reads are
+a red flag — usually a sign you're trying to second-guess another lane's
+output, which violates separation of concerns.
+
+| Lane    | Reads                                                                |
+|---------|----------------------------------------------------------------------|
+| Brief   | prompt.md                                                            |
+| Plan    | prompt.md, brief.md                                                  |
+| Build   | brief.md, plan.md, architecture.md, contracts.md, decisions.log      |
+| Verify  | plan.md, claims.md                                                   |
+| QA      | brief.md (and the running app)                                       |
+| Polish  | verification.md, qa-report.md                                        |
+| Deliver | everything                                                           |
+
+## When to ask the human (Block, don't guess)
+
+OneShot's pause-only-for-blockers principle applies. Workers MUST set
+state to `Blocked` (with a `## Blocker` section explaining what's needed)
+when:
+- A required credential / API key is missing.
+- The brief.md is genuinely ambiguous about a critical behavior.
+- An external service is required and unreachable.
+- A legal/safety concern surfaces that wasn't anticipated.
+
+Workers MUST NOT block for:
+- "I'm not sure which library to use" — pick one, log decision.
+- "Tests are slow" — let them run.
+- "I could optimize this" — out of scope; log to decisions.log if interesting.
+
+## Honesty about claims
+
+The Build lane appends to `claims.md`. Every entry must be literally true:
+- "tests pass" means you ran them and saw green.
+- "lint clean" means you ran the linter and saw 0 warnings.
+- "run-to-prove: <command>" means that command, run from a clean checkout
+  of this workspace, will reproduce the result.
+
+The Verify lane is an adversary. False claims will be caught and flow
+the ticket back to Build, costing more turns than honesty would have.
+
+## On gates — discipline aid, not security boundary
+
+The Deliver gate's bash checks (`grep -q '^verdict: GREEN'`,
+`shasum -a 256 == file.sha256`) are *discipline aids*. A worker that
+deliberately wants to fake delivery can: write `verdict: GREEN` directly
+into verification.md from a Build lane; replace qa-report.pdf and
+qa-report.pdf.sha256 simultaneously; etc. There is no filesystem-level
+ACL preventing this.
+
+The real defenses are:
+1. **Lane separation**: Build/Verify/QA/Deliver are different tickets,
+   each running a fresh model session that has no incentive to cover for
+   another lane's work.
+2. **Audit trail**: every vault write is in git history. `git log -p
+   .oneshot/vault/verification.md` shows which ticket (via commit
+   message) wrote each verdict. Dishonest writes are recoverable post-hoc.
+3. **Re-execution by Verify**: the Verify lane runs claims from scratch.
+   It doesn't trust claims.md; it trusts what its own shell produces.
+
+If you're tempted to relax a gate: don't. The gate is the cheapest
+honest mistake-catcher in the pipeline. If it's failing legitimately,
+fix the real cause; if it's failing because the work isn't done, it's
+doing exactly what it should.
+
+## On context windows
+
+Each ticket gets a fresh window. That is the *point* of this pattern. Do
+not try to load the whole project into context — load the vault files
+your lane requires, then load only the source files relevant to your slice.
+
+If your slice spec requires loading >10 files of the existing codebase,
+the slice is too big — set state to `Blocked` with a `## Blocker`
+requesting Plan to split it.

--- a/.claude/skills/symphony-oneshot/templates/WORKFLOW.oneshot.md
+++ b/.claude/skills/symphony-oneshot/templates/WORKFLOW.oneshot.md
@@ -1,0 +1,352 @@
+---
+tracker:
+  kind: file
+  board_root: ./kanban
+  active_states:
+    - Brief
+    - Plan
+    - Build
+    - Verify
+    - QA
+    - Polish
+    - Deliver
+  terminal_states:
+    - Delivered
+    - Cancelled
+    - Blocked
+    - Done
+
+polling:
+  interval_ms: 15000
+
+workspace:
+  root: ~/symphony_workspaces
+
+# Hooks run from inside the per-ticket workspace. They cannot directly
+# expose vars to the agent process, so the absolute project root is baked
+# into the prompt body below at bootstrap time (the __ONESHOT_ROOT__
+# placeholder is replaced by bootstrap.sh).
+hooks:
+  after_create: |
+    : noop
+  before_run: |
+    : noop
+  after_run: |
+    echo "[$(date -u +%FT%TZ)] turn finished" >> "__ONESHOT_ROOT__/log/oneshot.log" 2>/dev/null || true
+
+agent:
+  kind: claude
+  max_concurrent_agents: 4
+  max_turns: 20
+  max_concurrent_agents_by_state:
+    Brief: 1
+    Plan: 1
+    Build: 4
+    Verify: 1
+    QA: 1
+    Polish: 1
+    Deliver: 1
+
+claude:
+  command: claude -p --output-format stream-json --verbose
+  resume_across_turns: true
+  turn_timeout_ms: 3600000
+
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy: workspace-write
+
+server:
+  port: 9999
+---
+
+You are Symphony OneShot worker for ticket {{ issue.identifier }}: {{ issue.title }}.
+Current lane: {{ issue.state }}.
+{% if attempt %}Retry attempt: {{ attempt }}.{% endif %}
+
+ALWAYS START BY:
+
+```bash
+# The vault is at the project root, NOT this workspace. Symphony places
+# you in ~/symphony_workspaces/{{ issue.identifier }}/ — vault paths
+# below are absolute (baked at bootstrap).
+export ONESHOT_ROOT="__ONESHOT_ROOT__"
+test -d "$ONESHOT_ROOT/.oneshot" || { echo "vault missing at $ONESHOT_ROOT/.oneshot" >&2; exit 1; }
+cat "$ONESHOT_ROOT/.oneshot/SYSTEM.md"        # 3 invariants — re-anchor every turn
+{% if issue.state != "Brief" %}cat "$ONESHOT_ROOT/.oneshot/vault/brief.md" 2>/dev/null{% endif %}
+```
+
+Append-only files: `claims.md`, `verification.md`, `decisions.log`. Use `>>` redirect, never `>`.
+For concurrent appends (e.g. multiple Build workers), wrap with `flock`:
+
+```bash
+( flock 9; cat >> "$ONESHOT_ROOT/.oneshot/vault/claims.md" <<EOF
+...
+EOF
+) 9>"$ONESHOT_ROOT/.oneshot/vault/.claims.lock"
+```
+
+Description for this ticket:
+{{ issue.description }}
+
+----- LANE-SPECIFIC INSTRUCTIONS -----
+
+{% if issue.state == "Brief" %}
+You are the Brief lane. Convert the raw user prompt into a structured brief.
+
+Inputs:
+- `$ONESHOT_ROOT/.oneshot/prompt.md` (the user's verbatim ask)
+
+Outputs:
+- `$ONESHOT_ROOT/.oneshot/vault/brief.md` with sections: Goal, Audience, Done criteria, Constraints, Out of scope, Proof requirements
+- If the product appears to be a web/browser app (HTML, React, Vue, Svelte, Next, Astro, etc.), `touch $ONESHOT_ROOT/.oneshot/vault/.is_browser_app`
+
+Rules:
+- Done criteria MUST be objective — commands that can be run, files that must exist, behaviors that can be checked.
+- For browser apps the Proof requirements section MUST include "Playwright spec covering <flows>" and "qa-report.pdf produced".
+- Match scope to the prompt — a one-line bugfix needs a brief shorter than a whole product. Don't over-specify.
+- Do NOT plan or implement. Brief only.
+
+When done, FROM THE PROJECT ROOT (`cd "$ONESHOT_ROOT"`):
+```bash
+cd "$ONESHOT_ROOT"
+symphony board new PLAN-1 "Decompose into work tickets" \
+  --priority 1 --state Plan \
+  --description "Read .oneshot/vault/brief.md and produce .oneshot/vault/plan.md + per-slice tickets per the Plan lane prompt."
+# Mark this Brief ticket as Done
+sed -i.bak 's/^state: .*/state: Done/' "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md" && rm -f "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md.bak"
+echo -e "\n## Resolution\nbrief written to .oneshot/vault/brief.md; PLAN-1 spawned in lane Plan." >> "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md"
+```
+
+{% elsif issue.state == "Plan" %}
+You are the Plan lane. ONLY job: produce a complete decomposition.
+
+Inputs:
+- `$ONESHOT_ROOT/.oneshot/vault/brief.md`
+- `$ONESHOT_ROOT/.oneshot/vault/prompt.md`
+
+Outputs:
+- `$ONESHOT_ROOT/.oneshot/vault/plan.md` (ticket table + per-ticket §spec sections)
+- `$ONESHOT_ROOT/.oneshot/vault/architecture.md` (system design, components, data model)
+- `$ONESHOT_ROOT/.oneshot/vault/contracts.md` (interface contracts between Build slices)
+
+For each Build/Verify/QA/Deliver ticket in plan.md, create it from the project root with the **next lane as its starting state** (this is critical — `--state` defaults to Todo which is NOT in active_states):
+
+```bash
+cd "$ONESHOT_ROOT"
+symphony board new BUILD-1 "<title>" --priority 2 --state Build \
+  --description "Read .oneshot/vault/plan.md §BUILD-1 for the spec."
+symphony board new BUILD-2 "<title>" --priority 2 --state Build \
+  --description "Read .oneshot/vault/plan.md §BUILD-2 for the spec."
+# ... etc, one per slice ...
+
+symphony board new VERIFY-1 "Verify all build slices" --priority 2 --state Verify \
+  --description "Re-run every claim in claims.md. Per Verify lane prompt."
+
+# QA only if browser app
+[ -f "$ONESHOT_ROOT/.oneshot/vault/.is_browser_app" ] && \
+  symphony board new QA-1 "Playwright QA + PDF" --priority 2 --state QA \
+    --description "Drive the running app via Playwright. Per QA lane prompt."
+
+symphony board new DELIVER-1 "Final packaging + sign-off" --priority 2 --state Deliver \
+  --description "Run the Deliver gate. Write delivery.md. Per Deliver lane prompt."
+```
+
+For ordering, edit each ticket's frontmatter to add `blocked_by: [BUILD-1]` etc. Note that Symphony's `blocked_by` is advisory — workers should still self-check via `symphony board show <BLOCKER>`.
+
+**Scope sizing (lanes can be skipped):**
+- Tiny scope (one-line bugfix): just BUILD-1 + VERIFY-1 + DELIVER-1.
+- Medium (single feature): + as many BUILD-N as slices.
+- Large (whole product): all 7 lanes; phase if >12 build tickets.
+
+When done:
+```bash
+cd "$ONESHOT_ROOT"
+sed -i.bak 's/^state: .*/state: Done/' "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md" && rm -f "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md.bak"
+```
+
+CONSTRAINT: do NOT write any implementation code. Plan only.
+
+{% elsif issue.state == "Build" %}
+You are a Build worker for one slice.
+
+Inputs (read minimum needed):
+- `$ONESHOT_ROOT/.oneshot/vault/brief.md`
+- `$ONESHOT_ROOT/.oneshot/vault/plan.md` — only your section: `grep -A 40 "^## {{ issue.identifier }}" "$ONESHOT_ROOT/.oneshot/vault/plan.md"`
+- `$ONESHOT_ROOT/.oneshot/vault/architecture.md`
+- `$ONESHOT_ROOT/.oneshot/vault/contracts.md`
+- `$ONESHOT_ROOT/.oneshot/vault/decisions.log`
+
+Outputs:
+- code in this workspace (Symphony places you in `~/symphony_workspaces/{{ issue.identifier }}/`)
+- one append entry to `$ONESHOT_ROOT/.oneshot/vault/claims.md`
+
+Workflow:
+1. Read your slice spec from plan.md.
+2. Implement. Follow `contracts.md` exactly. If you need a contract change, edit `contracts.md` AND open a fixup ticket against the owning slice — do not silently mock.
+3. Write tests for what you built. Run them. They must pass.
+4. Run typecheck + lint if available.
+5. Append claim using flock to avoid races with parallel Build workers:
+
+```bash
+( flock 9; cat >> "$ONESHOT_ROOT/.oneshot/vault/claims.md" <<EOF
+
+## $(date -u +%FT%TZ) {{ issue.identifier }} → ReadyToVerify
+- implemented: <bullets>
+- tests added/changed: <files>
+- run-to-prove: \`<exact command(s) — must work from a clean checkout>\`
+- last run: <PASS/FAIL + counts>
+EOF
+) 9>"$ONESHOT_ROOT/.oneshot/vault/.claims.lock"
+```
+
+6. Transition state:
+```bash
+sed -i.bak 's/^state: .*/state: Verify/' "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md" && rm -f "$ONESHOT_ROOT/kanban/{{ issue.identifier }}.md.bak"
+```
+
+If a design pivot is needed, append to `decisions.log` BEFORE continuing.
+
+{% elsif issue.state == "Verify" %}
+You are the Verify lane. You are an ADVERSARY to `claims.md` — re-prove every entry.
+
+Inputs:
+- `$ONESHOT_ROOT/.oneshot/vault/plan.md`
+- `$ONESHOT_ROOT/.oneshot/vault/claims.md`
+
+Outputs:
+- append to `$ONESHOT_ROOT/.oneshot/vault/verification.md`
+
+Workflow:
+1. For each claim entry whose ticket is currently in `Verify` state (`symphony board ls --state Verify`), run its `run-to-prove` command from a clean workspace (use `git stash && git pull` or a fresh clone).
+2. Exercise integration points across slices (start the dev server; curl the API; etc.).
+3. Run the FULL test suite — not just slice-specific tests.
+4. Type-check + lint the whole project.
+5. Append verdict:
+
+```bash
+cat >> "$ONESHOT_ROOT/.oneshot/vault/verification.md" <<EOF
+
+## $(date -u +%FT%TZ) Verify ran: <ticket list>
+verifier-ticket: {{ issue.identifier }}
+- claim re-runs: <result per ticket>
+- integration probes: <result>
+- full suite: <result>
+verdict: <GREEN | RED>
+EOF
+```
+
+6. If GREEN:
+   - For each verified Build ticket, set its state to `QA` (if `$ONESHOT_ROOT/.oneshot/vault/.is_browser_app` exists) or `Polish` (otherwise; or `Deliver` for tiny-scope plans where Polish is skipped).
+   - Set this Verify ticket → `Done`.
+7. If RED:
+   - For each ticket whose claim didn't reproduce, set its state to `Build` and append `## Issues` to its kanban file with the exact discrepancy + repro command.
+   - Set this Verify ticket → `Done`. A fresh Verify ticket will be needed after fixes.
+
+Use `sed -i.bak 's/^state: .*/state: <STATE>/' "$ONESHOT_ROOT/kanban/<ID>.md" && rm -f "$ONESHOT_ROOT/kanban/<ID>.md.bak"` for transitions.
+
+CONSTRAINT: do NOT edit application code. Verify is read-only on the codebase.
+
+{% elsif issue.state == "QA" %}
+You are the QA lane (browser apps only). Drive the running app via Playwright as a black-box.
+
+Inputs:
+- `$ONESHOT_ROOT/.oneshot/vault/brief.md` (Done criteria + Proof requirements)
+- the running app (start it per brief.md "How to run" if not already up)
+
+Outputs:
+- `$ONESHOT_ROOT/.oneshot/vault/qa-report.md`
+- `$ONESHOT_ROOT/.oneshot/vault/artifacts/screenshots/<flow>-<step>-<desc>.png`
+- `$ONESHOT_ROOT/.oneshot/vault/artifacts/test-results/results.json`
+- `$ONESHOT_ROOT/.oneshot/vault/artifacts/qa-report.pdf` (REQUIRED gate artifact)
+- `$ONESHOT_ROOT/.oneshot/vault/artifacts/qa-report.pdf.sha256` (written by qa-pdf.sh; checked by Deliver gate)
+
+Setup:
+```bash
+cd "$ONESHOT_ROOT"
+mkdir -p .oneshot/vault/artifacts/screenshots .oneshot/vault/artifacts/test-results
+if [ ! -f tests/e2e/qa.spec.ts ]; then
+  mkdir -p tests/e2e
+  cp .claude/skills/symphony-oneshot/templates/playwright-qa.spec.ts tests/e2e/qa.spec.ts
+fi
+test -f package.json || { echo "QA lane requires a node project (no package.json found)" >&2; exit 1; }
+npm i -D @playwright/test axe-playwright marked
+npx playwright install chromium --with-deps
+```
+
+Adapt `tests/e2e/qa.spec.ts` to cover every flow listed in brief.md's Proof requirements: golden path per persona; edge cases (empty/oversized/duplicate/network drop/back-button); auth boundary (if in scope); accessibility (axe-core; fail on serious+); one screenshot per visible step.
+
+Run:
+```bash
+QA_BASE_URL="<the running app URL>" npx playwright test tests/e2e/qa.spec.ts \
+  --reporter=list,json \
+  --output=.oneshot/vault/artifacts/test-results
+```
+
+Build `qa-report.md` (see `.claude/skills/symphony-oneshot/reference/qa-browser.md` for exact format). End with a single literal line: `Verdict: APPROVED FOR DELIVERY` or `Verdict: BLOCKED — see Findings`.
+
+Render PDF (writes the sha256 to a separate file the Deliver gate verifies):
+```bash
+bash .claude/skills/symphony-oneshot/templates/qa-pdf.sh
+test -s .oneshot/vault/artifacts/qa-report.pdf || { echo "PDF not produced"; exit 1; }
+test -s .oneshot/vault/artifacts/qa-report.pdf.sha256 || { echo "sha256 not written"; exit 1; }
+```
+
+Transition:
+- APPROVED → set this QA ticket to `Done`; set ALL verified Build tickets to `Polish` (or `Deliver` if Polish skipped).
+- BLOCKED → set the underlying Build ticket(s) back to `Build` with reproduction steps; set this QA ticket to `Done`.
+
+{% elsif issue.state == "Polish" %}
+You are the Polish lane. Read findings; decide what (if anything) to address.
+
+Inputs:
+- `$ONESHOT_ROOT/.oneshot/vault/verification.md`
+- `$ONESHOT_ROOT/.oneshot/vault/qa-report.md`
+
+Outputs:
+- append decisions to `$ONESHOT_ROOT/.oneshot/vault/decisions.log`
+- possibly new fixup tickets
+
+Rules:
+- Finding is P0/P1 (security, data loss, broken golden path) → spawn a Build ticket for the fix; set this Polish ticket to `Blocked` with `blocked_by` on the fix.
+- Finding is cosmetic and out-of-scope per brief.md → log decision in `decisions.log`; proceed.
+- Everything acceptable → set state to `Deliver`.
+
+{% elsif issue.state == "Deliver" %}
+You are the Deliver lane. Final packaging + sign-off.
+
+Hard gate (run FIRST — abort if non-zero exit):
+```bash
+set -e
+cd "$ONESHOT_ROOT"
+test -s .oneshot/vault/brief.md
+test -s .oneshot/vault/plan.md
+test -s .oneshot/vault/verification.md
+grep -q '^verdict: GREEN' .oneshot/vault/verification.md || { echo "verify not green"; exit 1; }
+if [ -f .oneshot/vault/.is_browser_app ]; then
+  test -s .oneshot/vault/artifacts/qa-report.pdf
+  test -s .oneshot/vault/artifacts/qa-report.pdf.sha256
+  expected=$(awk '{print $1}' .oneshot/vault/artifacts/qa-report.pdf.sha256)
+  actual=$(shasum -a 256 .oneshot/vault/artifacts/qa-report.pdf | awk '{print $1}')
+  [ "$expected" = "$actual" ] || { echo "QA PDF hash mismatch (expected=$expected actual=$actual)"; exit 1; }
+  # PDF must be newer than markdown — protects against post-render md edits
+  pdf_mtime=$(stat -f %m .oneshot/vault/artifacts/qa-report.pdf 2>/dev/null || stat -c %Y .oneshot/vault/artifacts/qa-report.pdf)
+  md_mtime=$(stat -f %m .oneshot/vault/qa-report.md 2>/dev/null || stat -c %Y .oneshot/vault/qa-report.md)
+  [ "$pdf_mtime" -ge "$md_mtime" ] || { echo "qa-report.md edited after PDF render — re-render required"; exit 1; }
+  grep -q '^Verdict: APPROVED FOR DELIVERY' .oneshot/vault/qa-report.md
+fi
+```
+
+If gate passes:
+1. Write `.oneshot/vault/delivery.md` (artifacts + sha256 list, run instructions, brief.md done-criteria checklist with citations to verification.md timestamps).
+2. `git add -A && git commit -m "deliver: oneshot-delivered" && git tag -a oneshot-delivered -m "Symphony OneShot delivery"` (skip the tag if it already exists).
+3. Set this ticket's state to `Delivered`. Append `## Resolution` pointing at `delivery.md`.
+
+If gate fails:
+- Set state to `Blocked` with `## Blocker` listing exactly which check failed.
+
+{% else %}
+Unknown lane: {{ issue.state }}. Set state to `Blocked` with a `## Blocker` section noting the lane is not recognized and which lane was expected.
+{% endif %}

--- a/.claude/skills/symphony-oneshot/templates/bootstrap.sh
+++ b/.claude/skills/symphony-oneshot/templates/bootstrap.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# bootstrap.sh — Symphony OneShot vault + workflow + intake ticket
+#
+# Usage:   bash bootstrap.sh "<the user's one-shot prompt>"
+# Re-init: FORCE=1 bash bootstrap.sh "<new prompt>"  (clobbers .oneshot/, backs up WORKFLOW.md)
+#
+# Single-shot init by design. Re-running on an existing .oneshot/ aborts
+# unless FORCE=1, because partially-merged state across runs is worse
+# than a hard reset.
+
+set -euo pipefail
+
+PROMPT="${1:-}"
+FORCE="${FORCE:-0}"
+
+if [ -z "$PROMPT" ]; then
+  echo "usage: bash bootstrap.sh \"<one-shot prompt>\"" >&2
+  exit 2
+fi
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(pwd)"
+
+# Stricter repo detection — match the actual symphony package, not any pyproject
+if ! { [ -f "$PROJECT_ROOT/src/symphony/cli.py" ] || \
+       grep -q '^name = "symphony' "$PROJECT_ROOT/pyproject.toml" 2>/dev/null; }; then
+  echo "warn: $PROJECT_ROOT does not look like the symphony-multi-agent repo." >&2
+  echo "       (no src/symphony/cli.py and pyproject.toml doesn't name 'symphony')" >&2
+  echo "       Vault will be created at $PROJECT_ROOT/.oneshot/ anyway." >&2
+fi
+
+if ! command -v symphony >/dev/null 2>&1; then
+  echo "error: 'symphony' CLI not on PATH." >&2
+  echo "       Install: pip install -e \".[dev]\" from the symphony-multi-agent repo." >&2
+  exit 1
+fi
+
+if [ -d "$PROJECT_ROOT/.oneshot" ] && [ "$FORCE" != "1" ]; then
+  echo "abort: $PROJECT_ROOT/.oneshot already exists." >&2
+  echo "       Re-run with FORCE=1 to clobber, or move/remove the dir manually." >&2
+  exit 1
+fi
+
+# Hard reset under FORCE
+if [ "$FORCE" = "1" ] && [ -d "$PROJECT_ROOT/.oneshot" ]; then
+  mv "$PROJECT_ROOT/.oneshot" "$PROJECT_ROOT/.oneshot.aborted-$(date +%s)"
+fi
+
+# 1. Vault skeleton
+mkdir -p "$PROJECT_ROOT/.oneshot/vault/artifacts/screenshots"
+mkdir -p "$PROJECT_ROOT/.oneshot/vault/artifacts/test-results"
+mkdir -p "$PROJECT_ROOT/log"
+mkdir -p "$PROJECT_ROOT/kanban"
+
+# 2. Constitution + raw prompt + project root marker
+cp "$SKILL_DIR/SYSTEM.md" "$PROJECT_ROOT/.oneshot/SYSTEM.md"
+printf "%s\n" "$PROMPT" > "$PROJECT_ROOT/.oneshot/prompt.md"
+echo "$PROJECT_ROOT" > "$PROJECT_ROOT/.oneshot/.project_root"
+
+# 3. Empty append-only ledgers + lock files
+: > "$PROJECT_ROOT/.oneshot/vault/claims.md"
+: > "$PROJECT_ROOT/.oneshot/vault/verification.md"
+: > "$PROJECT_ROOT/.oneshot/vault/decisions.log"
+: > "$PROJECT_ROOT/.oneshot/vault/.claims.lock"
+: > "$PROJECT_ROOT/.oneshot/vault/.verification.lock"
+
+# 4. Placeholder living docs
+cat > "$PROJECT_ROOT/.oneshot/vault/brief.md" <<EOF
+<!-- Will be filled in by the Brief lane. Do not hand-edit. -->
+EOF
+cat > "$PROJECT_ROOT/.oneshot/vault/plan.md" <<EOF
+<!-- Will be filled in by the Plan lane. Do not hand-edit. -->
+EOF
+cat > "$PROJECT_ROOT/.oneshot/vault/architecture.md" <<EOF
+<!-- Will be filled in by the Plan lane. -->
+EOF
+cat > "$PROJECT_ROOT/.oneshot/vault/contracts.md" <<EOF
+<!-- Will be filled in by the Plan lane. -->
+EOF
+
+# 5. WORKFLOW.md — substitute __ONESHOT_ROOT__ with the absolute project path
+if [ -f "$PROJECT_ROOT/WORKFLOW.md" ]; then
+  cp "$PROJECT_ROOT/WORKFLOW.md" "$PROJECT_ROOT/WORKFLOW.md.bak.$(date +%s)"
+  echo "info: prior WORKFLOW.md backed up" >&2
+fi
+# sed -i needs an empty backup ext on macOS; use a temp + mv to be portable
+sed "s|__ONESHOT_ROOT__|$PROJECT_ROOT|g" "$SKILL_DIR/WORKFLOW.oneshot.md" > "$PROJECT_ROOT/WORKFLOW.md"
+
+# Sanity: make sure substitution actually happened
+if grep -q '__ONESHOT_ROOT__' "$PROJECT_ROOT/WORKFLOW.md"; then
+  echo "error: __ONESHOT_ROOT__ placeholder still present in WORKFLOW.md after substitution" >&2
+  exit 1
+fi
+
+# 6. Initialize kanban board if empty
+if [ ! -d "$PROJECT_ROOT/kanban" ] || [ -z "$(ls -A "$PROJECT_ROOT/kanban" 2>/dev/null)" ]; then
+  symphony board init "$PROJECT_ROOT/kanban" >/dev/null
+fi
+
+# 7. Create the INTAKE ticket directly in the Brief lane (--state defaults to Todo, which isn't an active state)
+INTAKE_ID="INTAKE-1"
+if [ -f "$PROJECT_ROOT/kanban/${INTAKE_ID}.md" ]; then
+  echo "warn: $INTAKE_ID already exists — will not recreate" >&2
+else
+  symphony board new "$INTAKE_ID" "Symphony OneShot intake — convert prompt to brief" \
+    --priority 1 --state Brief \
+    --description "Read .oneshot/prompt.md and produce .oneshot/vault/brief.md per the Brief lane prompt in WORKFLOW.md."
+fi
+
+# 8. Preflight
+echo "------ symphony doctor ------"
+if ! symphony doctor "$PROJECT_ROOT/WORKFLOW.md"; then
+  echo "doctor reported issues — fix before launching" >&2
+  exit 1
+fi
+
+cat <<EOF
+
+✓ Symphony OneShot bootstrapped at $PROJECT_ROOT/.oneshot/
+✓ WORKFLOW.md installed (any prior one backed up)
+✓ INTAKE-1 created in lane: Brief
+✓ Project root pinned: $PROJECT_ROOT (also written to .oneshot/.project_root)
+
+Next step:
+
+  # interactive (needs a TTY)
+  symphony tui ./WORKFLOW.md
+
+  # headless (recommended when an orchestrator session is driving)
+  symphony ./WORKFLOW.md --port 9999 2>> log/symphony.log &
+
+Then poll:
+  curl -s http://127.0.0.1:9999/api/v1/state | jq '.counts'
+
+The loop is done when DELIVER-1 reaches state 'Delivered' AND
+.oneshot/vault/delivery.md exists. For browser apps,
+.oneshot/vault/artifacts/qa-report.pdf must also exist with the sha256
+matching .oneshot/vault/artifacts/qa-report.pdf.sha256.
+EOF

--- a/.claude/skills/symphony-oneshot/templates/playwright-qa.spec.ts
+++ b/.claude/skills/symphony-oneshot/templates/playwright-qa.spec.ts
@@ -1,0 +1,173 @@
+// Symphony OneShot — Playwright QA spec stub.
+//
+// The QA lane copies this file to tests/e2e/qa.spec.ts and adapts the
+// flows + selectors to the actual product. The five categories below are
+// MANDATORY — do not delete sections, only fill them in or mark them
+// "n/a per brief.md" with a citation.
+//
+// Required dependencies (installed by the QA lane prompt):
+//   npm i -D @playwright/test axe-playwright
+//   npx playwright install chromium
+
+import { test, expect, type Page } from '@playwright/test';
+import { injectAxe, checkA11y } from 'axe-playwright';
+import { mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Resolve vault under the project root (NOT this test's CWD, which may be elsewhere).
+const ROOT =
+  process.env.ONESHOT_ROOT ??
+  (existsSync(join(process.cwd(), '.oneshot/.project_root'))
+    ? readFileSync(join(process.cwd(), '.oneshot/.project_root'), 'utf8').trim()
+    : process.cwd());
+const ARTIFACT_ROOT = join(ROOT, '.oneshot/vault/artifacts');
+const SCREENSHOTS = join(ARTIFACT_ROOT, 'screenshots');
+mkdirSync(SCREENSHOTS, { recursive: true });
+
+const BASE_URL = process.env.QA_BASE_URL ?? 'http://localhost:3000';
+
+async function shot(page: Page, name: string) {
+  await page.screenshot({
+    path: join(SCREENSHOTS, `${name}.png`),
+    fullPage: true,
+  });
+}
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+// ---------- 1. GOLDEN PATHS ----------
+// One block per primary persona from brief.md "Audience". Cover the
+// happy-flow end-to-end. Screenshot every visible state change.
+
+test.describe('1. Golden paths', () => {
+  test('1.1 anonymous visitor → primary CTA', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await expect(page).toHaveTitle(/.+/);
+    await shot(page, '1-1-1-landing');
+
+    // EDIT ME: replace with the actual primary CTA selector from brief.md
+    // const cta = page.getByRole('button', { name: /get started/i });
+    // await expect(cta).toBeVisible();
+    // await cta.click();
+    // await shot(page, '1-1-2-after-cta');
+    // await expect(page).toHaveURL(/.+/);
+  });
+
+  // EDIT ME: add 1.2, 1.3, ... per persona
+});
+
+// ---------- 2. EDGE CASES ----------
+// At minimum: empty input, oversized input, duplicate submission,
+// network drop mid-flow, back-button mid-flow.
+
+test.describe('2. Edge cases', () => {
+  test('2.1 empty form submission shows validation', async ({ page }) => {
+    await page.goto(`${BASE_URL}/`); // EDIT ME: target form route
+    // EDIT ME
+    await shot(page, '2-1-empty-form');
+  });
+
+  test('2.2 oversized payload rejected gracefully', async ({ page }) => {
+    // EDIT ME: paste 10k chars into a text field that should cap
+    await page.goto(BASE_URL);
+    await shot(page, '2-2-oversized');
+  });
+
+  test('2.3 duplicate submission deduped', async ({ page }) => {
+    // EDIT ME: double-click submit; backend / UI must not double-create
+    await page.goto(BASE_URL);
+    await shot(page, '2-3-duplicate');
+  });
+
+  test('2.4 network drop mid-flow surfaces retry UI', async ({ page, context }) => {
+    await context.route('**/api/**', (route) => route.abort());
+    await page.goto(BASE_URL);
+    // EDIT ME: trigger an API-bound action; assert retry button shown
+    await shot(page, '2-4-net-drop');
+  });
+
+  test('2.5 back-button mid-flow does not corrupt state', async ({ page }) => {
+    await page.goto(BASE_URL);
+    // EDIT ME: navigate forward two steps, hit back, ensure state is sane
+    await page.goBack();
+    await shot(page, '2-5-back-button');
+  });
+});
+
+// ---------- 3. AUTHENTICATION BOUNDARY (if auth in scope) ----------
+// Mark "n/a per brief.md (no auth)" with citation if not applicable.
+
+test.describe('3. Authentication boundary', () => {
+  test('3.1 unauthed access to protected route redirects', async ({ page }) => {
+    // EDIT ME: visit a /dashboard or /settings route
+    await page.goto(`${BASE_URL}/`);
+    // await expect(page).toHaveURL(/login|signin/i);
+    await shot(page, '3-1-redirect-to-login');
+  });
+
+  test('3.2 logout invalidates session', async ({ page }) => {
+    // EDIT ME: log in, capture cookies, log out, hit protected route again
+    await page.goto(BASE_URL);
+    await shot(page, '3-2-after-logout');
+  });
+});
+
+// ---------- 4. ACCESSIBILITY (axe-core) ----------
+// Fail on serious or critical violations. One scan per page in golden path.
+
+test.describe('4. Accessibility', () => {
+  test('4.1 landing page a11y', async ({ page }) => {
+    await page.goto(BASE_URL);
+    await injectAxe(page);
+    await checkA11y(page, undefined, {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+      axeOptions: {
+        runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
+      },
+    });
+    await shot(page, '4-1-a11y-landing');
+  });
+
+  // EDIT ME: 4.2 per other golden-path page
+});
+
+// ---------- 5. PERFORMANCE SMOKE (optional but recommended) ----------
+// Web vitals via the standard `web-vitals` API or Playwright's
+// `page.evaluate()`. Don't fail the build on perf — just record.
+
+test.describe('5. Performance smoke', () => {
+  test('5.1 capture LCP/CLS on landing', async ({ page }) => {
+    await page.goto(BASE_URL, { waitUntil: 'networkidle' });
+    const metrics = await page.evaluate(
+      () =>
+        new Promise<Record<string, number>>((resolve) => {
+          const out: Record<string, number> = {};
+          new PerformanceObserver((list) => {
+            for (const e of list.getEntries()) {
+              if (e.entryType === 'largest-contentful-paint') {
+                out.lcp = e.startTime;
+              }
+              if (e.entryType === 'layout-shift' && !(e as any).hadRecentInput) {
+                out.cls = (out.cls ?? 0) + (e as any).value;
+              }
+            }
+          }).observe({ type: 'largest-contentful-paint', buffered: true });
+          // Layout-shift observer
+          new PerformanceObserver((list) => {
+            for (const e of list.getEntries()) {
+              if (e.entryType === 'layout-shift' && !(e as any).hadRecentInput) {
+                out.cls = (out.cls ?? 0) + (e as any).value;
+              }
+            }
+          }).observe({ type: 'layout-shift', buffered: true });
+          setTimeout(() => resolve(out), 3000);
+        })
+    );
+    test.info().annotations.push({
+      type: 'perf',
+      description: JSON.stringify(metrics),
+    });
+    await shot(page, '5-1-perf-landing');
+  });
+});

--- a/.claude/skills/symphony-oneshot/templates/qa-pdf.sh
+++ b/.claude/skills/symphony-oneshot/templates/qa-pdf.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# qa-pdf.sh — Render .oneshot/vault/qa-report.md → .oneshot/vault/artifacts/qa-report.pdf
+#
+# Uses Playwright (already installed for the QA spec) to render markdown
+# → HTML → PDF. No pandoc, no wkhtmltopdf, no LaTeX dependency.
+#
+# Refuses to render unless the QA test results JSON exists — prevents
+# generating an "approved" PDF without actually running the spec.
+set -euo pipefail
+
+# Resolve vault to absolute path. Prefer ONESHOT_ROOT (set by lane prompt
+# preamble), fall back to .oneshot/.project_root, then to relative path.
+if [ -n "${ONESHOT_ROOT:-}" ]; then
+  ROOT="$ONESHOT_ROOT"
+elif [ -f "$(pwd)/.oneshot/.project_root" ]; then
+  ROOT="$(cat "$(pwd)/.oneshot/.project_root")"
+else
+  ROOT="$(pwd)"
+fi
+
+VAULT="${VAULT:-$ROOT/.oneshot/vault}"
+MD="${VAULT}/qa-report.md"
+PDF="${VAULT}/artifacts/qa-report.pdf"
+PDF_HASH="${PDF}.sha256"
+RESULTS_DIR="${VAULT}/artifacts/test-results"
+
+if [ ! -f "$ROOT/package.json" ]; then
+  echo "error: $ROOT/package.json missing — qa-pdf.sh requires a Node project (uses Playwright + marked)" >&2
+  exit 1
+fi
+
+if [ ! -s "$MD" ]; then
+  echo "error: $MD missing or empty — write the QA report markdown first" >&2
+  exit 1
+fi
+
+# Refuse to render without test evidence (prevents a 'rubber-stamp' PDF)
+if [ ! -d "$RESULTS_DIR" ] || [ -z "$(ls -A "$RESULTS_DIR" 2>/dev/null)" ]; then
+  echo "error: $RESULTS_DIR is empty — Playwright spec must run before PDF render" >&2
+  echo "       expected at least one of: results.json, *.xml, trace.zip" >&2
+  exit 1
+fi
+
+# Verdict line is mandatory
+if ! grep -qE '^Verdict: (APPROVED FOR DELIVERY|BLOCKED — see Findings)' "$MD"; then
+  echo "error: $MD missing required 'Verdict:' line" >&2
+  echo "       last line should be 'Verdict: APPROVED FOR DELIVERY' or 'Verdict: BLOCKED — see Findings'" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$PDF")"
+
+# Tiny Node renderer using Playwright + marked.
+# Inlined to keep the skill self-contained — no extra files.
+TMP_RENDERER="$(mktemp -t qa-pdf.XXXXXX.mjs)"
+trap 'rm -f "$TMP_RENDERER"' EXIT
+
+cat > "$TMP_RENDERER" <<'NODE'
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { chromium } from '@playwright/test';
+import { marked } from 'marked';
+
+const [, , mdPath, pdfPath] = process.argv;
+if (!mdPath || !pdfPath) {
+  console.error('usage: node qa-pdf.mjs <input.md> <output.pdf>');
+  process.exit(2);
+}
+
+const mdAbs = resolve(mdPath);
+const pdfAbs = resolve(pdfPath);
+const mdDir = dirname(mdAbs);
+const md = readFileSync(mdAbs, 'utf8');
+
+// Resolve <img src="artifacts/screenshots/foo.png"> relative to md file
+marked.use({
+  renderer: {
+    image(href, title, text) {
+      let resolved = href;
+      try {
+        const candidate = resolve(mdDir, href);
+        if (existsSync(candidate)) {
+          resolved = pathToFileURL(candidate).href;
+        }
+      } catch {
+        // leave as-is
+      }
+      const t = title ? ` title="${title}"` : '';
+      return `<img src="${resolved}" alt="${text}"${t} />`;
+    },
+  },
+});
+
+const bodyHtml = marked.parse(md);
+const generatedAt = new Date().toISOString();
+
+const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QA Report</title>
+<style>
+  @page { size: A4; margin: 18mm; }
+  body { font: 11pt/1.5 -apple-system, Segoe UI, Helvetica, Arial, sans-serif; color: #111; }
+  h1 { font-size: 22pt; margin: 0 0 8pt; border-bottom: 2pt solid #333; padding-bottom: 4pt; }
+  h2 { font-size: 15pt; margin: 18pt 0 6pt; color: #1d4ed8; }
+  h3 { font-size: 12pt; margin: 12pt 0 4pt; }
+  table { border-collapse: collapse; width: 100%; margin: 6pt 0; }
+  th, td { border: 0.5pt solid #999; padding: 4pt 6pt; vertical-align: top; }
+  th { background: #f3f4f6; text-align: left; }
+  code, pre { font-family: ui-monospace, SF Mono, Menlo, monospace; }
+  pre { background: #f7f7f7; padding: 8pt; overflow: hidden; }
+  img { max-width: 100%; height: auto; border: 0.5pt solid #ddd; margin: 4pt 0; }
+  .meta { color: #555; font-size: 9pt; margin-top: 24pt; border-top: 0.5pt solid #ccc; padding-top: 4pt; }
+</style>
+</head>
+<body>
+${bodyHtml}
+<div class="meta">Rendered ${generatedAt} by Symphony OneShot qa-pdf.sh — Playwright/Chromium PDF.</div>
+</body>
+</html>`;
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.setContent(html, { waitUntil: 'networkidle' });
+  await page.pdf({
+    path: pdfAbs,
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '18mm', right: '18mm', bottom: '18mm', left: '18mm' },
+    displayHeaderFooter: true,
+    headerTemplate: '<div></div>',
+    footerTemplate:
+      '<div style="font-size:8pt;color:#888;width:100%;text-align:center;">' +
+      '<span class="pageNumber"></span> / <span class="totalPages"></span>' +
+      '</div>',
+  });
+} finally {
+  await browser.close();
+}
+
+console.log(`wrote ${pdfAbs}`);
+NODE
+
+# Make sure marked is installed (cheap if already present)
+if ! node -e "import('marked')" 2>/dev/null; then
+  echo "info: installing 'marked' (one-time)" >&2
+  npm i -D marked >/dev/null 2>&1 || npm i marked >/dev/null 2>&1 || {
+    echo "error: failed to install 'marked' — run \`npm i -D marked\` manually" >&2
+    exit 1
+  }
+fi
+
+cd "$ROOT" && node "$TMP_RENDERER" "$MD" "$PDF"
+
+# Verify and emit hash to a separate file (Deliver gate reads from here, NOT from verification.md)
+test -s "$PDF" || { echo "error: PDF not produced" >&2; exit 1; }
+HASH="$(shasum -a 256 "$PDF" | awk '{print $1}')"
+SIZE="$(wc -c < "$PDF" | tr -d ' ')"
+
+# Refuse to "approve" trivially small PDFs (likely empty/error pages)
+if [ "$SIZE" -lt 4096 ]; then
+  echo "error: PDF too small (${SIZE} bytes) — likely render failure" >&2
+  rm -f "$PDF"
+  exit 1
+fi
+
+# Single-source-of-truth hash file. Deliver gate verifies this matches re-shasum'd PDF.
+printf '%s  %s\n' "$HASH" "$(basename "$PDF")" > "$PDF_HASH"
+echo "ok: $PDF  size=${SIZE}  sha256=${HASH}  hash-file=${PDF_HASH}"

--- a/.claude/skills/using-symphony/SKILL.md
+++ b/.claude/skills/using-symphony/SKILL.md
@@ -98,6 +98,11 @@ backend.
 - The user wants Linear integration — see `README.md` and
   `WORKFLOW.example.md` for the `tracker.kind: linear` config; then
   upstream Symphony docs apply.
+- The user wants a *whole product* built end-to-end from a single prompt
+  (with shared-knowledge vault, multi-lane workflow, and PDF-gated
+  verification) — use `symphony-oneshot` instead. That skill builds on
+  this one; understand `using-symphony` first, then layer the OneShot
+  pattern on top.
 
 ## Quick reference
 


### PR DESCRIPTION
## Summary
- New project-level skill at \`.claude/skills/symphony-oneshot/\` that adapts the [OneShot pattern](https://github.com/oneshot-repo/OneShot) onto symphony-multi-agent's polling Kanban
- Turns one prompt — bugfix, feature, refactor, or whole product — into a verified, signed-off delivery via 7 lanes (Brief → Plan → Build → Verify → QA → Polish → Deliver) implemented as Liquid \`{% if issue.state == \"X\" %}\` branches in a single \`WORKFLOW.md\` body
- Browser apps gain a Playwright + screenshots + PDF QA gate; the Deliver lane mechanically refuses to close without proof artifacts

## Why this is separate from \`using-symphony\`
\`using-symphony\` is the bare CLI for ad-hoc tickets. \`symphony-oneshot\` is one specific opinionated workflow on top — distinct skill, both useful. The new SKILL.md cross-references back to the bare-CLI skill as a prerequisite.

## What's in the skill
- \`SKILL.md\` — entry point + scope sizing table (lanes scale down for tiny scopes)
- \`reference/\` — vault contract, lane semantics, browser-QA flow, decomposition heuristics, troubleshooting
- \`templates/\`
  - \`WORKFLOW.oneshot.md\` — drop-in workflow with all 7 lanes wired
  - \`SYSTEM.md\` — orchestrator constitution (3 invariants, gate honesty disclosure)
  - \`bootstrap.sh\` — one-command init (vault + WORKFLOW.md + INTAKE-1)
  - \`playwright-qa.spec.ts\` — Playwright stub (golden + edge + auth + a11y + perf)
  - \`qa-pdf.sh\` — renders qa-report.md → PDF via Playwright/Chromium (no pandoc dependency)

## Test plan
- [x] \`bash -n\` syntax check on both shipped scripts
- [x] WORKFLOW.oneshot.md parses through symphony's own \`load_workflow\` + \`build_service_config\`
- [x] Liquid branching renders a distinct prompt body for each of the 7 lanes
- [x] \`bootstrap.sh\` end-to-end against the real \`symphony\` CLI in a scratch dir → \`symphony doctor\` returns 4/4 PASS
- [x] Code review (CRITICAL/HIGH issues addressed): \`--state\` on every \`board new\` (was pipeline-blocker), absolute project-root substitution for vault paths (workers run from per-ticket workspaces), PDF hash sidecar instead of grepping verification.md, mtime check, \`flock\` for concurrent claims.md appends, honor-system gate disclosure in SYSTEM.md
- [ ] Live run against a real prompt — recommend trying with a tiny scope first ("fix the typo in README")