### PR TITLE
feat(tui): tui.max_cards_per_column to handle column overflow

### DIFF
--- a/.claude/skills/using-symphony/reference/workflow-config.md
+++ b/.claude/skills/using-symphony/reference/workflow-config.md
@@ -194,9 +194,13 @@ observe via stderr logs and the TUI.
 
 ```yaml
 tui:
-  language: en    # `en` (default) or `ko`. Aliases like `Korean` / `ko-KR`
-                  # also resolve. Unknown values fall back to English.
+  language: en               # `en` (default) or `ko`. Aliases like `Korean` /
+                             # `ko-KR` also resolve. Unknown → English.
+  max_cards_per_column: 6    # cap each column at N cards; rest collapses to
+                             # "+M more". Omit / 0 / negative = render all.
 ```
+
+### `language`
 
 Only TUI chrome (column placeholder, header/footer field labels, card
 meta verbs `turn` / `retry #` / `blocked by`) is localized. Tracker
@@ -207,3 +211,22 @@ Per-key fallback to English is silent — adding a new locale never
 crashes the TUI on missing keys, but a missing translation surfaces as
 the literal key string (e.g. `card.turn`) so the gap is obvious in the
 running board.
+
+The `SYMPHONY_LANG` environment variable overrides `tui.language` for the
+session, so a single operator can flip locale without committing a
+config change others would inherit:
+
+```bash
+SYMPHONY_LANG=ko symphony tui ./WORKFLOW.md
+```
+
+### `max_cards_per_column`
+
+`rich.live.Live(screen=True)` runs in alt-screen mode and clips overflow
+silently — there's no terminal scrollback inside the TUI. When a column
+grows past one viewport, the cards beyond the cutoff just disappear off
+the bottom edge. `max_cards_per_column: N` caps each column at N cards
+and renders a dim `+M more` line for the rest, so the count stays
+honest and you know to filter the board.
+
+Set to `0` (or omit) to keep the original render-everything behavior.

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -67,7 +67,8 @@ server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`
 
 tui:
-  language: en          # `en` (default) or `ko` — chrome only. SYMPHONY_LANG env overrides.
+  language: en               # `en` (default) or `ko`. SYMPHONY_LANG env overrides.
+  max_cards_per_column: 6    # cap each column at N cards; rest collapses to "+M more"
 ---
 
 You are picking up issue {{ issue.identifier }}: {{ issue.title }}.

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -55,7 +55,8 @@ server:
   port: 9999            # optional JSON API; the primary UI is `symphony tui`
 
 tui:
-  language: en          # `en` (default) or `ko` — chrome only. SYMPHONY_LANG env overrides.
+  language: en               # `en` (default) or `ko`. SYMPHONY_LANG env overrides.
+  max_cards_per_column: 6    # cap each column at N cards; rest collapses to "+M more"
 ---
 You are picking up ticket {{ issue.identifier }}: {{ issue.title }}.
 Current state: {{ issue.state }}.

--- a/src/symphony/i18n.py
+++ b/src/symphony/i18n.py
@@ -50,6 +50,8 @@ STRINGS: Final[dict[str, dict[str, str]]] = {
         # language switch hint shown in the header
         "header.lang": "lang=",
         "header.lang_hint": "(SYMPHONY_LANG=ko or set tui.language in WORKFLOW.md)",
+        # column overflow indicator. {n} is replaced at format time.
+        "column.more": "+{n} more",
     },
     "ko": {
         # header
@@ -72,6 +74,8 @@ STRINGS: Final[dict[str, dict[str, str]]] = {
         # language switch hint shown in the header
         "header.lang": "언어=",
         "header.lang_hint": "(SYMPHONY_LANG=en 또는 WORKFLOW.md tui.language 수정 후 재시작)",
+        # column overflow indicator. {n} is replaced at format time.
+        "column.more": "+{n}개 더",
     },
 }
 

--- a/src/symphony/tui.py
+++ b/src/symphony/tui.py
@@ -236,16 +236,21 @@ class KanbanTUI:
             issues_by_state.setdefault(key, []).append(issue)
 
         descriptions = cfg.tracker.state_descriptions
+        max_cards = cfg.tui.max_cards_per_column
         panels: list[Panel] = []
         for state_label in ordered:
             state_key = normalize_state(state_label)
             issues = sorted(issues_by_state.get(state_key, []), key=_card_sort_key)
             color = STATE_COLOR.get(state_key, "white")
+            visible_issues = (
+                issues if max_cards is None or max_cards <= 0 else issues[:max_cards]
+            )
+            hidden_count = len(issues) - len(visible_issues)
             cards = [
                 self._render_card(
                     issue, runtime_index.get(issue.id, _CardStatus()), color, cfg.tui.language
                 )
-                for issue in issues
+                for issue in visible_issues
             ]
             legend = descriptions.get(state_key)
             elements: list[Any] = []
@@ -253,6 +258,13 @@ class KanbanTUI:
                 elements.append(Text(legend, style="dim italic"))
             if cards:
                 elements.extend(cards)
+                if hidden_count > 0:
+                    elements.append(
+                        Text(
+                            t("column.more", cfg.tui.language).format(n=hidden_count),
+                            style="dim italic",
+                        )
+                    )
                 body: Any = Group(*elements)
             elif legend:
                 elements.append(

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -246,6 +246,12 @@ class TuiConfig:
     # user data and are never translated. Defaults to "en".
     language: str = "en"
 
+    # Cap how many cards each column renders before collapsing the rest into
+    # a single "+N more" indicator. None / 0 / negative = render every card.
+    # `rich.live.Live(screen=True)` clips overflow silently — capping the
+    # count is the cheap fix for boards that have outgrown one terminal page.
+    max_cards_per_column: int | None = None
+
 
 @dataclass(frozen=True)
 class ServiceConfig:
@@ -517,7 +523,17 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
     from .i18n import resolve_language
     # SYMPHONY_LANG env var takes precedence over WORKFLOW.md so a single
     # operator can flip without editing the shared workflow file.
-    tui = TuiConfig(language=resolve_language(tui_raw.get("language")))
+    raw_max = tui_raw.get("max_cards_per_column")
+    if isinstance(raw_max, bool):
+        max_cards: int | None = None
+    elif isinstance(raw_max, int) and raw_max > 0:
+        max_cards = raw_max
+    else:
+        max_cards = None
+    tui = TuiConfig(
+        language=resolve_language(tui_raw.get("language")),
+        max_cards_per_column=max_cards,
+    )
 
     prompt_template = workflow.prompt_template or DEFAULT_PROMPT
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -175,6 +175,65 @@ def test_workflow_env_override_wins_over_config(tmp_path, monkeypatch):
     assert cfg.tui.language == "ko"
 
 
+def test_column_more_format_string():
+    assert t("column.more").format(n=3) == "+3 more"
+    assert t("column.more", "ko").format(n=3) == "+3개 더"
+
+
+def test_workflow_max_cards_default_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.max_cards_per_column is None
+
+
+def test_workflow_max_cards_explicit(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x }
+            tui: { max_cards_per_column: 6 }
+            ---
+            body
+            """
+        ),
+    )
+    cfg = build_service_config(load_workflow(path))
+    assert cfg.tui.max_cards_per_column == 6
+
+
+def test_workflow_max_cards_invalid_values_become_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINEAR_API_KEY", "tok")
+    for raw in ("not-an-int", -1, 0, True, False):
+        path = _write(
+            tmp_path,
+            textwrap.dedent(
+                f"""\
+                ---
+                tracker: {{ kind: linear, project_slug: x }}
+                tui: {{ max_cards_per_column: {raw!r} }}
+                ---
+                body
+                """
+            ),
+        )
+        cfg = build_service_config(load_workflow(path))
+        assert cfg.tui.max_cards_per_column is None, f"raw={raw!r} should map to None"
+
+
 def test_workflow_alias_korean(tmp_path, monkeypatch):
     monkeypatch.setenv("LINEAR_API_KEY", "tok")
     path = _write(


### PR DESCRIPTION
Adds a per-column card cap with a `+N more` overflow indicator, working around `rich.live.Live(screen=True)` clipping content past the viewport without scrollback.\n\nDefault `None` keeps existing behavior (render every card). Set e.g. `max_cards_per_column: 6` and any column with 7+ cards renders the top 6 (sorted by priority + identifier) plus a dim italic `+M more` line so the count stays honest.\n\nReal viewport scrolling deferred — `rich.Live` alt-screen mode would need cross-platform raw-mode stdin handling, larger blast radius than this 100-line config knob.\n\nTests: 146 passed (142 → +4 covering format string both locales, default None, explicit positive int, invalid-shapes-become-None matrix).