### PR TITLE
fix: gemini default command broken in Gemini CLI 0.39+

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ adds:
    - **Codex** — `codex app-server` (JSON-RPC stdio, multi-turn) — original
    - **Claude Code** — `claude -p --output-format stream-json --verbose`
      (NDJSON events, per-turn subprocess with `--resume`)
-   - **Gemini** — `gemini -p` (one-shot per turn, stdin prompt → stdout result)
+   - **Gemini** — `gemini -p ""` (one-shot per turn, stdin prompt → stdout result)
 2. A **Jira-style CLI Kanban TUI** built on `rich` that replaces the upstream
    server-rendered HTML dashboard. Columns are tracker states; cards show the
    active agent, turn count, last event, and accumulated tokens.

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -47,7 +47,9 @@ claude:
   stall_timeout_ms: 300000
 
 gemini:
-  command: gemini -p
+  # `gemini -p` (no argument) prints help in Gemini CLI 0.39+; pass an
+  # empty `""` so the prompt comes purely from stdin.
+  command: 'gemini -p ""'
   turn_timeout_ms: 3600000
   read_timeout_ms: 5000
   stall_timeout_ms: 300000

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -38,7 +38,9 @@ claude:
   command: claude -p --output-format stream-json --verbose
 
 gemini:
-  command: gemini -p
+  # `gemini -p` (no argument) prints help in Gemini CLI 0.39+; pass `""`
+  # so the prompt comes purely from stdin.
+  command: 'gemini -p ""'
 
 server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -47,7 +47,11 @@ DEFAULT_AGENT_KIND = "codex"
 DEFAULT_CLAUDE_COMMAND = (
     "claude -p --output-format stream-json --include-partial-messages --verbose"
 )
-DEFAULT_GEMINI_COMMAND = "gemini -p"
+# `gemini -p` (no argument) prints help and exits in Gemini CLI 0.39+ — the
+# `-p`/`--prompt` flag now requires a string. We pass an empty string so
+# stdin alone is the prompt (Gemini documents stdin as "Appended to input on
+# stdin (if any).").
+DEFAULT_GEMINI_COMMAND = 'gemini -p ""'
 DEFAULT_BACKEND_TURN_TIMEOUT_MS = 3_600_000
 DEFAULT_BACKEND_READ_TIMEOUT_MS = 5_000
 DEFAULT_BACKEND_STALL_TIMEOUT_MS = 300_000

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -75,7 +75,7 @@ def _make_cfg(kind: str, *, workspace_root: Path) -> ServiceConfig:
             resume_across_turns=True,
         ),
         gemini=GeminiConfig(
-            command="gemini -p",
+            command='gemini -p ""',
             turn_timeout_ms=60_000,
             read_timeout_ms=5_000,
             stall_timeout_ms=30_000,

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -62,7 +62,7 @@ def _make_config(
             resume_across_turns=True,
         ),
         gemini=GeminiConfig(
-            command="gemini -p",
+            command='gemini -p ""',
             turn_timeout_ms=3_600_000,
             read_timeout_ms=5_000,
             stall_timeout_ms=300_000,


### PR DESCRIPTION
## Summary

\`gemini -p\` (no argument) prints help and exits in Gemini CLI **0.39+** — the \`-p\`/\`--prompt\` flag now requires a string. Symphony's default \`gemini -p\` therefore never reaches the model. Fix: pass an empty \`\"\"\` so the prompt comes purely from stdin (Gemini documents stdin as *Appended to input on stdin (if any)*).

Verified end-to-end on Windows 11 + Gemini CLI 0.39.1 + Git Bash:
- Symphony dispatched a real ticket
- Gemini wrote \`result.txt\`, edited \`kanban/TASK-3.md\` to \`state: Done\` with a \`## Resolution\` section
- \`worker_exit reason=normal\`

## Files changed
- \`src/symphony/workflow.py\` — \`DEFAULT_GEMINI_COMMAND\`
- \`WORKFLOW.example.md\`, \`WORKFLOW.file.example.md\` — example configs
- \`tests/test_backends.py\`, \`tests/test_orchestrator_dispatch.py\` — hardcoded command strings
- \`README.md\` — backend list mention

## Known follow-up (not in this PR)

Gemini's first turn on Windows took ~5 min and was killed by the default \`stall_timeout_ms=300000\`; second attempt succeeded in ~90 s. A separate follow-up should either bump gemini's stall default or switch to stream-json for progress signals.

## Test plan
- [x] \`pytest -q\` 89/89 on Windows
- [x] Live dispatch end-to-end through symphony with the new default
- [ ] macOS regression
- [ ] Linux regression