### PR TITLE
feat(workflow): six-stage production pipeline (Plan / Review / QA / Done)

### DIFF
--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -3,13 +3,15 @@ tracker:
   kind: linear
   project_slug: my-team-project
   api_key: $LINEAR_API_KEY
-  active_states: [Todo, In Progress]
+  active_states: [Todo, "In Progress", Review, QA]
   terminal_states: [Closed, Cancelled, Canceled, Duplicate, Done]
   # Optional one-line legend rendered under each TUI column header.
   state_descriptions:
-    Todo: "Ready for an agent to pick up"
-    "In Progress": "Agent actively working"
-    Done: "Completed by the agent"
+    Todo: "Plan + first failing test"
+    "In Progress": "TDD loop, draft PR"
+    Review: "Read diff, fix CRITICAL/HIGH"
+    QA: "Execute real code, capture evidence"
+    Done: "As-Is -> To-Be report"
 
 polling:
   interval_ms: 30000
@@ -34,6 +36,8 @@ agent:
   max_concurrent_agents_by_state:
     Todo: 2
     "In Progress": 4
+    Review: 2
+    QA: 2
 
 codex:
   command: codex app-server
@@ -63,14 +67,14 @@ server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`
 
 tui:
-  language: en          # `en` (default) or `ko` — only TUI chrome localizes;
-                        # tracker states and ticket titles stay as authored.
+  language: en          # `en` (default) or `ko` — chrome only. SYMPHONY_LANG env overrides.
 ---
 
 You are picking up issue {{ issue.identifier }}: {{ issue.title }}.
-
 Current state: {{ issue.state }}.
-{% if attempt %}This is retry attempt {{ attempt }}.{% endif %}
+{% if attempt %}This is retry attempt {{ attempt }}. Read the previous Linear
+comment thread first and address the root cause from the prior failure, not the
+symptom.{% endif %}
 
 {% if issue.description %}
 ## Description
@@ -78,9 +82,7 @@ Current state: {{ issue.state }}.
 {{ issue.description }}
 {% endif %}
 
-{% if issue.labels %}
-Labels: {{ issue.labels | join: ", " }}
-{% endif %}
+{% if issue.labels %}Labels: {{ issue.labels | join: ", " }}{% endif %}
 
 {% if issue.blocked_by %}
 This issue depends on:
@@ -88,10 +90,103 @@ This issue depends on:
 {% endfor %}
 {% endif %}
 
-Workflow expectations:
-- Read the repo, plan a small change, and implement it.
-- Run the project's tests before considering work complete.
-- When done, transition the ticket to `Human Review` and add a comment with the
-  PR link using the `linear_graphql` tool.
-- If you cannot proceed (missing info, conflict, ambiguous spec), transition the
-  ticket to `Blocked` with a comment explaining what is needed.
+## Production pipeline (six stages, no skipping)
+
+Every issue flows through the same gates. Honour the gate that matches
+`{{ issue.state }}`. Each stage owns one transition; never jump ahead.
+
+```
+  Todo / In Progress  ->  Review  ->  QA  ->  Done
+                              \                 ^
+                               +-> Blocked      |
+                                                |
+              (QA failure rewinds to In Progress)
+```
+
+State transitions and stage notes are written via the `linear_graphql` tool:
+`issueUpdate` for state changes, `commentCreate` for the per-stage notes
+described below. Each stage produces one comment.
+
+## Stage rules
+
+### IMPLEMENT  -- when state is `Todo` or `In Progress`
+
+1. Research first: search the repo, the test suite, and library docs before
+   writing anything new. Reuse battle-tested helpers over hand-rolled ones.
+2. Post a Plan comment: the smallest sustainable change, the files you
+   intend to touch, the test you will write first.
+3. TDD loop: write a failing test, make it pass, refactor. No production
+   code without a test exercising it.
+4. Open a draft PR. Post an Implementation comment with the PR link, the
+   touched files, and the commit-style intent of each change.
+5. Transition state to `Review`.
+
+### REVIEW  -- when state is `Review`
+
+1. Read the diff on the PR (`git diff origin/main...HEAD`). Re-read the
+   touched files end-to-end, not just the hunks.
+2. Apply the checklist: clarity, naming, error handling, security,
+   performance, simplicity, no dead code, no debug prints, no secrets.
+3. Fix every CRITICAL and HIGH issue. Post a Review comment with one
+   bullet per finding (`severity | file:line | fix`).
+4. If unfixable / out of scope: transition state to `Blocked`, post a
+   Blocker comment with what is needed and stop.
+5. Otherwise transition state to `QA`.
+
+### QA  -- when state is `QA`  (THIS STAGE MUST EXECUTE REAL CODE)
+
+A QA pass that only inspects code is a failed QA. Run something and
+capture its output as evidence.
+
+1. Detect the project type and execute the matching real-world check:
+   - **Tests**: run the full suite (`pytest -q`, `npm test`, etc.).
+   - **HTTP API**: capture the As-Is response by hitting the baseline
+     build and the To-Be response by hitting the new build (curl /
+     httpie / `requests`). Diff the two.
+   - **Web UI**: run or author a Playwright / Cypress script that walks
+     the flow end-to-end. Attach screenshots / traces to the PR.
+   - **CLI / script**: run the command and assert exit code plus
+     observable stdout/stderr / file output.
+2. Post a QA Evidence comment listing:
+   - the exact commands run,
+   - their exit codes,
+   - a short excerpt of relevant output (3-10 lines),
+   - links to PR-attached artefacts (screenshots, logs, traces).
+3. If anything fails: transition state back to `In Progress`, post a QA
+   Failure comment describing what regressed, and stop. Do NOT silence,
+   retry, or skip the failing check.
+4. If everything passes: transition state to `Done`.
+
+### DONE  -- when state is `Done`
+
+Terminal. Post a final As-Is -> To-Be Report comment with this exact
+structure:
+
+```
+## As-Is -> To-Be Report
+
+### As-Is
+- <prior behaviour, with evidence: response payload, log line, screenshot link>
+
+### To-Be
+- <new behaviour, with the matching piece of evidence>
+
+### Reasoning
+- Why this approach over the alternatives considered.
+- Trade-offs accepted (performance, complexity, scope).
+- Follow-ups intentionally deferred (with linked tickets).
+
+### Evidence
+- Commands run during QA, with exit codes.
+- Test names, PR-attached artefacts.
+- Links to log lines or dashboards.
+```
+
+Leave the state as `Done` and stop.
+
+## Hard rules
+
+- Never skip a stage. Never mark `Done` without a QA Evidence comment.
+- Never silence failing tests or hide errors. Fix the root cause or move
+  to `Blocked`.
+- Touch only what the issue requires. No drive-by refactors.

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -2,16 +2,15 @@
 tracker:
   kind: file
   board_root: ./kanban
-  active_states: [Todo, In Progress]
+  active_states: [Todo, "In Progress", Review, QA]
   terminal_states: [Done, Cancelled, Blocked]
-  # Optional one-line legend rendered under each TUI column header so a
-  # casual viewer can tell what work happens in each lane.
+  # Optional one-line legend rendered under each TUI column header.
   state_descriptions:
-    Todo: "Ready for an agent to pick up"
-    "In Progress": "Agent actively working"
-    Done: "Completed by the agent"
-    Blocked: "Awaiting human input"
-    Cancelled: "Junk / stale / agent-rejected"
+    Todo: "Plan + first failing test"
+    "In Progress": "TDD loop, draft PR"
+    Review: "Read diff, fix CRITICAL/HIGH"
+    QA: "Execute real code, capture evidence"
+    Done: "As-Is -> To-Be report"
 
 polling:
   interval_ms: 30000
@@ -35,6 +34,8 @@ agent:
   max_concurrent_agents_by_state:
     Todo: 2
     "In Progress": 4
+    Review: 2
+    QA: 2
 
 codex:
   command: codex app-server
@@ -54,16 +55,13 @@ server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`
 
 tui:
-  # TUI chrome language. Currently `en` (default) and `ko`. Tracker state
-  # names, ticket titles, and `tracker.state_descriptions` are user data
-  # and are never translated — only the column placeholder, header / footer
-  # field labels, and card meta verbs (turn / retry / blocked by) localize.
-  language: en
+  language: en          # `en` (default) or `ko` — chrome only. SYMPHONY_LANG env overrides.
 ---
-
 You are picking up ticket {{ issue.identifier }}: {{ issue.title }}.
 Current state: {{ issue.state }}.
-{% if attempt %}This is retry attempt {{ attempt }}.{% endif %}
+{% if attempt %}This is retry attempt {{ attempt }}. Read the previous `## Resolution`,
+`## Blocker`, or `## QA Failure` section before acting and address the root cause,
+not the symptom.{% endif %}
 
 {% if issue.description %}
 ## Description
@@ -79,20 +77,109 @@ This ticket depends on:
 {% endfor %}
 {% endif %}
 
-## How to update the ticket
+## Production pipeline (six stages, no skipping)
 
-The ticket file is located at `kanban/{{ issue.identifier }}.md`. To change
-state, edit its YAML front matter `state:` field and rewrite the file.
-Allowed states are: {{ issue.state }}, plus those listed in tracker.active_states /
-terminal_states inside WORKFLOW.md.
+Every ticket flows through the same gates. Honour the gate that matches
+`{{ issue.state }}`. Each stage owns one transition; never jump ahead.
 
-When you finish (or hit a blocker), use your shell tools to update the file
-in-place — Symphony will reconcile on the next poll tick.
+```
+  Todo / In Progress  ->  Review  ->  QA  ->  Done
+                              \                 ^
+                               +-> Blocked      |
+                                                |
+              (QA failure rewinds to In Progress)
+```
 
-Workflow expectations:
-- Read the repo, plan a small change, and implement it.
-- Run the project's tests before considering the work complete.
-- When done, set the ticket `state` to `Done` and append a `## Resolution`
-  section to the body explaining what was changed.
-- If you cannot proceed, set `state` to `Blocked` and append a `## Blocker`
-  section explaining what is needed.
+The ticket file lives at `kanban/{{ issue.identifier }}.md`. Edit the YAML
+front matter `state:` field to transition; append narrative sections to the
+body. Symphony reconciles on the next poll tick.
+
+## Stage rules
+
+### IMPLEMENT  -- when state is `Todo` or `In Progress`
+
+1. Research first. Search the workspace, the existing test suite, and the
+   relevant library docs before writing anything new. Reuse battle-tested
+   helpers over hand-rolled ones.
+2. Write a `## Plan` section in the ticket: the smallest sustainable change,
+   the files you intend to touch, and the test you will write first.
+3. TDD loop: write a failing test, make it pass, refactor. No production
+   code without a test that exercises it.
+4. Append `## Implementation` to the ticket: list the touched files, the
+   commit-style intent of each change, and any decisions worth recording.
+5. Set state to `Review`.
+
+### REVIEW  -- when state is `Review`
+
+1. Read your own diff (`git diff`, `git status`, or whatever the workspace
+   provides). Re-read the touched files end-to-end, not just the hunks.
+2. Apply the checklist: clarity, naming, error handling, security,
+   performance, simplicity, no dead code, no debug prints, no secrets.
+3. Fix every CRITICAL and HIGH issue you find. Record findings under
+   `## Review` (one bullet per issue with `severity | file:line | fix`).
+4. If something is genuinely out of scope or unfixable, set state to
+   `Blocked` and append a `## Blocker` explaining what is needed.
+5. Otherwise set state to `QA`.
+
+### QA  -- when state is `QA`  (THIS STAGE MUST EXECUTE REAL CODE)
+
+A QA pass that only inspects code is a failed QA. You must run something
+and capture its output as evidence.
+
+1. Detect the project type and execute the matching real-world check:
+   - **Tests**: run the full suite (`pytest -q`, `npm test`, `pnpm test`,
+     `go test ./...`, `mvn test`, `cargo test`). All must pass.
+   - **HTTP API**: capture the As-Is response by hitting the baseline build
+     and the To-Be response by hitting the new build (curl / httpie /
+     `requests`). Diff the two and confirm the change is what the ticket
+     asked for, and nothing else.
+   - **Web UI**: author or run a Playwright (or Cypress) script that walks
+     the user-facing flow end-to-end. Save screenshots or traces under
+     `qa-artifacts/` in the workspace.
+   - **CLI / script**: run the command and assert exit code plus the
+     observable stdout/stderr / file output.
+2. Append `## QA Evidence` to the ticket with:
+   - the exact commands run (one per line),
+   - their exit codes,
+   - a short excerpt of relevant output (3-10 lines), and
+   - paths to any larger artefacts (logs, screenshots, traces).
+3. If anything fails: set state back to `In Progress`, add a
+   `## QA Failure` section describing what regressed, and stop. Do NOT
+   silence, retry, or skip the failing check.
+4. If everything passes: set state to `Done`.
+
+### DONE  -- when state is `Done`
+
+Terminal. The ticket has already passed QA. Confirm by appending an
+`## As-Is -> To-Be Report` section with this exact structure:
+
+```
+## As-Is -> To-Be Report
+
+### As-Is
+- <prior behaviour, with evidence: response payload, log line, screenshot path>
+
+### To-Be
+- <new behaviour, with the matching piece of evidence>
+
+### Reasoning
+- Why this approach over the alternatives considered.
+- Trade-offs accepted (performance, complexity, scope).
+- Follow-ups intentionally deferred (with ticket / file references).
+
+### Evidence
+- Commands run during QA, with exit codes.
+- Test names, file paths, artefact locations.
+- Links to relevant log lines under `log/`.
+```
+
+Leave state as `Done` and stop. Do not re-run earlier stages.
+
+## Hard rules (apply in every stage)
+
+- Never skip a stage. Never mark `Done` without `## QA Evidence`.
+- Never silence failing tests, hide errors, or add fake success paths. Fix
+  the root cause or move the ticket to `Blocked`.
+- Touch only what the ticket requires. No drive-by refactors.
+- Record reasoning for non-trivial decisions in
+  `log/changelog-YYYY-MM-DD.md` (append; do not overwrite).

--- a/docs/PIPELINE-DEMO.md
+++ b/docs/PIPELINE-DEMO.md
@@ -1,0 +1,87 @@
+---
+id: PIPELINE-DEMO
+identifier: PIPELINE-DEMO
+title: Reference ticket showing the Plan / Review / QA / Done shape
+state: Done
+priority: 3
+labels:
+- demo
+- docs
+created_at: '2026-05-09T20:00:00Z'
+updated_at: '2026-05-09T20:00:00Z'
+---
+
+This ticket is a worked example. It illustrates the artefacts the agent
+should produce as it walks the production pipeline. Real tickets follow
+this same shape but with project-specific content.
+
+## Plan
+
+- 작업 범위: `/api/v1/refresh` 엔드포인트의 응답 캐시 헤더를 `Cache-Control: no-store`로 변경.
+- 변경 파일: `src/symphony/server.py` (1 곳), `tests/test_server.py` (테스트 1건 추가).
+- 가장 먼저 추가할 실패 테스트: `test_refresh_sets_no_store_cache_header`.
+
+## Implementation
+
+- `src/symphony/server.py:142` — `_handle_refresh()` 응답에 `Cache-Control: no-store` 헤더 추가.
+- `tests/test_server.py:88` — 응답 헤더를 검증하는 회귀 테스트 추가.
+- 그 외 변경 없음. 다른 핸들러는 영향받지 않도록 의도적으로 좁게 수정.
+
+## Review
+
+- LOW | `src/symphony/server.py:142` | 헤더 키를 상수로 빼는 것이 깔끔하나, 단일 사용처라 인라인 유지 (간결성 우선). 액션 없음.
+- HIGH | 없음.
+- CRITICAL | 없음.
+
+## QA Evidence
+
+```
+$ pytest -q tests/test_server.py
+....                                                                     [100%]
+4 passed in 0.42s
+exit code: 0
+
+$ curl -i -X POST http://127.0.0.1:9999/api/v1/refresh
+HTTP/1.1 200 OK
+Content-Type: application/json
+Cache-Control: no-store
+...
+exit code: 0
+
+$ python scripts/diff_refresh_response.py --baseline main --candidate HEAD
+- Cache-Control: max-age=0
++ Cache-Control: no-store
+exit code: 0
+```
+
+artefacts: `qa-artifacts/refresh-response-tobe.json`,
+            `qa-artifacts/refresh-response-asis.json`.
+
+## As-Is -> To-Be Report
+
+### As-Is
+- `/api/v1/refresh` 응답이 `Cache-Control: max-age=0`으로 내려가 일부 프록시
+  계층(특히 사내 NGINX)이 짧게 캐시. 운영자가 강제 새로고침해도 같은 페이로드를
+  수 초간 재사용하는 사례가 보고됨 (log/symphony.log 2026-05-08 14:22 부근).
+
+### To-Be
+- 동일 엔드포인트가 `Cache-Control: no-store`를 반환. 프록시 캐시 우회가
+  보장되며 강제 새로고침 시 항상 최신 폴링 결과가 반영됨. 위 QA 단계의
+  curl 출력으로 확인.
+
+### Reasoning
+- 가장 좁은 변경으로 문제 해결 (헤더 한 줄). 캐시 정책 전반을 손대지 않은 것은
+  다른 엔드포인트가 의도적으로 캐시 가능 상태이기 때문.
+- 대안으로 `Pragma: no-cache` 동시 부착도 검토했으나, HTTP/1.1 환경에서는
+  `Cache-Control`만으로 충분하고 헤더 중복은 디버깅을 흐림.
+- 후속: `/api/v1/state`도 동일 이슈 가능성이 있으나 별도 티켓에서 다룸
+  (TASK-NEXT 에 기록 예정).
+
+### Evidence
+- 명령: `pytest -q tests/test_server.py` (rc=0),
+  `curl -i -X POST http://127.0.0.1:9999/api/v1/refresh` (rc=0),
+  `python scripts/diff_refresh_response.py --baseline main --candidate HEAD` (rc=0).
+- 테스트: `tests/test_server.py::test_refresh_sets_no_store_cache_header`.
+- 아티팩트: `qa-artifacts/refresh-response-asis.json`,
+              `qa-artifacts/refresh-response-tobe.json`.
+- 관련 로그: `log/symphony.log` 2026-05-08 14:22:11Z 라인.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,0 +1,93 @@
+# Production pipeline
+
+Symphony's default task (the prompt template in `WORKFLOW.md`) drives every
+ticket through six gated stages. The harness picks the ticket up on each poll
+tick; the agent moves it from one stage to the next by editing the ticket
+file's `state` field. The orchestrator only reads, so this stage machine is
+intentionally implemented in the prompt rather than the Python core.
+
+```
+  Todo / In Progress  ->  Review  ->  QA  ->  Done
+                              \                 ^
+                               +-> Blocked      |
+                                                |
+              (QA failure rewinds to In Progress)
+```
+
+| State          | Owner of this turn         | Output it must produce                              |
+|----------------|----------------------------|-----------------------------------------------------|
+| Todo           | implementer                | `## Plan` + first failing test                      |
+| In Progress    | implementer                | `## Implementation`, transition to Review           |
+| Review         | reviewer                   | `## Review`, fix CRITICAL/HIGH, transition to QA    |
+| QA             | qa runner (executes code)  | `## QA Evidence` (real exit codes), -> Done         |
+| Done           | reporter                   | `## As-Is -> To-Be Report` (structured)             |
+| Blocked        | -                          | `## Blocker` describing what is needed              |
+
+## Why a QA stage
+
+A code review confirms intent; only execution confirms behaviour. The QA
+stage forces the agent to run real commands and capture the output:
+
+- **Tests** — the project's full suite (`pytest`, `npm test`, `go test`, ...).
+- **HTTP APIs** — curl / httpie against the baseline (As-Is) and against
+  the new build (To-Be); diff the two responses.
+- **Web UIs** — a Playwright or Cypress script that walks the flow
+  end-to-end. Screenshots and traces land in `qa-artifacts/`.
+- **CLIs** — run the command, assert exit code and observable output.
+
+A QA pass that only inspects code is a failed QA. The agent must record
+the exact commands it ran, their exit codes, and a short excerpt of the
+output under `## QA Evidence` in the ticket.
+
+If anything fails the agent rewinds the ticket to `In Progress` and writes
+a `## QA Failure` section. It must not silence, retry, or skip the failing
+check.
+
+## The Done report
+
+`Done` is not a "stop" signal — it is a "produce a report" signal. Every
+completed ticket carries an `## As-Is -> To-Be Report` block that captures:
+
+- **As-Is** — prior behaviour, evidence-backed.
+- **To-Be** — new behaviour, evidence-backed (same shape as As-Is so they
+  can be diffed visually).
+- **Reasoning** — why this approach over alternatives, trade-offs accepted,
+  follow-ups intentionally deferred.
+- **Evidence** — commands run during QA, test names, artefact paths.
+
+The block lives in the ticket body so future readers (and future agent
+runs) get the full story without spelunking through git or chat history.
+
+## Stage transitions and the orchestrator
+
+`active_states` in `WORKFLOW.md` is `[Todo, "In Progress", Review, QA]`.
+The orchestrator dispatches a worker for any ticket whose state is in
+that set, regardless of which stage it is on. Each turn the agent reads
+`{{ issue.state }}` from the prompt and applies the matching stage rule.
+That keeps the Python core simple: states are just strings; the pipeline
+is policy expressed in the prompt.
+
+`max_concurrent_agents_by_state` lets you cap how many tickets can sit
+in each stage in parallel — useful when QA runs are expensive (real
+browsers, real backends).
+
+## Adopting the pipeline
+
+1. Copy `WORKFLOW.file.example.md` (file tracker) or `WORKFLOW.example.md`
+   (Linear) to `WORKFLOW.md` and customize.
+2. Confirm `tracker.active_states` includes `Review` and `QA`.
+3. Make sure your `before_run` / `after_create` hooks land the agent in
+   a workspace where the test suite, target API, or browser harness is
+   actually runnable. The QA stage is only as good as the workspace it
+   runs in.
+4. Run `symphony doctor ./WORKFLOW.md` before launching to catch the
+   common first-run failures (port collision, missing CLI on PATH,
+   placeholder clone URL).
+
+## Reference ticket
+
+A complete worked example lives at [`docs/PIPELINE-DEMO.md`](./PIPELINE-DEMO.md).
+It carries every section a finished pipeline ticket should have
+(`## Plan`, `## Implementation`, `## Review`, `## QA Evidence`, and the
+`## As-Is -> To-Be Report` block). Copy its structure when authoring a
+real ticket — the test suite asserts this exact shape stays consistent.

--- a/tests/test_workflow_pipeline_prompt.py
+++ b/tests/test_workflow_pipeline_prompt.py
@@ -1,0 +1,153 @@
+"""Coverage for the production-pipeline prompt template shipped in
+WORKFLOW.md / WORKFLOW.file.example.md / WORKFLOW.example.md.
+
+These tests assert the prompt: (1) parses + renders for every active state,
+(2) carries the stage-specific instructions the agent needs at each stage,
+(3) renders the retry and blocked_by branches, and (4) preserves the
+fixed `## As-Is -> To-Be Report` shape required at Done.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from symphony.issue import BlockerRef, Issue
+from symphony.prompt import build_prompt_env, render
+from symphony.workflow import build_service_config, load_workflow
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# `WORKFLOW.md` is gitignored — every operator customizes it for their own
+# board (different prompt body, different agent.kind, different hooks). The
+# pipeline prompt is shipped via the *example* files; those are the
+# canonical reference users copy from. We deliberately do not assert the
+# pipeline prompt lives in `WORKFLOW.md` itself, since requiring that
+# would break any non-pipeline workflow people legitimately run.
+WORKFLOW_FILES = (
+    "WORKFLOW.file.example.md",
+    "WORKFLOW.example.md",
+)
+
+# Phrases that must appear in every render. The template is not state-
+# branched in the parser sense; it ships every stage rule and the agent
+# selects the matching one. So whatever the issue's state, all stage
+# headings must be present (and the issue's state must be echoed).
+STAGE_HEADINGS = (
+    "IMPLEMENT",
+    "REVIEW",
+    "QA",
+    "DONE",
+)
+
+# File-tracker variants record QA via a `## QA Evidence` markdown section in
+# the ticket body; the Linear variant records it as a "QA Evidence comment".
+# Both must mention `QA Evidence` and demand real execution.
+QA_HARD_RULES = (
+    "THIS STAGE MUST EXECUTE REAL CODE",
+    "QA Evidence",
+)
+
+DONE_REPORT_SHAPE = (
+    "## As-Is -> To-Be Report",
+    "### As-Is",
+    "### To-Be",
+    "### Reasoning",
+    "### Evidence",
+)
+
+
+def _load(name: str):
+    cfg = build_service_config(load_workflow(REPO_ROOT / name))
+    return cfg
+
+
+def _issue(state: str, **overrides) -> Issue:
+    base = dict(
+        id="DEMO-1",
+        identifier="DEMO-1",
+        title="t",
+        description="d",
+        priority=2,
+        state=state,
+        labels=(),
+    )
+    base.update(overrides)
+    return Issue(**base)
+
+
+@pytest.mark.parametrize("workflow", WORKFLOW_FILES)
+def test_active_states_include_review_and_qa(workflow: str) -> None:
+    cfg = _load(workflow)
+    assert "Review" in cfg.tracker.active_states
+    assert "QA" in cfg.tracker.active_states
+
+
+@pytest.mark.parametrize("workflow", WORKFLOW_FILES)
+@pytest.mark.parametrize("state", ["Todo", "In Progress", "Review", "QA", "Done"])
+def test_prompt_renders_for_every_stage(workflow: str, state: str) -> None:
+    cfg = _load(workflow)
+    rendered = render(cfg.prompt_template, build_prompt_env(_issue(state), attempt=None))
+    assert f"Current state: {state}." in rendered
+    for heading in STAGE_HEADINGS:
+        assert heading in rendered, f"missing stage heading {heading!r} at state={state}"
+
+
+@pytest.mark.parametrize("workflow", WORKFLOW_FILES)
+def test_qa_stage_demands_real_execution(workflow: str) -> None:
+    cfg = _load(workflow)
+    rendered = render(cfg.prompt_template, build_prompt_env(_issue("QA"), attempt=None))
+    for phrase in QA_HARD_RULES:
+        assert phrase in rendered, f"QA stage missing hard rule: {phrase!r}"
+
+
+@pytest.mark.parametrize("workflow", WORKFLOW_FILES)
+def test_done_stage_carries_as_is_to_be_report_shape(workflow: str) -> None:
+    cfg = _load(workflow)
+    rendered = render(cfg.prompt_template, build_prompt_env(_issue("Done"), attempt=None))
+    for heading in DONE_REPORT_SHAPE:
+        assert heading in rendered, f"Done report missing section: {heading!r}"
+
+
+@pytest.mark.parametrize("workflow", WORKFLOW_FILES)
+def test_retry_branch_renders(workflow: str) -> None:
+    cfg = _load(workflow)
+    rendered = render(
+        cfg.prompt_template, build_prompt_env(_issue("In Progress"), attempt=2)
+    )
+    assert "retry attempt 2" in rendered
+
+
+@pytest.mark.parametrize("workflow", WORKFLOW_FILES)
+def test_blocked_by_branch_renders(workflow: str) -> None:
+    cfg = _load(workflow)
+    issue = _issue(
+        "Todo",
+        blocked_by=(BlockerRef(id="b1", identifier="B-1", state="Todo"),),
+    )
+    rendered = render(cfg.prompt_template, build_prompt_env(issue, attempt=None))
+    assert "B-1 (Todo)" in rendered
+
+
+def test_pipeline_demo_ticket_is_a_complete_worked_example() -> None:
+    """The shipped reference ticket must demonstrate every artefact the
+    pipeline expects, so users can copy its structure.
+
+    Lives under ``docs/`` (not ``kanban/``) so it is tracked in git;
+    ``kanban/`` is gitignored as the user-local board directory.
+    """
+    body = (REPO_ROOT / "docs" / "PIPELINE-DEMO.md").read_text(encoding="utf-8")
+    for required in (
+        "## Plan",
+        "## Implementation",
+        "## Review",
+        "## QA Evidence",
+        "## As-Is -> To-Be Report",
+        "### As-Is",
+        "### To-Be",
+        "### Reasoning",
+        "### Evidence",
+    ):
+        assert required in body, f"PIPELINE-DEMO missing section {required!r}"


### PR DESCRIPTION
Replaces the default "do work, mark Done" prompt with a gated six-stage pipeline (Plan -> Implementation -> Review -> QA -> Done with As-Is->To-Be Report). QA stage demands real execution (test commands, HTTP diffs, Playwright walks) — capturing exit codes + output excerpts as evidence in the ticket body. The orchestrator core stays opaque to state semantics; the pipeline is policy expressed in the prompt template, so existing forks keep working.\n\n## What changed\n\n- WORKFLOW.example.md / WORKFLOW.file.example.md: adds Review + QA active_states, replaces body with stage rules and As-Is->To-Be report shape.\n- docs/PIPELINE.md: operator guide.\n- docs/PIPELINE-DEMO.md: reference ticket with every required section. Shipped under docs/ (not kanban/) because kanban/ is gitignored.\n- tests/test_workflow_pipeline_prompt.py: 21 tests asserting the prompt renders for every stage, QA demands real execution, Done carries the report shape, retry/blocked_by branches render, and the demo ticket has every required section.\n\n## Tests\n\npytest -q -- 142 passed (was 121; 21 new).