### PR TITLE
feat(tui): EN/KO language toggle (default EN)

### DIFF
--- a/.claude/skills/using-symphony/reference/workflow-config.md
+++ b/.claude/skills/using-symphony/reference/workflow-config.md
@@ -189,3 +189,21 @@ server:
 
 When unset, the orchestrator runs without an HTTP server and you can only
 observe via stderr logs and the TUI.
+
+## TUI display tweaks
+
+```yaml
+tui:
+  language: en    # `en` (default) or `ko`. Aliases like `Korean` / `ko-KR`
+                  # also resolve. Unknown values fall back to English.
+```
+
+Only TUI chrome (column placeholder, header/footer field labels, card
+meta verbs `turn` / `retry #` / `blocked by`) is localized. Tracker
+state names, ticket titles, and `tracker.state_descriptions` come from
+user data and stay as authored.
+
+Per-key fallback to English is silent — adding a new locale never
+crashes the TUI on missing keys, but a missing translation surfaces as
+the literal key string (e.g. `card.turn`) so the gap is obvious in the
+running board.

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -61,6 +61,10 @@ gemini:
 
 server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`
+
+tui:
+  language: en          # `en` (default) or `ko` — only TUI chrome localizes;
+                        # tracker states and ticket titles stay as authored.
 ---
 
 You are picking up issue {{ issue.identifier }}: {{ issue.title }}.

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -52,6 +52,13 @@ gemini:
 
 server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`
+
+tui:
+  # TUI chrome language. Currently `en` (default) and `ko`. Tracker state
+  # names, ticket titles, and `tracker.state_descriptions` are user data
+  # and are never translated — only the column placeholder, header / footer
+  # field labels, and card meta verbs (turn / retry / blocked by) localize.
+  language: en
 ---
 
 You are picking up ticket {{ issue.identifier }}: {{ issue.title }}.

--- a/src/symphony/i18n.py
+++ b/src/symphony/i18n.py
@@ -1,0 +1,99 @@
+"""TUI string localization.
+
+A minimal i18n layer for the Kanban TUI. Tracker state names, ticket titles,
+and labels in `tracker.state_descriptions` come from user data and are not
+translated — only the chrome (column placeholder, header / footer field
+labels, card meta verbs) is.
+
+Add a new language by appending a key to `STRINGS` and adding the same
+keys you find under `STRINGS["en"]`. Keys that go untranslated fall back
+to the English value silently — never raise on a missing key, since a
+missing string would crash the TUI on every render.
+
+Tech-y tokens that look the same across locales (`in=`, `out=`, `total=`,
+`agent=`, `P1`, `#label`) deliberately do not pass through this layer.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+DEFAULT_LANGUAGE: Final[str] = "en"
+
+# All keys must exist in the English map. Other locales may omit keys,
+# in which case `t()` falls back to English.
+STRINGS: Final[dict[str, dict[str, str]]] = {
+    "en": {
+        # header
+        "header.agent": "agent=",
+        "header.tracker": "tracker=",
+        "header.workflow": "workflow=",
+        "header.running": "running=",
+        "header.retrying": "retrying=",
+        "header.generated_at": "generated_at",
+        # footer
+        "footer.tokens": "tokens",
+        "footer.runtime": "runtime=",
+        "footer.rate_limits": "rate-limits=",
+        # column
+        "column.empty": "— empty —",
+        # card meta
+        "card.turn": "turn",
+        "card.retry": "retry #",
+        "card.blocked_by": "blocked by",
+    },
+    "ko": {
+        # header
+        "header.agent": "에이전트=",
+        "header.tracker": "트래커=",
+        "header.workflow": "워크플로=",
+        "header.running": "실행=",
+        "header.retrying": "재시도=",
+        "header.generated_at": "생성시각",
+        # footer
+        "footer.tokens": "토큰",
+        "footer.runtime": "실행시간=",
+        "footer.rate_limits": "API제한=",
+        # column
+        "column.empty": "— 비어있음 —",
+        # card meta
+        "card.turn": "턴",
+        "card.retry": "재시도 #",
+        "card.blocked_by": "차단:",
+    },
+}
+
+SUPPORTED_LANGUAGES: Final[tuple[str, ...]] = tuple(STRINGS.keys())
+
+
+def t(key: str, language: str | None = None) -> str:
+    """Look up a localized string. Falls back to English on missing key."""
+    lang = (language or DEFAULT_LANGUAGE).lower()
+    if lang not in STRINGS:
+        lang = DEFAULT_LANGUAGE
+    table = STRINGS[lang]
+    if key in table:
+        return table[key]
+    # Fall back to English; if even that is missing, return the raw key
+    # so a missing translation surfaces obviously rather than blanking out.
+    return STRINGS[DEFAULT_LANGUAGE].get(key, key)
+
+
+def normalize_language(value: str | None) -> str:
+    """Coerce a config value into a supported language code, with EN fallback."""
+    if not isinstance(value, str):
+        return DEFAULT_LANGUAGE
+    candidate = value.strip().lower()
+    if candidate in STRINGS:
+        return candidate
+    # Common aliases so `Korean` / `KO_KR` / `kr` all map to `ko`.
+    aliases = {
+        "english": "en",
+        "en_us": "en",
+        "en-us": "en",
+        "korean": "ko",
+        "kr": "ko",
+        "ko_kr": "ko",
+        "ko-kr": "ko",
+    }
+    return aliases.get(candidate, DEFAULT_LANGUAGE)

--- a/src/symphony/tui.py
+++ b/src/symphony/tui.py
@@ -28,6 +28,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from .i18n import t
 from .issue import Issue, normalize_state
 from .logging import get_logger
 from .orchestrator import Orchestrator
@@ -170,46 +171,49 @@ class KanbanTUI:
         runtime_index = self._build_runtime_index(snapshot)
         column_panels = self._build_columns(cfg, runtime_index)
         header = self._build_header(cfg, snapshot)
-        footer = self._build_footer(snapshot)
+        footer = self._build_footer(cfg, snapshot)
         return Group(header, Columns(column_panels, expand=True, equal=True), footer)
 
     def _build_header(self, cfg: ServiceConfig, snap: dict[str, Any]) -> Panel:
+        lang = cfg.tui.language
         counts = snap.get("counts", {})
         agent_kind = cfg.agent.kind
         agent_color = AGENT_COLOR.get(agent_kind, "white")
         title = Text("symphony-multi-agent", style="bold")
-        title.append(f"  agent=", style="dim")
+        title.append(f"  {t('header.agent', lang)}", style="dim")
         title.append(agent_kind, style=f"bold {agent_color}")
-        title.append(f"  tracker={cfg.tracker.kind}", style="dim")
-        title.append(f"  workflow={cfg.workflow_path.name}", style="dim")
+        title.append(f"  {t('header.tracker', lang)}{cfg.tracker.kind}", style="dim")
+        title.append(f"  {t('header.workflow', lang)}{cfg.workflow_path.name}", style="dim")
         right = Text()
-        right.append(f"running={counts.get('running', 0)}  ", style="green")
-        right.append(f"retrying={counts.get('retrying', 0)}  ", style="yellow")
-        right.append(f"generated_at {snap.get('generated_at', '?')}", style="dim")
+        right.append(f"{t('header.running', lang)}{counts.get('running', 0)}  ", style="green")
+        right.append(f"{t('header.retrying', lang)}{counts.get('retrying', 0)}  ", style="yellow")
+        right.append(f"{t('header.generated_at', lang)} {snap.get('generated_at', '?')}", style="dim")
         bar = Table.grid(expand=True)
         bar.add_column(justify="left", ratio=2)
         bar.add_column(justify="right", ratio=1)
         bar.add_row(title, right)
         return Panel(bar, box=SIMPLE, padding=(0, 1))
 
-    def _build_footer(self, snap: dict[str, Any]) -> Panel:
+    def _build_footer(self, cfg: ServiceConfig, snap: dict[str, Any]) -> Panel:
+        lang = cfg.tui.language
         totals = snap.get("codex_totals", {})
         rl = snap.get("rate_limits")
         line = Text()
-        line.append("tokens  ", style="dim")
+        line.append(f"{t('footer.tokens', lang)}  ", style="dim")
         line.append(f"in={totals.get('input_tokens', 0):,}  ", style="cyan")
         line.append(f"out={totals.get('output_tokens', 0):,}  ", style="bright_cyan")
         line.append(f"total={totals.get('total_tokens', 0):,}", style="bold cyan")
         line.append("    ", style="dim")
-        line.append(f"runtime={totals.get('seconds_running', 0):.1f}s", style="dim")
+        line.append(f"{t('footer.runtime', lang)}{totals.get('seconds_running', 0):.1f}s", style="dim")
         if rl:
-            line.append("    rate-limits=", style="dim")
+            line.append(f"    {t('footer.rate_limits', lang)}", style="dim")
             line.append(_compact_rate_limits(rl), style="yellow")
         return Panel(line, box=SIMPLE, padding=(0, 1))
 
     def _build_columns(
         self, cfg: ServiceConfig, runtime_index: dict[str, _CardStatus]
     ) -> list[Panel]:
+        empty_text = t("column.empty", cfg.tui.language)
         # Active columns first (in declared order), then terminal columns.
         column_states: list[str] = list(cfg.tracker.active_states) + list(
             cfg.tracker.terminal_states
@@ -236,7 +240,9 @@ class KanbanTUI:
             issues = sorted(issues_by_state.get(state_key, []), key=_card_sort_key)
             color = STATE_COLOR.get(state_key, "white")
             cards = [
-                self._render_card(issue, runtime_index.get(issue.id, _CardStatus()), color)
+                self._render_card(
+                    issue, runtime_index.get(issue.id, _CardStatus()), color, cfg.tui.language
+                )
                 for issue in issues
             ]
             legend = descriptions.get(state_key)
@@ -248,11 +254,11 @@ class KanbanTUI:
                 body: Any = Group(*elements)
             elif legend:
                 elements.append(
-                    Align.center(Text("— empty —", style="dim italic"), vertical="middle")
+                    Align.center(Text(empty_text, style="dim italic"), vertical="middle")
                 )
                 body = Group(*elements)
             else:
-                body = Align.center(Text("— empty —", style="dim italic"), vertical="middle")
+                body = Align.center(Text(empty_text, style="dim italic"), vertical="middle")
             title = Text(f"{state_label} ", style=f"bold {color}")
             title.append(f"({len(issues)})", style="dim")
             panels.append(
@@ -266,7 +272,9 @@ class KanbanTUI:
             )
         return panels
 
-    def _render_card(self, issue: Issue, status: _CardStatus, color: str) -> Panel:
+    def _render_card(
+        self, issue: Issue, status: _CardStatus, color: str, language: str = "en"
+    ) -> Panel:
         title = Text(issue.identifier, style=f"bold {color}")
         if status.runtime == "running":
             title.append("  ●", style="bold green")
@@ -282,7 +290,7 @@ class KanbanTUI:
 
         meta = Text()
         if status.runtime == "running":
-            meta.append(f"turn {status.turn}", style="green")
+            meta.append(f"{t('card.turn', language)} {status.turn}", style="green")
             if status.last_event:
                 meta.append(f"  {status.last_event}", style="dim")
             if status.input_tokens or status.output_tokens or status.tokens:
@@ -293,13 +301,16 @@ class KanbanTUI:
                 meta.append(" / ", style="dim")
                 meta.append(f"total={status.tokens:,}", style="bold cyan")
         elif status.runtime == "retrying":
-            meta.append(f"retry #{status.attempt}", style="yellow")
+            meta.append(f"{t('card.retry', language)}{status.attempt}", style="yellow")
             if status.error:
                 meta.append(f"  {_truncate(status.error, 40)}", style="dim red")
         elif issue.blocked_by:
             blocker_names = [b.identifier for b in issue.blocked_by[:3] if b.identifier]
             if blocker_names:
-                meta.append(f"blocked by {', '.join(blocker_names)}", style="dim red")
+                meta.append(
+                    f"{t('card.blocked_by', language)} {', '.join(blocker_names)}",
+                    style="dim red",
+                )
         elif issue.labels:
             meta.append("  ".join(f"#{l}" for l in issue.labels[:3]), style="dim")
 

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -237,6 +237,17 @@ class ServerConfig:
 
 
 @dataclass(frozen=True)
+class TuiConfig:
+    """Display-time TUI tweaks. Affects rendering only; orchestrator ignores."""
+
+    # ISO-639-1 language code used to look up localized chrome strings
+    # (column placeholder, header / footer field labels, card meta verbs).
+    # Tracker state names, ticket titles, and `state_descriptions` come from
+    # user data and are never translated. Defaults to "en".
+    language: str = "en"
+
+
+@dataclass(frozen=True)
 class ServiceConfig:
     workflow_path: Path
     poll_interval_ms: int
@@ -248,6 +259,7 @@ class ServiceConfig:
     claude: ClaudeConfig
     gemini: GeminiConfig
     server: ServerConfig
+    tui: TuiConfig = field(default_factory=TuiConfig)
     raw: dict[str, Any] = field(default_factory=dict)
     prompt_template: str = ""
 
@@ -499,6 +511,12 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         port = None
     server = ServerConfig(port=port)
 
+    tui_raw = cfg.get("tui") or {}
+    if not isinstance(tui_raw, dict):
+        tui_raw = {}
+    from .i18n import normalize_language
+    tui = TuiConfig(language=normalize_language(tui_raw.get("language")))
+
     prompt_template = workflow.prompt_template or DEFAULT_PROMPT
 
     return ServiceConfig(
@@ -512,6 +530,7 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         claude=claude,
         gemini=gemini,
         server=server,
+        tui=tui,
         raw=dict(cfg),
         prompt_template=prompt_template,
     )

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,136 @@
+"""TUI i18n behavior."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from symphony.i18n import DEFAULT_LANGUAGE, STRINGS, normalize_language, t
+from symphony.workflow import build_service_config, load_workflow
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "WORKFLOW.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_default_language_is_english():
+    assert DEFAULT_LANGUAGE == "en"
+    assert t("card.turn") == "turn"
+
+
+def test_known_keys_translate():
+    assert t("card.turn", "ko") == "턴"
+    assert t("column.empty", "ko") == "— 비어있음 —"
+    assert t("header.running", "ko") == "실행="
+
+
+def test_unknown_language_falls_back_to_english():
+    assert t("card.turn", "fr") == "turn"
+    assert t("column.empty", "klingon") == "— empty —"
+
+
+def test_unknown_key_returns_raw_key():
+    # Surfaces missing translations during dev rather than blanking the cell.
+    assert t("nonexistent.key") == "nonexistent.key"
+
+
+def test_normalize_language_aliases():
+    assert normalize_language("Korean") == "ko"
+    assert normalize_language("KO_KR") == "ko"
+    assert normalize_language("ko-kr") == "ko"
+    assert normalize_language("English") == "en"
+    assert normalize_language("EN-US") == "en"
+    # Unknown / blank / non-string → default.
+    assert normalize_language("eo") == "en"
+    assert normalize_language("") == "en"
+    assert normalize_language(None) == "en"
+    assert normalize_language(42) == "en"
+
+
+def test_all_languages_have_same_key_set():
+    en_keys = set(STRINGS["en"].keys())
+    for lang, table in STRINGS.items():
+        if lang == "en":
+            continue
+        missing = en_keys - set(table.keys())
+        # Other locales may omit keys but t() must fall back; the test
+        # ensures the EN map remains the canonical superset.
+        assert missing == set() or all(t(k, lang) for k in missing), (
+            f"{lang} is missing keys {missing} but they don't fall back cleanly"
+        )
+
+
+def test_workflow_default_tui_language(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.language == "en"
+
+
+def test_workflow_explicit_korean(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            tui:
+              language: ko
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.language == "ko"
+
+
+def test_workflow_invalid_tui_block_falls_back_to_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            tui: not-a-dict
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.language == "en"
+
+
+def test_workflow_alias_korean(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            tui: { language: Korean }
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.language == "ko"


### PR DESCRIPTION
## Summary

Adds a \`tui.language\` config knob to localize the Kanban TUI's static
chrome between English (default) and Korean. No behavior change at the
default — purely additive.

```yaml
tui:
  language: ko    # `en` (default), `ko`. Aliases like `Korean` / `ko-KR` resolve.
```

## What localizes

- Column placeholder: \`— empty —\` ↔ \`— 비어있음 —\`
- Header labels: \`running=\` / \`retrying=\` / \`generated_at\` / \`agent=\` / \`tracker=\` / \`workflow=\`
- Footer labels: \`tokens\` / \`runtime=\` / \`rate-limits=\`
- Card meta verbs: \`turn\` / \`retry #\` / \`blocked by\`

## What does NOT localize (deliberate)

- Tracker state names (\`Todo\`, \`In Progress\`, \`Review\`, etc.) — user data
- Ticket titles, priorities, labels — user data
- \`tracker.state_descriptions\` — user-authored, already in their preferred language
- Token breakdown \`in= / out= / total=\` — technical units; flipping to \`입력= / 출력= / 합계=\` would harm scannability for bilingual teams

## Implementation

Tiny new module: \`src/symphony/i18n.py\` with a \`STRINGS: dict[lang, dict[key, str]]\` table, a \`t(key, lang)\` helper, and \`normalize_language()\` for aliases. Missing keys fall back to English silently — adding a new locale never crashes the TUI on a missing translation. Missing English keys surface the raw key string so the gap is obvious.

\`tui.py\` was updated to thread \`cfg.tui.language\` through \`_build_header\`, \`_build_footer\`, \`_build_columns\`, and \`_render_card\`. Each formerly-hardcoded string is now \`t(\"key\", lang)\`. Default behavior at \`language: en\` is byte-identical.

## Tests

10 new tests in \`test_i18n.py\` covering defaults, KO lookups, unknown-language fallback, unknown-key fallback, alias normalization (Korean / ko-KR / KR), key-set parity across locales, and four WORKFLOW.md parse cases (default, explicit ko, invalid \`tui:\` block, alias).

\`pytest -q\` — **115 passed** (was 105).

## Out of scope

- RTL locales (Arabic / Hebrew) — no bidi handling here.
- Translating agent-emitted \`last_event\` / \`last_message\` (those come from the agent backend in whatever language the agent itself emitted).
- A \`SYMPHONY_LANG\` env var override. Could add later if useful; for now \`tui.language\` in WORKFLOW.md is the single source of truth.

## Test plan

- [x] \`pytest -q\` (115 passed)
- [x] Manually rendered with \`tui: { language: ko }\` — every chrome string flips to Korean; user data unchanged
- [ ] Native-Korean reviewer to spot-check translations (especially \`API제한=\` which is compact but maybe \`사용량제한=\` reads better — kept short for layout)