### PR TITLE
feat(tui): in-app keyboard scroll + card description preview + header controls hint

### DIFF
--- a/src/symphony/_keyboard.py
+++ b/src/symphony/_keyboard.py
@@ -1,0 +1,125 @@
+"""Cross-platform raw-mode keyboard polling for the TUI.
+
+Why this exists: the Kanban TUI uses `rich.live.Live(screen=True)` which
+takes over the alternate screen buffer for flicker-free renders. To accept
+keyboard input *inside the app* (not terminal scrollback), we need to read
+stdin in raw mode. Windows uses `msvcrt` and Unix uses `termios + select`.
+
+Returned key tokens are normalized to short stable strings so the TUI
+handler can match without caring about platform: ``"j"``, ``"DOWN"``,
+``"PGDN"``, ``"q"`` …
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from typing import Iterator
+
+# Platform detection without importing both modules eagerly.
+_IS_WINDOWS = sys.platform.startswith("win")
+
+if _IS_WINDOWS:
+    import msvcrt  # type: ignore[import-not-found]
+else:
+    import select
+    import termios
+    import tty
+
+
+# Windows scancodes after the \x00 / \xe0 prefix from msvcrt.getwch().
+_WIN_SPECIAL = {
+    "H": "UP",
+    "P": "DOWN",
+    "K": "LEFT",
+    "M": "RIGHT",
+    "I": "PGUP",
+    "Q": "PGDN",
+    "G": "HOME",
+    "O": "END",
+}
+
+# Unix CSI sequences after ESC '['.
+_UNIX_CSI = {
+    "A": "UP",
+    "B": "DOWN",
+    "D": "LEFT",
+    "C": "RIGHT",
+    "5~": "PGUP",
+    "6~": "PGDN",
+    "H": "HOME",
+    "F": "END",
+}
+
+
+@contextlib.contextmanager
+def raw_mode() -> Iterator[None]:
+    """Put stdin in raw mode for the duration of the context."""
+    if _IS_WINDOWS:
+        # msvcrt.getwch reads without needing termios setup.
+        yield
+        return
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        yield
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def poll_key() -> str | None:
+    """Non-blocking read of a single key event. Returns normalized token or None.
+
+    Tokens: single printable char ('j', 'q', ...), or one of:
+    'UP', 'DOWN', 'LEFT', 'RIGHT', 'PGUP', 'PGDN', 'HOME', 'END', 'ESC',
+    'ENTER', 'CTRL_C'.
+    """
+    if _IS_WINDOWS:
+        return _poll_windows()
+    return _poll_unix()
+
+
+def _poll_windows() -> str | None:
+    if not msvcrt.kbhit():
+        return None
+    ch = msvcrt.getwch()
+    if ch in ("\x00", "\xe0"):
+        # Two-byte extended scancode.
+        if not msvcrt.kbhit():
+            return None
+        scan = msvcrt.getwch()
+        return _WIN_SPECIAL.get(scan, None)
+    return _normalize_simple(ch)
+
+
+def _poll_unix() -> str | None:
+    r, _, _ = select.select([sys.stdin], [], [], 0)
+    if not r:
+        return None
+    ch = sys.stdin.read(1)
+    if ch == "\x1b":
+        # Possible CSI escape sequence. Peek with short timeout for the rest.
+        r2, _, _ = select.select([sys.stdin], [], [], 0.01)
+        if not r2:
+            return "ESC"
+        bracket = sys.stdin.read(1)
+        if bracket != "[":
+            return "ESC"
+        # Read up to 2 more chars (covers '5~', '6~', 'A'..'F').
+        rest = sys.stdin.read(1)
+        if rest in ("5", "6"):
+            tilde = sys.stdin.read(1)
+            return _UNIX_CSI.get(rest + tilde, None)
+        return _UNIX_CSI.get(rest, None)
+    return _normalize_simple(ch)
+
+
+def _normalize_simple(ch: str) -> str:
+    if ch == "\r" or ch == "\n":
+        return "ENTER"
+    if ch == "\x03":
+        return "CTRL_C"
+    if ch == "\x1b":
+        return "ESC"
+    return ch

--- a/src/symphony/i18n.py
+++ b/src/symphony/i18n.py
@@ -52,6 +52,9 @@ STRINGS: Final[dict[str, dict[str, str]]] = {
         "header.lang_hint": "(SYMPHONY_LANG=ko or set tui.language in WORKFLOW.md)",
         # column overflow indicator. {n} is replaced at format time.
         "column.more": "+{n} more",
+        "column.more_above": "↑ {n} above",
+        # controls hint shown in the header of the TUI
+        "header.controls": "controls: j/↓ down · k/↑ up · PgDn/PgUp page · g/G top/bot · q quit · cap={n}",
     },
     "ko": {
         # header
@@ -76,6 +79,9 @@ STRINGS: Final[dict[str, dict[str, str]]] = {
         "header.lang_hint": "(SYMPHONY_LANG=en 또는 WORKFLOW.md tui.language 수정 후 재시작)",
         # column overflow indicator. {n} is replaced at format time.
         "column.more": "+{n}개 더",
+        "column.more_above": "↑ 위로 {n}개",
+        # controls hint shown in the header of the TUI
+        "header.controls": "조작: j/↓ 다음 · k/↑ 이전 · PgDn/PgUp 페이지 · g/G 처음/끝 · q 종료 · cap={n}",
     },
 }
 

--- a/src/symphony/tui.py
+++ b/src/symphony/tui.py
@@ -28,6 +28,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from . import _keyboard
 from .i18n import t
 from .issue import Issue, normalize_state
 from .logging import get_logger
@@ -90,6 +91,7 @@ class KanbanTUI:
         self._candidates_lock = asyncio.Lock()
         self._stop = asyncio.Event()
         self._render_signal = asyncio.Event()
+        self._scroll_offset = 0  # global viewport offset applied to all columns
 
     # ------------------------------------------------------------------
     # public lifecycle
@@ -99,6 +101,7 @@ class KanbanTUI:
         # Wake on every orchestrator tick so the board updates as state moves.
         self._orch.add_observer(self._on_orchestrator_tick)
         candidate_task = asyncio.create_task(self._candidate_refresh_loop())
+        keyboard_task = asyncio.create_task(self._keyboard_loop())
         try:
             with Live(
                 self._render(),
@@ -116,11 +119,12 @@ class KanbanTUI:
                     live.update(self._render())
         finally:
             self._stop.set()
-            candidate_task.cancel()
-            try:
-                await candidate_task
-            except (asyncio.CancelledError, Exception):
-                pass
+            for task in (candidate_task, keyboard_task):
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
 
     def request_stop(self) -> None:
         self._stop.set()
@@ -145,6 +149,92 @@ class KanbanTUI:
                 return  # stop fired
             except asyncio.TimeoutError:
                 continue
+
+    async def _keyboard_loop(self) -> None:
+        """Poll stdin in raw mode and dispatch in-app navigation keys."""
+        try:
+            with _keyboard.raw_mode():
+                while not self._stop.is_set():
+                    key = _keyboard.poll_key()
+                    if key is None:
+                        await asyncio.sleep(0.05)
+                        continue
+                    self._handle_key(key)
+        except Exception as exc:  # never crash the TUI on stdin issues
+            log.debug("tui_keyboard_failed", error=str(exc))
+
+    def _handle_key(self, key: str) -> None:
+        # Quit
+        if key in ("q", "Q", "ESC", "CTRL_C"):
+            self.request_stop()
+            return
+        # Down (j / DOWN / PGDN)
+        if key in ("j", "J", "DOWN"):
+            self._scroll_offset += 1
+            self._render_signal.set()
+            return
+        if key == "PGDN":
+            self._scroll_offset += self._page_step()
+            self._render_signal.set()
+            return
+        # Up (k / UP / PGUP)
+        if key in ("k", "K", "UP"):
+            if self._scroll_offset > 0:
+                self._scroll_offset -= 1
+                self._render_signal.set()
+            return
+        if key == "PGUP":
+            self._scroll_offset = max(0, self._scroll_offset - self._page_step())
+            self._render_signal.set()
+            return
+        # Top / bottom
+        if key in ("g", "HOME"):
+            if self._scroll_offset != 0:
+                self._scroll_offset = 0
+                self._render_signal.set()
+            return
+        if key in ("G", "END"):
+            self._scroll_offset = self._max_scroll_offset()
+            self._render_signal.set()
+            return
+
+    def _page_step(self) -> int:
+        cfg = self._ws.current()
+        if cfg is None:
+            return 1
+        n = cfg.tui.max_cards_per_column
+        return n if isinstance(n, int) and n > 0 else 5
+
+    def _max_scroll_offset(self) -> int:
+        """Tallest column's scrollable extent (so G goes to last hidden card)."""
+        cfg = self._ws.current()
+        max_cards = (cfg.tui.max_cards_per_column if cfg else None) or 0
+        if max_cards <= 0:
+            return 0
+        column_lens = self._column_lengths()
+        if not column_lens:
+            return 0
+        tallest = max(column_lens)
+        return max(0, tallest - max_cards)
+
+    def _column_lengths(self) -> list[int]:
+        cfg = self._ws.current()
+        if cfg is None:
+            return []
+        states = list(cfg.tracker.active_states) + list(cfg.tracker.terminal_states)
+        seen: set[str] = set()
+        lengths: list[int] = []
+        bucket: dict[str, int] = {}
+        for issue in self._all_known_issues():
+            key = normalize_state(issue.state)
+            bucket[key] = bucket.get(key, 0) + 1
+        for s in states:
+            key = normalize_state(s)
+            if key in seen:
+                continue
+            seen.add(key)
+            lengths.append(bucket.get(key, 0))
+        return lengths
 
     async def _refresh_tracker(self, cfg: ServiceConfig) -> None:
         try:
@@ -194,7 +284,15 @@ class KanbanTUI:
         bar.add_column(justify="left", ratio=2)
         bar.add_column(justify="right", ratio=1)
         bar.add_row(title, right)
-        return Panel(bar, box=SIMPLE, padding=(0, 1))
+        max_cards = cfg.tui.max_cards_per_column
+        max_cards_display = (
+            max_cards if (isinstance(max_cards, int) and max_cards > 0) else "off"
+        )
+        controls = Text(
+            t("header.controls", lang).format(n=max_cards_display),
+            style="dim italic",
+        )
+        return Panel(Group(bar, controls), box=SIMPLE, padding=(0, 1))
 
     def _build_footer(self, cfg: ServiceConfig, snap: dict[str, Any]) -> Panel:
         lang = cfg.tui.language
@@ -237,15 +335,27 @@ class KanbanTUI:
 
         descriptions = cfg.tracker.state_descriptions
         max_cards = cfg.tui.max_cards_per_column
+        offset = self._scroll_offset
         panels: list[Panel] = []
         for state_label in ordered:
             state_key = normalize_state(state_label)
             issues = sorted(issues_by_state.get(state_key, []), key=_card_sort_key)
             color = STATE_COLOR.get(state_key, "white")
-            visible_issues = (
-                issues if max_cards is None or max_cards <= 0 else issues[:max_cards]
-            )
-            hidden_count = len(issues) - len(visible_issues)
+            if max_cards is None or max_cards <= 0:
+                start = min(offset, len(issues))
+                visible_issues = issues[start:]
+            else:
+                start = min(offset, max(0, len(issues) - 1)) if issues else 0
+                # When offset would skip past everything, clamp to last page
+                # so scrolling never blanks a column with content above.
+                max_start_for_full_page = max(0, len(issues) - max_cards)
+                if start > max_start_for_full_page and len(issues) > max_cards:
+                    start = max_start_for_full_page
+                if start > len(issues):
+                    start = len(issues)
+                visible_issues = issues[start : start + max_cards]
+            hidden_above = start
+            hidden_below = max(0, len(issues) - (start + len(visible_issues)))
             cards = [
                 self._render_card(
                     issue, runtime_index.get(issue.id, _CardStatus()), color, cfg.tui.language
@@ -256,17 +366,24 @@ class KanbanTUI:
             elements: list[Any] = []
             if legend:
                 elements.append(Text(legend, style="dim italic"))
+            if hidden_above > 0:
+                elements.append(
+                    Text(
+                        t("column.more_above", cfg.tui.language).format(n=hidden_above),
+                        style="dim italic",
+                    )
+                )
             if cards:
                 elements.extend(cards)
-                if hidden_count > 0:
+                if hidden_below > 0:
                     elements.append(
                         Text(
-                            t("column.more", cfg.tui.language).format(n=hidden_count),
+                            t("column.more", cfg.tui.language).format(n=hidden_below),
                             style="dim italic",
                         )
                     )
                 body: Any = Group(*elements)
-            elif legend:
+            elif legend or hidden_above > 0:
                 elements.append(
                     Align.center(Text(empty_text, style="dim italic"), vertical="middle")
                 )
@@ -329,6 +446,9 @@ class KanbanTUI:
             meta.append("  ".join(f"#{l}" for l in issue.labels[:3]), style="dim")
 
         rows: list[Any] = [body]
+        desc_preview = _first_meaningful_line(issue.description)
+        if desc_preview:
+            rows.append(Text(_truncate(desc_preview, 80), style="dim"))
         if meta.plain.strip():
             rows.append(meta)
         if status.last_message:
@@ -394,6 +514,20 @@ def _truncate(text: str, n: int) -> str:
     if len(text) <= n:
         return text
     return text[: max(n - 1, 1)] + "…"
+
+
+def _first_meaningful_line(description: str | None) -> str:
+    """description 본문에서 첫 의미 있는 줄 (markdown 헤딩/코드펜스 skip) 반환."""
+    if not description:
+        return ""
+    for raw in description.splitlines():
+        s = raw.strip()
+        if not s:
+            continue
+        if s.startswith(("#", "```", "---")):
+            continue
+        return s
+    return ""
 
 
 def _card_sort_key(issue: Issue) -> tuple[int, str]:


### PR DESCRIPTION
## Summary

- Adds true in-app keyboard scroll for the Kanban TUI: alt-screen stays on (no flicker), keys handled inside the app via cross-platform raw mode.
- Each card now shows a one-line description preview (first meaningful body line, 80-char dim).
- Controls hint moved to the header (`controls: j/↓ down · k/↑ up · PgDn/PgUp page · g/G top/bot · q quit · cap=N`); footer reverts to tokens/runtime line.

## Why

`tui.max_cards_per_column` (PR #12) made the +N more indicator visible but the hidden cards were unreachable. `screen=False` + native scrollback caused flicker because of rich Live's automatic 4 Hz redraw. Keeping alt-screen and intercepting keys inside the app gives a flicker-free viewport scroll.

## Changes

- `src/symphony/_keyboard.py` (new): cross-platform raw-mode reader (`msvcrt` on Windows, `termios + select` on Unix). Normalized key tokens: `j`, `k`, `q`, `UP`, `DOWN`, `PGUP`, `PGDN`, `HOME`, `END`, `ESC`, `CTRL_C`.
- `src/symphony/tui.py`:
  - `KanbanTUI._scroll_offset` global viewport state.
  - `_keyboard_loop` async task (50 ms poll) cancelled on shutdown.
  - `_handle_key` dispatcher → mutates offset and triggers a render.
  - `_build_columns` slices `issues[start:start + max_cards]`; emits `↑ N above` and `+N more` indicators on either side.
  - `_render_card` adds `Text(_truncate(desc, 80), style="dim")` row when description has a non-empty first line.
  - `_first_meaningful_line` helper skips markdown headings, code fences, and YAML separators.
  - `_build_header` renders controls under the existing grid via `Group(bar, controls)`.
- `src/symphony/i18n.py`:
  - `header.controls` (EN/KO) — the new keybinding line.
  - `column.more_above` (EN/KO) — `↑ N above` / `↑ 위로 N개` indicator.

## Key Map

| Key | Action |
|-----|--------|
| `j` / `↓` | offset +1 |
| `k` / `↑` | offset −1 (clamped to 0) |
| `PgDn` | offset += `max_cards_per_column` |
| `PgUp` | offset −= `max_cards_per_column` |
| `g` / `Home` | offset = 0 |
| `G` / `End` | offset = tallest column's last page |
| `q` / `ESC` / `Ctrl+C` | quit |

## Test plan

- [x] `pytest -q` — 146/146 pass on Windows
- [x] Keyboard module smoke (`poll_key()` non-blocking, `raw_mode()` no-op on Windows)
- [ ] Manual: `symphony tui ./WORKFLOW.md` on Windows — verify j/k/PgDn/PgUp/g/G/q, header shows controls, no flicker
- [ ] Manual on Unix (termios path) — verify arrow + PgUp/PgDn CSI parsing