### PR TITLE
feat(tui): per-column legend (state_descriptions) + per-card in/out token breakdown

### DIFF
--- a/.claude/skills/using-symphony/reference/workflow-config.md
+++ b/.claude/skills/using-symphony/reference/workflow-config.md
@@ -97,6 +97,28 @@ tracker:
 `terminal_states` are end columns (the orchestrator stops watching once a
 ticket lands here).
 
+### Column legends (`tracker.state_descriptions`)
+
+Optional. Maps a state name to a one-line description that the TUI
+renders under each column header. Useful when lanes encode workflow
+semantics (Triage / Fix / Self-review / Deploy) that aren't obvious
+from the lane name alone.
+
+```yaml
+tracker:
+  active_states: [Todo, "In Progress", Review]
+  terminal_states: [Done, Cancelled, Blocked]
+  state_descriptions:
+    Todo: "Triage: read PR + decide next action"
+    "In Progress": "Apply fix locally, run tests"
+    Review: "Self-review the diff before Done"
+    Cancelled: "Junk / stale / agent-rejected"
+```
+
+Keys are matched case-insensitively. Empty strings and non-string
+values are dropped. Omit the field entirely to keep the original
+column-name-only header.
+
 ## Workspace + concurrency
 
 ```yaml

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -5,6 +5,11 @@ tracker:
   api_key: $LINEAR_API_KEY
   active_states: [Todo, In Progress]
   terminal_states: [Closed, Cancelled, Canceled, Duplicate, Done]
+  # Optional one-line legend rendered under each TUI column header.
+  state_descriptions:
+    Todo: "Ready for an agent to pick up"
+    "In Progress": "Agent actively working"
+    Done: "Completed by the agent"
 
 polling:
   interval_ms: 30000

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -4,6 +4,14 @@ tracker:
   board_root: ./kanban
   active_states: [Todo, In Progress]
   terminal_states: [Done, Cancelled, Blocked]
+  # Optional one-line legend rendered under each TUI column header so a
+  # casual viewer can tell what work happens in each lane.
+  state_descriptions:
+    Todo: "Ready for an agent to pick up"
+    "In Progress": "Agent actively working"
+    Done: "Completed by the agent"
+    Blocked: "Awaiting human input"
+    Cancelled: "Junk / stale / agent-rejected"
 
 polling:
   interval_ms: 30000

--- a/src/symphony/tui.py
+++ b/src/symphony/tui.py
@@ -66,6 +66,8 @@ class _CardStatus:
     turn: int = 0
     last_event: str = ""
     tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
     attempt: int | None = None
     error: str | None = None
     last_message: str = ""
@@ -227,6 +229,7 @@ class KanbanTUI:
             key = normalize_state(issue.state)
             issues_by_state.setdefault(key, []).append(issue)
 
+        descriptions = cfg.tracker.state_descriptions
         panels: list[Panel] = []
         for state_label in ordered:
             state_key = normalize_state(state_label)
@@ -236,9 +239,18 @@ class KanbanTUI:
                 self._render_card(issue, runtime_index.get(issue.id, _CardStatus()), color)
                 for issue in issues
             ]
-            body: Any
+            legend = descriptions.get(state_key)
+            elements: list[Any] = []
+            if legend:
+                elements.append(Text(legend, style="dim italic"))
             if cards:
-                body = Group(*cards)
+                elements.extend(cards)
+                body: Any = Group(*elements)
+            elif legend:
+                elements.append(
+                    Align.center(Text("— empty —", style="dim italic"), vertical="middle")
+                )
+                body = Group(*elements)
             else:
                 body = Align.center(Text("— empty —", style="dim italic"), vertical="middle")
             title = Text(f"{state_label} ", style=f"bold {color}")
@@ -273,8 +285,13 @@ class KanbanTUI:
             meta.append(f"turn {status.turn}", style="green")
             if status.last_event:
                 meta.append(f"  {status.last_event}", style="dim")
-            if status.tokens:
-                meta.append(f"  {status.tokens:,} tok", style="cyan")
+            if status.input_tokens or status.output_tokens or status.tokens:
+                meta.append("  ", style="dim")
+                meta.append(f"in={status.input_tokens:,}", style="cyan")
+                meta.append(" / ", style="dim")
+                meta.append(f"out={status.output_tokens:,}", style="bright_cyan")
+                meta.append(" / ", style="dim")
+                meta.append(f"total={status.tokens:,}", style="bold cyan")
         elif status.runtime == "retrying":
             meta.append(f"retry #{status.attempt}", style="yellow")
             if status.error:
@@ -328,12 +345,14 @@ class KanbanTUI:
         index: dict[str, _CardStatus] = {}
         for row in snap.get("running", []):
             issue_id = row.get("issue_id") or ""
-            tokens = row.get("tokens", {}).get("total_tokens", 0)
+            tokens_block = row.get("tokens") or {}
             index[issue_id] = _CardStatus(
                 runtime="running",
                 turn=int(row.get("turn_count", 0) or 0),
                 last_event=str(row.get("last_event") or ""),
-                tokens=int(tokens or 0),
+                tokens=int(tokens_block.get("total_tokens") or 0),
+                input_tokens=int(tokens_block.get("input_tokens") or 0),
+                output_tokens=int(tokens_block.get("output_tokens") or 0),
                 last_message=str(row.get("last_message") or ""),
             )
         for row in snap.get("retrying", []):

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -167,6 +167,11 @@ class TrackerConfig:
     terminal_states: tuple[str, ...]
     # tracker.kind=file: absolute path to the board directory.
     board_root: Path | None = None
+    # Optional one-line description rendered as a legend under each column
+    # title in the TUI. Keys are state names (case-insensitive match against
+    # active_states / terminal_states); values are short human-readable
+    # explanations of what work happens in that lane.
+    state_descriptions: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -313,6 +318,23 @@ def _normalize_state_map(value: Any) -> dict[str, int]:
     return out
 
 
+def _normalize_state_description_map(value: Any) -> dict[str, str]:
+    """tracker.state_descriptions — keys lowercased, non-string entries dropped."""
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key, raw in value.items():
+        if not isinstance(key, str):
+            continue
+        if not isinstance(raw, str):
+            continue
+        text = raw.strip()
+        if not text:
+            continue
+        out[key.lower()] = text
+    return out
+
+
 def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
     """§6.1 — apply defaults and resolve typed values."""
     cfg = workflow.config
@@ -363,6 +385,9 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
             tracker_raw.get("terminal_states"), DEFAULT_TERMINAL_STATES
         ),
         board_root=board_path,
+        state_descriptions=_normalize_state_description_map(
+            tracker_raw.get("state_descriptions")
+        ),
     )
 
     polling_raw = cfg.get("polling") or {}

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -220,6 +220,77 @@ def test_validate_for_dispatch_missing_project_slug(tmp_path, monkeypatch):
         validate_for_dispatch(cfg)
 
 
+def test_state_descriptions_default_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker:
+              kind: linear
+              project_slug: x
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tracker.state_descriptions == {}
+
+
+def test_state_descriptions_normalized(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker:
+              kind: linear
+              project_slug: x
+              state_descriptions:
+                Todo: "  Triage incoming work  "
+                "In Progress": Code + tests
+                Review: Self-review the diff
+                Empty: ""
+                42: "non-string key dropped"
+                Bogus: 123
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    # Keys lowercased, blank/non-string values dropped, non-string keys dropped,
+    # leading/trailing whitespace stripped.
+    assert cfg.tracker.state_descriptions == {
+        "todo": "Triage incoming work",
+        "in progress": "Code + tests",
+        "review": "Self-review the diff",
+    }
+
+
+def test_state_descriptions_invalid_root_ignored(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker:
+              kind: linear
+              project_slug: x
+              state_descriptions: not-a-dict
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tracker.state_descriptions == {}
+
+
 def test_invalid_max_turns_fails_validation(tmp_path):
     path = _write(
         tmp_path,


### PR DESCRIPTION
## Summary

Two small TUI usability improvements that make the board easier to read at a
glance:

1. **\`tracker.state_descriptions\`** — optional one-line legend rendered under
   each column title. Distinguishes lanes whose intent isn't obvious from the
   name alone (e.g. \"Todo\" meaning *triage incoming PR* vs. \"Todo\" meaning
   *ready to implement*).
2. **Per-card token breakdown** — running cards now show \`in=X / out=Y /
   total=Z\` instead of just \`total\`, using fields the orchestrator already
   exposes in \`/api/v1/state\`. Surfaces context-window saturation / prompt
   bloat early.

## Why

The TUI today shows column names without context. Operators looking at a
custom workflow (Triage → Fix → Self-review → Deploy) can't tell what an
agent is *supposed* to do in each lane unless they read \`WORKFLOW.md\`'s
prompt body. A one-line legend resolves this without expanding the prompt
template surface area.

For tokens: the existing \`1,611,090 tok\` on a running card answers \"how
much have we burned?\" but not \"is this turn re-reading a giant context or
generating a lot?\" — which is the actually useful signal for catching a
runaway turn early. The orchestrator already tracks \`input_tokens\` and
\`output_tokens\` separately; the TUI just wasn't surfacing them.

## What changed

| File | Change |
|------|--------|
| \`src/symphony/workflow.py\` | New \`TrackerConfig.state_descriptions: dict[str, str]\` (default empty). New \`_normalize_state_description_map()\` parser — case-folds keys, drops non-string/empty values, mirrors the existing \`_normalize_state_map()\` pattern. |
| \`src/symphony/tui.py\` | \`_CardStatus\` gains \`input_tokens\` / \`output_tokens\` fields. \`_build_runtime_index()\` reads them from the snapshot. \`_render_card()\` shows \`in=X / out=Y / total=Z\` on running cards (replacing the single \`total tok\` line). \`_build_columns()\` prepends a dim-italic legend line inside each column body when \`state_descriptions\` has a matching entry. |
| \`tests/test_workflow.py\` | 3 new tests: default-empty, normalization (case-folding, blank/non-string drop, whitespace strip), invalid-shape (non-dict root) ignored. |
| \`WORKFLOW.example.md\` / \`WORKFLOW.file.example.md\` | Add a 3-line \`state_descriptions:\` example so new users see the field exists. |
| \`.claude/skills/using-symphony/reference/workflow-config.md\` | New \"Column legends\" subsection documenting the field with an example. |

No breaking changes. Existing WORKFLOW.md files render identically; the
field is purely additive.

## Out of scope

Cache token tracking (\`cache_read_input_tokens\` /
\`cache_creation_input_tokens\` from Claude Code \`result\` events) would
require new fields on \`RunEntry\` and per-backend extraction. Worth a
follow-up — it would let the breakdown show \`in=X (cached=Y) / out=Z\`
which is even more useful for cost-watching, but the change here uses
only what the orchestrator already exposes.

## Test plan

- [x] \`pytest -q\` — 105 passed (was 102; 3 new in \`test_workflow.py\`).
- [x] Manually verified the legend renders on a 6-column custom workflow
  (Todo / In Progress / Review / Done / Cancelled / Blocked) on Windows.
- [x] Manually verified the token breakdown updates live during an
  active turn (Claude Code backend).
- [ ] Reviewer to spot-check the YAML parsing edge cases — did I miss
  any reasonable user input shape?