### PR TITLE
docs(skills): document hook authoring rules to prevent awk -F: pitfall

### DIFF
--- a/.claude/skills/using-symphony/reference/troubleshooting.md
+++ b/.claude/skills/using-symphony/reference/troubleshooting.md
@@ -25,7 +25,7 @@ tail -F log/symphony.log
 
 | Log line                                 | Meaning                                                  | Fix                                                                                 |
 |------------------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------|
-| `hook_failed hook=after_create rc=128`   | First-time clone failed                                  | Replace placeholder repo URL in `WORKFLOW.md`, or set `after_create: \|\n  : noop`   |
+| `hook_failed hook=after_create rc=128`   | First-time clone failed                                  | Replace placeholder repo URL in `WORKFLOW.md`, or set `after_create: \|\n  : noop`. If the hook parses ticket frontmatter, see "awk vs sed for YAML values" below |
 | `worker_exit reason=error`               | Worker terminated abnormally                             | Read the preceding `hook_failed` event or backend stderr for the actual cause       |
 | `outcome=turn_error`                     | Turn ended in error (timeout, agent crash, tool failure) | Inspect backend stderr; for timeouts, raise `<kind>.turn_timeout_ms`                |
 | `hook_timeout`                           | Hook exceeded its time budget                            | Shorten the hook or remove blocking commands                                        |
@@ -74,6 +74,25 @@ By design — workspaces persist for inspection. Manually clean up with
 Both read from the JSON snapshot via the same orchestrator instance, but
 *you can only have one orchestrator process per board at a time*. Stop one
 before starting another, otherwise both will fight for hook locks.
+
+### "after_create exits 128 every retry, same error each time"
+
+If your hook parses ticket frontmatter to compute a clone URL, the
+single most common cause is an `awk -F':'` field separator that splits
+on every colon. A value like `repo: https://github.com/owner/repo.git`
+becomes `$2 = "https"`, which `git clone` rejects with rc=128. The
+retries fail identically because the parse is deterministic.
+
+```bash
+# Wrong — splits on every colon:
+REPO=$(awk -F': *' '/^repo:/ {print $2; exit}' "$TICKET")
+
+# Right — captures everything after the first `: `:
+REPO=$(sed -n 's/^repo: *\(.*\)$/\1/p' "$TICKET" | head -1 | tr -d '\r"')
+```
+
+See `reference/workflow-config.md` ("Hook authoring rules") for the
+full list of related gotchas (CRLF, absolute paths, `set -e`, etc.).
 
 ### Linear-tracker specific: "tickets aren't appearing"
 

--- a/.claude/skills/using-symphony/reference/workflow-config.md
+++ b/.claude/skills/using-symphony/reference/workflow-config.md
@@ -76,6 +76,53 @@ immediately with `worker_exit reason=error`. The shipped sample
 box. Replace with `: noop` for experiments or with a real clone for actual
 work. `symphony doctor` catches this.
 
+### Hook authoring rules
+
+Hooks run via `bash -lc` in the workspace directory and inherit only
+`os.environ.copy()` — no ticket-specific env vars are injected
+(`workspace.py:155-167`). The ticket ID is recoverable as
+`basename "$PWD"`; everything else must be parsed out of
+`<board_root>/<ID>.md` by hand. Six rules to avoid the most common
+self-inflicted hook failures:
+
+1. **Never parse YAML frontmatter with `awk -F':'`.** It splits on every
+   colon, so a value like `repo: https://github.com/owner/repo.git`
+   becomes `$2 = "https"` — `git clone https .` then fails with rc=128
+   and the worker bounces through retries with the same error. Capture
+   everything after the first `: ` instead:
+   ```bash
+   # Wrong:
+   REPO=$(awk -F': *' '/^repo:/ {print $2; exit}' "$TICKET")
+
+   # Right:
+   REPO=$(sed -n 's/^repo: *\(.*\)$/\1/p' "$TICKET" | head -1 | tr -d '\r"')
+   ```
+2. **Verify the hook body in isolation before launching the TUI.** Drop
+   the `after_create` body into `/tmp/sym-verify-<ID>` and run it
+   manually. Symphony cleans up failed workspaces aggressively, which
+   makes post-mortem hard.
+3. **`set -e` at the top of every non-trivial hook.** Without it, a
+   failed `git clone` happily continues into `git checkout` and the
+   error trail becomes ambiguous.
+4. **Use absolute paths inside hook bodies.** `./kanban/$ID.md` is
+   resolved against the workspace cwd, not the WORKFLOW.md directory —
+   so it points at a file that doesn't exist. Hardcode the absolute
+   board path:
+   ```bash
+   BOARD="/abs/path/to/kanban"
+   TICKET="$BOARD/$(basename "$PWD").md"
+   ```
+5. **Strip CR and quotes after parsing.** `tr -d '\r"'` on every
+   sed-extracted value. Frontmatter authored on Windows is CRLF, and
+   string values often pick up surrounding quotes that break shell
+   substitution.
+6. **`after_create` runs once but is not idempotent.** Symphony removes
+   the workspace on hook failure before retrying, so from-scratch is
+   safe — but a partial-success scenario (e.g. clone OK, checkout fail)
+   leaves you debugging in the workspace before symphony wipes it.
+   Defensive checks (`[ -d .git ] && exit 0` early, `git rev-parse
+   HEAD` to validate clone, etc.) are worth the lines.
+
 ## Tracker
 
 Two kinds:


### PR DESCRIPTION
## Summary

Adds a **Hook authoring rules** subsection to `using-symphony`'s
`reference/workflow-config.md` plus a related entry in
`reference/troubleshooting.md`, capturing the most common
self-inflicted hook failures encountered while writing custom
\`after_create\` hooks that parse ticket frontmatter.

## Why

While building a multi-PR triage workflow on Windows, every ticket
died with the same error on every retry:

\`\`\`
hook_failed hook=after_create rc=128
symphony_error: hook after_create exited 128
\`\`\`

Symphony's logs were correct; the bug was in my hook. The hook used
\`awk -F': *'\` to extract a clone URL from the ticket file's YAML
frontmatter:

\`\`\`yaml
repo: https://github.com/owner/repo.git
\`\`\`

\`awk -F': *'\` splits on every colon, so \`$2\` was just \`https\`. The
resulting \`git clone https .\` rejected immediately with rc=128, and
because the parse is deterministic, all retries failed identically.
Symphony cleans up failed workspaces aggressively, which made
post-mortem hard — by the time I looked, the workspace was gone.

This is a foot-gun anyone writing dynamic clone hooks will eventually
hit. The reference doesn't currently warn about it.

## What changed

| File | Change |
|------|--------|
| \`.claude/skills/using-symphony/reference/workflow-config.md\` | New "Hook authoring rules" subsection with six numbered rules: prefer \`sed\` over \`awk -F:\` for YAML, verify in \`/tmp\` first, \`set -e\`, absolute paths, strip CR/quotes, idempotency caveat. |
| \`.claude/skills/using-symphony/reference/troubleshooting.md\` | Cross-reference from the existing \`hook_failed rc=128\` row + a new "after_create exits 128 every retry, same error each time" section with the awk-vs-sed example. |

No code changes. No new dependencies. Pure docs, lives entirely under
the \`using-symphony\` skill — opt-in for users who actually load that
skill.

## Test plan

- [x] \`pytest -q\` (no behavior changed; the suite still passes)
- [x] Confirmed the recommended \`sed\` snippet against a real ticket
  file end-to-end: clone + \`fetch origin pull/N/head:pr-N\` +
  \`checkout pr-N\` all succeed.
- [ ] Reviewer to spot-check the wording / decide if the rules belong
  in the upstream skill or in the README.