### PR TITLE
fix: address review findings on Windows compat patch

### DIFF
--- a/src/symphony/_shell.py
+++ b/src/symphony/_shell.py
@@ -56,10 +56,21 @@ def resolve_bash() -> str:
     the first call (typically before importing symphony) if you need to
     override. Tests that toggle the env var mid-process must call
     ``resolve_bash.cache_clear()`` between toggles.
+
+    A ``SYMPHONY_BASH`` override pointing at the Windows WSL launcher is
+    rejected (the whole reason this helper exists is to avoid that binary);
+    we fall through to the default detection so a misconfigured override
+    can't silently re-introduce the bug. Other override values are returned
+    as-is and validated by ``doctor.check_shell``.
     """
     override = os.environ.get("SYMPHONY_BASH")
     if override:
-        return override
+        if _is_wsl_launcher(override):
+            # Misconfiguration — fall through to default detection rather
+            # than honor a value we know will not work for hooks.
+            pass
+        else:
+            return override
 
     if sys.platform != "win32":
         return "bash"
@@ -72,6 +83,7 @@ def resolve_bash() -> str:
     if found and not _is_wsl_launcher(found):
         return found
 
-    # Last resort: PATH-based lookup, even if it points at WSL — keeps the
-    # behavior predictable rather than silently failing at spawn time.
+    # Last resort: bare ``bash`` so spawn-time error is reproducible from
+    # the doctor's ``check_shell`` failure (instead of failing at the first
+    # hook dispatch with an opaque ``FileNotFoundError``).
     return "bash"

--- a/src/symphony/doctor.py
+++ b/src/symphony/doctor.py
@@ -28,7 +28,7 @@ import tempfile
 from dataclasses import dataclass
 from typing import Iterable, Literal
 
-from ._shell import resolve_bash
+from ._shell import _is_wsl_launcher, resolve_bash
 from .errors import SymphonyError
 from .workflow import (
     ServiceConfig,
@@ -171,26 +171,31 @@ def check_shell() -> CheckResult:
     actually on ``$PATH`` so minimal containers and nix-shells fail loudly
     here rather than silently at first dispatch."""
     bash = resolve_bash()
-    if sys.platform == "win32":
-        if bash.lower() == "bash":
+    # If ``bash`` is a bare name (e.g. "bash" or "wsl"), resolve via PATH so
+    # WSL-launcher detection sees the actual binary.
+    resolved = bash if os.path.isfile(bash) else (shutil.which(bash) or bash)
+
+    if sys.platform == "win32" and _is_wsl_launcher(resolved):
+        return CheckResult(
+            "shell.bash",
+            "fail",
+            f"{resolved} is the WSL launcher — install Git for Windows "
+            "or set $SYMPHONY_BASH to a Git Bash binary",
+        )
+
+    if not (os.path.isfile(bash) or shutil.which(bash)):
+        if sys.platform == "win32":
             return CheckResult(
                 "shell.bash",
                 "fail",
-                "no bash on $PATH — install Git for Windows or set $SYMPHONY_BASH",
+                "no usable bash found — install Git for Windows or set $SYMPHONY_BASH",
             )
-        if not (os.path.isfile(bash) or shutil.which(bash)):
-            return CheckResult(
-                "shell.bash",
-                "fail",
-                f"resolved bash at {bash} but it is not executable",
-            )
-    else:
-        if not (os.path.isfile(bash) or shutil.which(bash)):
-            return CheckResult(
-                "shell.bash",
-                "fail",
-                f"{bash!r} not found on $PATH — install bash or set $SYMPHONY_BASH",
-            )
+        return CheckResult(
+            "shell.bash",
+            "fail",
+            f"{bash!r} not found on $PATH — install bash or set $SYMPHONY_BASH",
+        )
+
     return CheckResult("shell.bash", "pass", bash)
 
 

--- a/src/symphony/workspace.py
+++ b/src/symphony/workspace.py
@@ -6,7 +6,6 @@ import asyncio
 import os
 import shutil
 import sys
-import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,31 +18,42 @@ from .workflow import HooksConfig
 log = get_logger()
 
 
-def _force_rmtree(path: Path, *, attempts: int = 5) -> tuple[bool, str | None]:
+def _try_rmtree_once(path: Path) -> tuple[bool, str | None, bool]:
+    """Single rmtree attempt.
+
+    Returns ``(success, last_error, retryable)``. ``retryable`` is True only
+    for ``PermissionError`` on Windows — every other failure must propagate
+    immediately so POSIX permission errors aren't masked.
+    """
+    try:
+        shutil.rmtree(path)
+        return True, None, False
+    except FileNotFoundError:
+        return True, None, False
+    except PermissionError as exc:
+        return False, str(exc), sys.platform == "win32"
+    except OSError as exc:
+        return False, str(exc), False
+
+
+async def _force_rmtree(path: Path, *, attempts: int = 5) -> tuple[bool, str | None]:
     """Best-effort recursive delete with brief retry on Windows.
 
     Windows can hold a directory's handle open for tens of milliseconds after
     a child subprocess exits (the subprocess used the directory as its cwd),
     causing ``shutil.rmtree`` to fail with ``PermissionError`` even though the
-    process is gone. We retry only ``PermissionError`` and only on Windows so
-    POSIX permission failures still surface immediately. Returns
-    ``(success, last_error_str)`` so callers can preserve diagnostic context
-    in their warning logs.
+    process is gone. The backoff uses ``await asyncio.sleep`` so concurrent
+    workspace cleanups don't stall the event loop.
     """
     last_err: str | None = None
     for i in range(attempts):
-        try:
-            shutil.rmtree(path)
+        ok, err, retryable = _try_rmtree_once(path)
+        if ok:
             return True, None
-        except FileNotFoundError:
-            return True, None
-        except PermissionError as exc:
-            last_err = str(exc)
-            if sys.platform != "win32" or i == attempts - 1:
-                return False, last_err
-            time.sleep(0.05 * (i + 1))
-        except OSError as exc:
-            return False, str(exc)
+        last_err = err
+        if not retryable or i == attempts - 1:
+            return False, last_err
+        await asyncio.sleep(0.05 * (i + 1))
     return False, last_err
 
 
@@ -92,7 +102,7 @@ class WorkspaceManager:
                 await self._run_hook("after_create", self._hooks.after_create, path)
             except Exception:
                 # §9.4 — after_create failure is fatal; clean partial directory.
-                ok, err = _force_rmtree(path)
+                ok, err = await _force_rmtree(path)
                 if not ok:
                     log.warning(
                         "workspace_cleanup_incomplete", path=str(path), error=err
@@ -127,7 +137,7 @@ class WorkspaceManager:
                 await self._run_hook("before_remove", self._hooks.before_remove, path)
             except Exception as exc:  # §9.4 — log and ignore.
                 log.warning("hook_before_remove_failed", path=str(path), error=str(exc))
-        ok, err = _force_rmtree(path)
+        ok, err = await _force_rmtree(path)
         if not ok:
             log.warning("workspace_remove_failed", path=str(path), error=err)
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -6,37 +6,74 @@ import sys
 
 import pytest
 
-from symphony._shell import resolve_bash
+from symphony import _shell
+from symphony._shell import _is_wsl_launcher, resolve_bash
+
+
+@pytest.fixture(autouse=True)
+def _reset_resolve_bash_cache() -> None:
+    resolve_bash.cache_clear()
+    yield
+    resolve_bash.cache_clear()
 
 
 def test_symphony_bash_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SYMPHONY_BASH", "/custom/bash")
-    resolve_bash.cache_clear()
-    try:
-        assert resolve_bash() == "/custom/bash"
-    finally:
-        resolve_bash.cache_clear()
+    assert resolve_bash() == "/custom/bash"
 
 
-def test_resolve_bash_returns_string(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_bash_returns_nonempty_string(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("SYMPHONY_BASH", raising=False)
-    resolve_bash.cache_clear()
-    try:
-        result = resolve_bash()
-        assert isinstance(result, str)
-        assert result  # non-empty
-    finally:
-        resolve_bash.cache_clear()
+    result = resolve_bash()
+    assert isinstance(result, str)
+    assert result
+
+
+def test_symphony_bash_override_rejecting_wsl_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SYMPHONY_BASH value pointing at the WSL launcher must not be honored
+    — the whole purpose of the helper is to avoid that binary."""
+    monkeypatch.setenv(
+        "SYMPHONY_BASH", r"C:\Windows\System32\bash.exe"
+    )
+    result = resolve_bash()
+    assert not _is_wsl_launcher(result)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only WSL filter")
-def test_windows_does_not_pick_wsl_launcher(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When Git Bash is installed, the System32 WSL launcher must not win."""
+def test_windows_filter_rejects_wsl_when_only_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``shutil.which`` would otherwise return the WSL launcher and no
+    Git Bash candidate is on disk, ``resolve_bash`` must fall back to the
+    bare ``"bash"`` sentinel (caught by ``doctor.check_shell``) rather than
+    silently use the WSL binary."""
     monkeypatch.delenv("SYMPHONY_BASH", raising=False)
-    resolve_bash.cache_clear()
-    try:
-        result = resolve_bash().lower()
-        assert "system32" not in result
-        assert "windowsapps" not in result
-    finally:
-        resolve_bash.cache_clear()
+    monkeypatch.setattr(
+        _shell,
+        "_WIN_GIT_BASH_CANDIDATES",
+        (r"C:\nonexistent\nope.exe",),
+    )
+    monkeypatch.setattr(
+        _shell.shutil,
+        "which",
+        lambda name: r"C:\Windows\System32\bash.exe",
+    )
+    assert resolve_bash() == "bash"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only WSL filter")
+def test_windows_picks_git_bash_when_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """When a Git Bash candidate exists on disk, it wins over PATH."""
+    monkeypatch.delenv("SYMPHONY_BASH", raising=False)
+    fake_git_bash = tmp_path / "fake-git-bash.exe"
+    fake_git_bash.write_text("")
+    monkeypatch.setattr(
+        _shell,
+        "_WIN_GIT_BASH_CANDIDATES",
+        (str(fake_git_bash),),
+    )
+    assert resolve_bash() == str(fake_git_bash)


### PR DESCRIPTION
## Summary

Follow-up to #2. Addresses three MEDIUM issues from the post-merge review.

1. **\`_force_rmtree\` now async + \`await asyncio.sleep\`** — the previous \`time.sleep\` backoff blocked the event loop up to 250 ms, stalling concurrent workspace cleanups on Windows. Both call sites in \`WorkspaceManager.create_or_reuse\` and \`mgr.remove\` are awaited.
2. **\`SYMPHONY_BASH\` validation** — \`resolve_bash\` rejects an override that points at the WSL launcher (the helper exists to avoid that binary). \`doctor.check_shell\` also applies \`_is_wsl_launcher\` to the resolved path so a \`SYMPHONY_BASH=wsl\` style misconfiguration cannot slip past \`shutil.which\`.
3. **WSL filter test** — was trivially passing when Git Bash absent (fallback \`"bash"\` contains neither marker). Replaced with monkeypatch-driven tests that inject a fake WSL path and assert it's filtered. Added two related tests: Git Bash candidate-on-disk wins over PATH; \`SYMPHONY_BASH=...System32\\bash.exe\` override is ignored. \`cache_clear\` moved to autouse fixture.

## Test plan
- [x] \`pytest -q\` 89/89 on Windows (was 87/87 in #2; +2 new tests)
- [x] \`symphony doctor\` PASS in normal mode
- [x] \`SYMPHONY_BASH=C:\Windows\System32\bash.exe symphony doctor\` → still PASS (Git Bash auto-detected because override is ignored)
- [x] \`SYMPHONY_BASH=/nonexistent symphony doctor\` → FAIL loudly with \`shell.bash\` rejection
- [x] Mock backend dispatch unchanged (running=1, tokens climbing 2123→4532)
- [ ] macOS regression test
- [ ] Linux regression test