### PR TITLE
fix: Windows + macOS compatibility for hooks, backends, mock_codex

### DIFF
--- a/src/symphony/_shell.py
+++ b/src/symphony/_shell.py
@@ -1,0 +1,77 @@
+"""Shell resolution — pick a bash binary that can actually run Symphony's hooks.
+
+On Windows, ``where bash`` often returns:
+
+    C:\\Windows\\System32\\bash.exe          # WSL launcher
+    C:\\Program Files\\Git\\usr\\bin\\bash.exe   # Git Bash (MSYS)
+    C:\\Users\\<u>\\AppData\\Local\\Microsoft\\WindowsApps\\bash.exe   # WSL alias
+
+The WSL launcher is the wrong choice for Symphony: WSL mounts Windows drives
+at ``/mnt/c/...`` (not ``/c/...``), can't transparently invoke Windows ``.exe``
+files in user hooks, and runs in a separate Linux filesystem from the
+workspace cwd. We want MSYS ``bash`` (Git Bash), which speaks ``/c/...``,
+inherits the Windows cwd verbatim, and runs Windows binaries directly.
+
+This helper centralizes the lookup so every hook + backend uses the same
+binary. Set ``SYMPHONY_BASH`` to override.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from functools import lru_cache
+
+
+# Common Git for Windows install locations. Scoop and Winget installs land
+# under ``%USERPROFILE%\scoop\apps\git\current\bin\bash.exe`` and
+# ``%LOCALAPPDATA%\Programs\Git\bin\bash.exe`` respectively — those are
+# picked up by the ``shutil.which`` fallback below if the user's PATH is set
+# correctly. Extend this tuple if you need to support those installs without
+# requiring PATH config.
+_WIN_GIT_BASH_CANDIDATES = (
+    r"C:\Program Files\Git\bin\bash.exe",
+    r"C:\Program Files\Git\usr\bin\bash.exe",
+    r"C:\Program Files (x86)\Git\bin\bash.exe",
+    r"C:\Program Files (x86)\Git\usr\bin\bash.exe",
+)
+
+_WSL_LAUNCHER_FRAGMENTS = (
+    r"\windows\system32\bash.exe",
+    r"\microsoft\windowsapps\bash.exe",
+)
+
+
+def _is_wsl_launcher(path: str) -> bool:
+    p = path.lower()
+    return any(frag in p for frag in _WSL_LAUNCHER_FRAGMENTS)
+
+
+@lru_cache(maxsize=1)
+def resolve_bash() -> str:
+    """Return the bash executable to use for hooks and backend subprocesses.
+
+    Result is cached for the process lifetime — set ``SYMPHONY_BASH`` before
+    the first call (typically before importing symphony) if you need to
+    override. Tests that toggle the env var mid-process must call
+    ``resolve_bash.cache_clear()`` between toggles.
+    """
+    override = os.environ.get("SYMPHONY_BASH")
+    if override:
+        return override
+
+    if sys.platform != "win32":
+        return "bash"
+
+    for candidate in _WIN_GIT_BASH_CANDIDATES:
+        if os.path.isfile(candidate):
+            return candidate
+
+    found = shutil.which("bash")
+    if found and not _is_wsl_launcher(found):
+        return found
+
+    # Last resort: PATH-based lookup, even if it points at WSL — keeps the
+    # behavior predictable rather than silently failing at spawn time.
+    return "bash"

--- a/src/symphony/backends/claude_code.py
+++ b/src/symphony/backends/claude_code.py
@@ -27,6 +27,7 @@ import shlex
 import time
 from typing import Any
 
+from .._shell import resolve_bash
 from ..errors import (
     PortExit,
     ResponseError,
@@ -144,7 +145,7 @@ class ClaudeCodeBackend:
 
         try:
             proc = await asyncio.create_subprocess_exec(
-                "bash",
+                resolve_bash(),
                 "-lc",
                 cmd,
                 cwd=str(self._cwd),

--- a/src/symphony/backends/codex.py
+++ b/src/symphony/backends/codex.py
@@ -23,6 +23,7 @@ import os
 import time
 from typing import Any
 
+from .._shell import resolve_bash
 from ..errors import (
     CodexNotFound,
     PortExit,
@@ -104,7 +105,7 @@ class CodexAppServerBackend:
     async def start(self) -> None:
         try:
             self._process = await asyncio.create_subprocess_exec(
-                "bash",
+                resolve_bash(),
                 "-lc",
                 self._codex.command,
                 cwd=str(self._cwd),

--- a/src/symphony/backends/gemini.py
+++ b/src/symphony/backends/gemini.py
@@ -25,6 +25,7 @@ import time
 import uuid
 from typing import Any
 
+from .._shell import resolve_bash
 from ..errors import (
     PortExit,
     ResponseError,
@@ -129,7 +130,7 @@ class GeminiBackend:
 
         try:
             proc = await asyncio.create_subprocess_exec(
-                "bash",
+                resolve_bash(),
                 "-lc",
                 self._gemini.command,
                 cwd=str(self._cwd),

--- a/src/symphony/doctor.py
+++ b/src/symphony/doctor.py
@@ -28,6 +28,7 @@ import tempfile
 from dataclasses import dataclass
 from typing import Iterable, Literal
 
+from ._shell import resolve_bash
 from .errors import SymphonyError
 from .workflow import (
     ServiceConfig,
@@ -163,9 +164,40 @@ def check_tracker(cfg: ServiceConfig) -> CheckResult:
     return CheckResult(f"tracker.kind={tracker.kind}", "warn", "unknown tracker kind")
 
 
+def check_shell() -> CheckResult:
+    """Hooks and backend subprocesses spawn via ``bash -lc``. On Windows we
+    must avoid the WSL launcher (``C:\\Windows\\System32\\bash.exe``) — see
+    ``_shell.resolve_bash``. On macOS/Linux we still verify ``bash`` is
+    actually on ``$PATH`` so minimal containers and nix-shells fail loudly
+    here rather than silently at first dispatch."""
+    bash = resolve_bash()
+    if sys.platform == "win32":
+        if bash.lower() == "bash":
+            return CheckResult(
+                "shell.bash",
+                "fail",
+                "no bash on $PATH — install Git for Windows or set $SYMPHONY_BASH",
+            )
+        if not (os.path.isfile(bash) or shutil.which(bash)):
+            return CheckResult(
+                "shell.bash",
+                "fail",
+                f"resolved bash at {bash} but it is not executable",
+            )
+    else:
+        if not (os.path.isfile(bash) or shutil.which(bash)):
+            return CheckResult(
+                "shell.bash",
+                "fail",
+                f"{bash!r} not found on $PATH — install bash or set $SYMPHONY_BASH",
+            )
+    return CheckResult("shell.bash", "pass", bash)
+
+
 def run_checks(cfg: ServiceConfig, host: str = "127.0.0.1") -> list[CheckResult]:
     return [
         check_port(cfg, host=host),
+        check_shell(),
         check_agent_cli(cfg),
         check_after_create_hook(cfg),
         check_workspace_root(cfg),

--- a/src/symphony/mock_codex.py
+++ b/src/symphony/mock_codex.py
@@ -56,34 +56,36 @@ MAX_TURNS = _env_int("SYMPHONY_MOCK_MAX_TURNS", 0)
 
 
 class _Stdio:
-    """Simple wrapper to read/write JSON lines on stdio asynchronously."""
+    """Cross-platform async wrapper around blocking stdio.
+
+    Uses ``run_in_executor`` for stdin reads and stdout flushes so we don't
+    rely on ``loop.connect_read_pipe(sys.stdin)`` — that path fails on Windows
+    under ``ProactorEventLoop`` with ``OSError: [WinError 6]`` when the
+    interpreter's stdin handle is a redirected anonymous pipe.
+    """
 
     def __init__(self) -> None:
-        self._reader: asyncio.StreamReader | None = None
-        self._writer: asyncio.StreamWriter | None = None
+        self._stdin = sys.stdin.buffer
+        self._stdout = sys.stdout.buffer
 
     async def start(self) -> None:
-        loop = asyncio.get_event_loop()
-        self._reader = asyncio.StreamReader(limit=10 * 1024 * 1024)
-        protocol = asyncio.StreamReaderProtocol(self._reader)
-        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
-        transport, write_proto = await loop.connect_write_pipe(
-            asyncio.streams.FlowControlMixin, sys.stdout
-        )
-        self._writer = asyncio.StreamWriter(transport, write_proto, None, loop)
+        return None
 
     async def readline(self) -> bytes:
-        assert self._reader is not None
-        return await self._reader.readline()
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._stdin.readline)
 
     def write_json(self, obj: dict[str, Any]) -> None:
-        assert self._writer is not None
-        self._writer.write((json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8"))
+        line = (json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8")
+        try:
+            self._stdout.write(line)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
 
     async def drain(self) -> None:
-        assert self._writer is not None
+        loop = asyncio.get_running_loop()
         try:
-            await self._writer.drain()
+            await loop.run_in_executor(None, self._stdout.flush)
         except (BrokenPipeError, ConnectionResetError):
             pass
 

--- a/src/symphony/workspace.py
+++ b/src/symphony/workspace.py
@@ -5,15 +5,46 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from ._shell import resolve_bash
 from .errors import InvalidWorkspaceCwd, SymphonyError
 from .issue import workspace_key
 from .logging import get_logger
 from .workflow import HooksConfig
 
 log = get_logger()
+
+
+def _force_rmtree(path: Path, *, attempts: int = 5) -> tuple[bool, str | None]:
+    """Best-effort recursive delete with brief retry on Windows.
+
+    Windows can hold a directory's handle open for tens of milliseconds after
+    a child subprocess exits (the subprocess used the directory as its cwd),
+    causing ``shutil.rmtree`` to fail with ``PermissionError`` even though the
+    process is gone. We retry only ``PermissionError`` and only on Windows so
+    POSIX permission failures still surface immediately. Returns
+    ``(success, last_error_str)`` so callers can preserve diagnostic context
+    in their warning logs.
+    """
+    last_err: str | None = None
+    for i in range(attempts):
+        try:
+            shutil.rmtree(path)
+            return True, None
+        except FileNotFoundError:
+            return True, None
+        except PermissionError as exc:
+            last_err = str(exc)
+            if sys.platform != "win32" or i == attempts - 1:
+                return False, last_err
+            time.sleep(0.05 * (i + 1))
+        except OSError as exc:
+            return False, str(exc)
+    return False, last_err
 
 
 @dataclass(frozen=True)
@@ -61,10 +92,11 @@ class WorkspaceManager:
                 await self._run_hook("after_create", self._hooks.after_create, path)
             except Exception:
                 # §9.4 — after_create failure is fatal; clean partial directory.
-                try:
-                    shutil.rmtree(path)
-                except OSError:
-                    pass
+                ok, err = _force_rmtree(path)
+                if not ok:
+                    log.warning(
+                        "workspace_cleanup_incomplete", path=str(path), error=err
+                    )
                 raise
 
         return Workspace(path=path, workspace_key=key, created_now=created_now)
@@ -95,10 +127,9 @@ class WorkspaceManager:
                 await self._run_hook("before_remove", self._hooks.before_remove, path)
             except Exception as exc:  # §9.4 — log and ignore.
                 log.warning("hook_before_remove_failed", path=str(path), error=str(exc))
-        try:
-            shutil.rmtree(path, ignore_errors=False)
-        except OSError as exc:
-            log.warning("workspace_remove_failed", path=str(path), error=str(exc))
+        ok, err = _force_rmtree(path)
+        if not ok:
+            log.warning("workspace_remove_failed", path=str(path), error=err)
 
     def _enforce_root_containment(self, path: Path) -> None:
         """§9.5 invariant 2."""
@@ -116,7 +147,7 @@ class WorkspaceManager:
         log.info("hook_start", hook=name, cwd=str(cwd))
         # §9.4 — run script via `bash -lc` with workspace cwd.
         process = await asyncio.create_subprocess_exec(
-            "bash",
+            resolve_bash(),
             "-lc",
             script,
             cwd=str(cwd),

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -121,7 +121,12 @@ def test_port_fail_when_already_bound(tmp_path: Path) -> None:
         )
         result = check_port(cfg)
         assert result.status == "fail"
-        assert "Address already in use" in result.message or "in use" in result.message
+        # Doctor wraps the OSError as `cannot bind <host>:<port> — <exc>`.
+        # Avoid asserting on the OSError text — Windows OSes return a
+        # localized "Address already in use" (e.g. Korean "주소 …") that does
+        # not contain the English substring.
+        assert "cannot bind" in result.message
+        assert f"127.0.0.1:{bound_port}" in result.message
     finally:
         sock.close()
 
@@ -185,8 +190,8 @@ def test_run_checks_returns_one_result_per_check(tmp_path: Path) -> None:
         """,
     )
     results = run_checks(cfg)
-    # port + agent + after_create + workspace + tracker = 5
-    assert len(results) == 5
+    # port + shell + agent + after_create + workspace + tracker = 6
+    assert len(results) == 6
     assert {r.name.split("=")[0].split(".")[0] for r in results} >= {
         "agent",
         "hooks",

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,42 @@
+"""Cross-platform bash resolution — see ``symphony._shell``."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from symphony._shell import resolve_bash
+
+
+def test_symphony_bash_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SYMPHONY_BASH", "/custom/bash")
+    resolve_bash.cache_clear()
+    try:
+        assert resolve_bash() == "/custom/bash"
+    finally:
+        resolve_bash.cache_clear()
+
+
+def test_resolve_bash_returns_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SYMPHONY_BASH", raising=False)
+    resolve_bash.cache_clear()
+    try:
+        result = resolve_bash()
+        assert isinstance(result, str)
+        assert result  # non-empty
+    finally:
+        resolve_bash.cache_clear()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only WSL filter")
+def test_windows_does_not_pick_wsl_launcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When Git Bash is installed, the System32 WSL launcher must not win."""
+    monkeypatch.delenv("SYMPHONY_BASH", raising=False)
+    resolve_bash.cache_clear()
+    try:
+        result = resolve_bash().lower()
+        assert "system32" not in result
+        assert "windowsapps" not in result
+    finally:
+        resolve_bash.cache_clear()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,7 +15,9 @@ def _hooks(**overrides) -> HooksConfig:
         before_run=None,
         after_run=None,
         before_remove=None,
-        timeout_ms=2000,
+        # Generous default — Git Bash on Windows takes 1–4 s for a cold
+        # `bash -lc` startup; 2 s caused false-positive timeouts in CI.
+        timeout_ms=30_000,
     )
     base.update(overrides)
     return HooksConfig(**base)
@@ -42,12 +44,16 @@ async def test_sanitization(tmp_path):
 
 @pytest.mark.asyncio
 async def test_after_create_hook_runs_only_on_creation(tmp_path):
-    marker = tmp_path / "marker"
+    # Hook writes into its own cwd (the workspace) using a relative path so
+    # the assertion is independent of how bash on the host parses absolute
+    # paths — MSYS bash on Windows mishandles drive-letter prefixes when
+    # they're embedded in the script string.
     mgr = WorkspaceManager(
         tmp_path / "ws",
-        _hooks(after_create=f"echo created > {marker}"),
+        _hooks(after_create="echo created > marker"),
     )
     ws1 = await mgr.create_or_reuse("MT-2")
+    marker = ws1.path / "marker"
     assert marker.exists()
     marker.unlink()
     await mgr.create_or_reuse("MT-2")


### PR DESCRIPTION
## Summary

Verified the project on Windows 11 (Python 3.12, Git Bash + WSL coexisting). Found 4 production issues + 3 test issues that broke first-run on Windows; fixed each at the root cause and added regression tests.

- **mock_codex** crashed at startup with \`OSError [WinError 6]\` because \`loop.connect_read_pipe(sys.stdin)\` is unsupported on the ProactorEventLoop. Replaced with a thread-pool blocking-IO wrapper that works on every platform.
- **\`bash\` resolution** picked up the WSL launcher (\`C:\Windows\System32\bash.exe\`) ahead of Git Bash, so workspace cwds (\`C:\Users\...\`), MSYS paths (\`/c/Users/...\`), and Windows \`.exe\` binaries in user hooks all became unreachable. New \`_shell.resolve_bash\` prefers Git Bash on Windows, honors \`\$SYMPHONY_BASH\`, and is wired into \`workspace.py\` + the codex/claude/gemini backends.
- **Workspace cleanup race** on Windows (\`shutil.rmtree\` → \`PermissionError [WinError 32]\` because the OS holds the directory handle for tens of ms after the subprocess exits). New \`_force_rmtree\` retries \`PermissionError\` only on Windows so POSIX failures still surface immediately. Used in both after_create cleanup and \`mgr.remove\`.
- **\`symphony doctor\`** now includes a \`shell.bash\` check that flags WSL-only misconfiguration on Windows and missing \`bash\` on macOS/Linux.

Test fixes for the same root causes:
- \`test_workspace\` hook timeout 2000 → 30000 (Git Bash cold start is ~1–4 s)
- \`test_after_create_hook_runs_only_on_creation\` writes into the workspace cwd via a relative path so the assertion is not coupled to bash escape-handling of absolute Windows paths
- \`test_port_fail_when_already_bound\` asserts on doctor's stable \`cannot bind <host>:<port>\` wrapper, not the OS-specific (and locale-localized) \`Address already in use\`
- new \`tests/test_shell.py\` covers env override, return type, and the Windows WSL-launcher filter

## Test plan
- [x] \`pytest -q\` on Windows 11 (Python 3.12) → 87/87 pass (was 82/84)
- [x] \`symphony doctor\` 6/6 PASS on Windows
- [x] Mock backend dispatch verified end-to-end via JSON API (\`running=2\`, turn_count climbing, tokens accumulating)
- [x] Real Claude Code backend dispatch: \`turn_completed\`, ticket rewritten with \`state: Done\` and \`## Resolution\` section
- [ ] macOS regression test (please run \`pytest -q\` on macOS to confirm no behavior changed there)
- [ ] Linux regression test