### PR TITLE
feat(tui): SYMPHONY_LANG env override + visible language hint

### DIFF
--- a/src/symphony/i18n.py
+++ b/src/symphony/i18n.py
@@ -16,9 +16,15 @@ Tech-y tokens that look the same across locales (`in=`, `out=`, `total=`,
 
 from __future__ import annotations
 
+import os
 from typing import Final
 
 DEFAULT_LANGUAGE: Final[str] = "en"
+
+# Environment variable that overrides `tui.language` from WORKFLOW.md.
+# Useful for flipping the chrome locale per-session without editing the
+# shared workflow file (e.g. one operator on a multi-operator board).
+LANGUAGE_ENV_VAR: Final[str] = "SYMPHONY_LANG"
 
 # All keys must exist in the English map. Other locales may omit keys,
 # in which case `t()` falls back to English.
@@ -41,6 +47,9 @@ STRINGS: Final[dict[str, dict[str, str]]] = {
         "card.turn": "turn",
         "card.retry": "retry #",
         "card.blocked_by": "blocked by",
+        # language switch hint shown in the header
+        "header.lang": "lang=",
+        "header.lang_hint": "(SYMPHONY_LANG=ko or set tui.language in WORKFLOW.md)",
     },
     "ko": {
         # header
@@ -60,6 +69,9 @@ STRINGS: Final[dict[str, dict[str, str]]] = {
         "card.turn": "턴",
         "card.retry": "재시도 #",
         "card.blocked_by": "차단:",
+        # language switch hint shown in the header
+        "header.lang": "언어=",
+        "header.lang_hint": "(SYMPHONY_LANG=en 또는 WORKFLOW.md tui.language 수정 후 재시작)",
     },
 }
 
@@ -97,3 +109,11 @@ def normalize_language(value: str | None) -> str:
         "ko-kr": "ko",
     }
     return aliases.get(candidate, DEFAULT_LANGUAGE)
+
+
+def resolve_language(config_value: str | None) -> str:
+    """Effective TUI language. ENV var (SYMPHONY_LANG) wins over config."""
+    env_value = os.environ.get(LANGUAGE_ENV_VAR, "").strip()
+    if env_value:
+        return normalize_language(env_value)
+    return normalize_language(config_value)

--- a/src/symphony/tui.py
+++ b/src/symphony/tui.py
@@ -184,6 +184,8 @@ class KanbanTUI:
         title.append(agent_kind, style=f"bold {agent_color}")
         title.append(f"  {t('header.tracker', lang)}{cfg.tracker.kind}", style="dim")
         title.append(f"  {t('header.workflow', lang)}{cfg.workflow_path.name}", style="dim")
+        title.append(f"  {t('header.lang', lang)}{lang}", style="bright_magenta")
+        title.append(f"  {t('header.lang_hint', lang)}", style="dim italic")
         right = Text()
         right.append(f"{t('header.running', lang)}{counts.get('running', 0)}  ", style="green")
         right.append(f"{t('header.retrying', lang)}{counts.get('retrying', 0)}  ", style="yellow")

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -514,8 +514,10 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
     tui_raw = cfg.get("tui") or {}
     if not isinstance(tui_raw, dict):
         tui_raw = {}
-    from .i18n import normalize_language
-    tui = TuiConfig(language=normalize_language(tui_raw.get("language")))
+    from .i18n import resolve_language
+    # SYMPHONY_LANG env var takes precedence over WORKFLOW.md so a single
+    # operator can flip without editing the shared workflow file.
+    tui = TuiConfig(language=resolve_language(tui_raw.get("language")))
 
     prompt_template = workflow.prompt_template or DEFAULT_PROMPT
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from symphony.i18n import DEFAULT_LANGUAGE, STRINGS, normalize_language, t
+from symphony.i18n import (
+    DEFAULT_LANGUAGE,
+    LANGUAGE_ENV_VAR,
+    STRINGS,
+    normalize_language,
+    resolve_language,
+    t,
+)
 from symphony.workflow import build_service_config, load_workflow
 
 
@@ -116,6 +123,56 @@ def test_workflow_invalid_tui_block_falls_back_to_default(tmp_path, monkeypatch)
     )
     cfg = build_service_config(load_workflow(path))
     assert cfg.tui.language == "en"
+
+
+def test_resolve_language_env_overrides_config(monkeypatch):
+    monkeypatch.setenv(LANGUAGE_ENV_VAR, "ko")
+    assert resolve_language("en") == "ko"
+
+
+def test_resolve_language_env_alias(monkeypatch):
+    monkeypatch.setenv(LANGUAGE_ENV_VAR, "Korean")
+    assert resolve_language("en") == "ko"
+
+
+def test_resolve_language_no_env_uses_config(monkeypatch):
+    monkeypatch.delenv(LANGUAGE_ENV_VAR, raising=False)
+    assert resolve_language("ko") == "ko"
+    assert resolve_language(None) == "en"
+
+
+def test_resolve_language_blank_env_falls_through(monkeypatch):
+    monkeypatch.setenv(LANGUAGE_ENV_VAR, "   ")
+    assert resolve_language("ko") == "ko"
+
+
+def test_lang_hint_keys_exist():
+    assert t("header.lang") == "lang="
+    assert t("header.lang", "ko") == "언어="
+    # Hint contains the env var name in EN, and instructions in KO.
+    assert "SYMPHONY_LANG" in t("header.lang_hint")
+    assert "SYMPHONY_LANG" in t("header.lang_hint", "ko") or "tui.language" in t(
+        "header.lang_hint", "ko"
+    )
+
+
+def test_workflow_env_override_wins_over_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    monkeypatch.setenv(LANGUAGE_ENV_VAR, "ko")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            tui: { language: en }
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.language == "ko"
 
 
 def test_workflow_alias_korean(tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up on #9. Adds (1) `SYMPHONY_LANG` env var that overrides `tui.language` per-session and (2) a visible `lang=en (SYMPHONY_LANG=ko or set tui.language in WORKFLOW.md)` hint in the header so users discover the toggle exists. Tests: 121 passed (115 → +6). Runtime hotkey deferred — `rich.Live` alt-screen mode would need cross-platform raw-mode stdin handling.