### PR TITLE
release: v0.1.0 prep — PIPELINE.md sync + llm-wiki seed + test badge bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python: 3.10+](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg)](https://www.python.org/)
-[![Tests: 156 passing](https://img.shields.io/badge/tests-156%20passing-brightgreen.svg)](#tests)
+[![Tests: 164 passing](https://img.shields.io/badge/tests-164%20passing-brightgreen.svg)](#tests)
 
 > Drive any coding-agent CLI — Codex, Claude Code, Gemini, or Pi — from one
 > orchestrator, with a Jira-style Kanban board rendered straight in your
@@ -409,7 +409,7 @@ src/symphony/
 pytest -q
 ```
 
-156 tests pass: the upstream conformance suite plus the backend unit tests
+164 tests pass: the upstream conformance suite plus the backend unit tests
 covering the factory, event normalization, Claude / Pi usage accumulation,
 Gemini session synthesis, and Pi failure-reason detection. Subprocess-driven
 integration tests against real CLIs are intentionally not in CI — run them

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,27 +1,48 @@
 # Production pipeline
 
 Symphony's default task (the prompt template in `WORKFLOW.md`) drives every
-ticket through six gated stages. The harness picks the ticket up on each poll
-tick; the agent moves it from one stage to the next by editing the ticket
-file's `state` field. The orchestrator only reads, so this stage machine is
-intentionally implemented in the prompt rather than the Python core.
+ticket through seven gated stages. The harness picks the ticket up on each
+poll tick; the agent moves it from one stage to the next by editing the
+ticket file's `state` field. The orchestrator only reads, so this stage
+machine is intentionally implemented in the prompt rather than the Python
+core.
 
 ```
-  Todo / In Progress  ->  Review  ->  QA  ->  Done
-                              \                 ^
-                               +-> Blocked      |
-                                                |
-              (QA failure rewinds to In Progress)
+  Todo  ->  Explore  ->  In Progress  ->  Review  ->  QA  ->  Learn  ->  Done
+                              \                       \                    ^
+                               +-> Blocked             +-> Blocked          |
+                                                                            |
+                              (QA failure rewinds to In Progress)
 ```
 
-| State          | Owner of this turn         | Output it must produce                              |
-|----------------|----------------------------|-----------------------------------------------------|
-| Todo           | implementer                | `## Plan` + first failing test                      |
-| In Progress    | implementer                | `## Implementation`, transition to Review           |
-| Review         | reviewer                   | `## Review`, fix CRITICAL/HIGH, transition to QA    |
-| QA             | qa runner (executes code)  | `## QA Evidence` (real exit codes), -> Done         |
-| Done           | reporter                   | `## As-Is -> To-Be Report` (structured)             |
-| Blocked        | -                          | `## Blocker` describing what is needed              |
+| State          | Owner of this turn          | Output it must produce                                                |
+|----------------|-----------------------------|-----------------------------------------------------------------------|
+| Todo           | triager                     | `## Triage` line, route to Explore (or `Blocked`)                     |
+| Explore        | researcher (3 lenses)       | `## Domain Brief` + `## Plan Candidates` + `## Recommendation`        |
+| In Progress    | implementer                 | `## Implementation` (TDD), transition to Review                       |
+| Review         | reviewer                    | `## Review`, fix CRITICAL/HIGH, transition to QA                      |
+| QA             | qa runner (executes code)   | `## QA Evidence` (real exit codes), -> Learn                          |
+| Learn          | distiller                   | `llm-wiki/` updates + `## Learnings` + `## Wiki Updates`              |
+| Done           | reporter                    | `## As-Is -> To-Be Report` (structured)                               |
+| Blocked        | -                           | `## Blocker` describing what is needed                                |
+
+## Why an Explore stage
+
+Implementation that starts from whatever stale context the agent happens to
+have produces drive-by refactors and missed invariants. Explore forces a
+single, structured pass over three sources before any code changes:
+
+- **`llm-wiki/`** — domain knowledge written by prior tickets (read first).
+- **git history** — `git log --oneline -- <path>` for files the ticket
+  likely touches, then `git show <sha>` on the relevant commits to
+  recover the *why* behind prior changes.
+- **the source files themselves**, end-to-end, so the brief reflects
+  current state and not stale memory.
+
+The agent applies three lenses in one turn — domain expert, implementer,
+risk reviewer — and writes `## Domain Brief`, `## Plan Candidates`, and
+`## Recommendation` into the ticket. Implement reads the recommendation
+and follows it; it does not re-plan unless the brief got a fact wrong.
 
 ## Why a QA stage
 
@@ -43,6 +64,37 @@ If anything fails the agent rewinds the ticket to `In Progress` and writes
 a `## QA Failure` section. It must not silence, retry, or skip the failing
 check.
 
+## Why a Learn stage
+
+QA proves the change works; Learn makes the *next* ticket cheaper. After
+QA passes, the agent compares the Explore brief against reality — which
+assumptions held, which were wrong, what only became visible during
+implementation — and persists the delta to `llm-wiki/`:
+
+- If a relevant entry exists, it is edited in place. A new line is
+  appended to its **Decision log** (`YYYY-MM-DD | <issue.identifier> |
+  note`) and **Last updated** is refreshed.
+- Otherwise a new `llm-wiki/<topic-slug>.md` is created with a fixed
+  shape (Summary / Invariants & Constraints / Files of interest /
+  Decision log / Last updated) and a row is added to `llm-wiki/INDEX.md`.
+
+The agent then writes `## Learnings` (bullets of new facts and
+surprises) and `## Wiki Updates` (paths created or modified) into the
+ticket before transitioning to Done. If nothing genuinely new emerged,
+the agent says so explicitly ("no new wiki entries; existing coverage
+was correct") and still transitions.
+
+## The `llm-wiki/` knowledge base
+
+`llm-wiki/` lives at the workspace root next to the source code (parallel
+to `kanban/`). It is one Markdown entry per topic plus an `INDEX.md`
+that lists them. Treat it as a living memory that future tickets depend
+on: Explore reads it before any new work, Learn writes back to it after
+QA passes, and the first Learn stage to run creates the directory if it
+does not yet exist. The wiki is the project's institutional knowledge in
+prompt-friendly form — keep entries focused on invariants, constraints,
+and decision history, not transient task state.
+
 ## The Done report
 
 `Done` is not a "stop" signal — it is a "produce a report" signal. Every
@@ -60,7 +112,7 @@ runs) get the full story without spelunking through git or chat history.
 
 ## Stage transitions and the orchestrator
 
-`active_states` in `WORKFLOW.md` is `[Todo, "In Progress", Review, QA]`.
+`active_states` in `WORKFLOW.md` is `[Todo, Explore, "In Progress", Review, QA, Learn]`.
 The orchestrator dispatches a worker for any ticket whose state is in
 that set, regardless of which stage it is on. Each turn the agent reads
 `{{ issue.state }}` from the prompt and applies the matching stage rule.
@@ -69,18 +121,24 @@ is policy expressed in the prompt.
 
 `max_concurrent_agents_by_state` lets you cap how many tickets can sit
 in each stage in parallel — useful when QA runs are expensive (real
-browsers, real backends).
+browsers, real backends) or when Explore should stay serialized so the
+brief reflects a quiet workspace.
 
 ## Adopting the pipeline
 
 1. Copy `WORKFLOW.file.example.md` (file tracker) or `WORKFLOW.example.md`
    (Linear) to `WORKFLOW.md` and customize.
-2. Confirm `tracker.active_states` includes `Review` and `QA`.
+2. Confirm `tracker.active_states` includes `Explore`, `Review`, `QA`,
+   and `Learn` (in addition to `Todo` and `In Progress`).
 3. Make sure your `before_run` / `after_create` hooks land the agent in
    a workspace where the test suite, target API, or browser harness is
    actually runnable. The QA stage is only as good as the workspace it
    runs in.
-4. Run `symphony doctor ./WORKFLOW.md` before launching to catch the
+4. Decide whether `llm-wiki/` lives in the same repo as the source (the
+   default; Learn commits wiki edits onto the ticket's branch) or in a
+   sibling repo. Either works; keep it adjacent to `kanban/` so Explore
+   can reach it without extra configuration.
+5. Run `symphony doctor ./WORKFLOW.md` before launching to catch the
    common first-run failures (port collision, missing CLI on PATH,
    placeholder clone URL).
 

--- a/llm-wiki/INDEX.md
+++ b/llm-wiki/INDEX.md
@@ -1,0 +1,9 @@
+# llm-wiki index
+
+This directory is Symphony's domain knowledge base. Each row points to a
+topic-scoped Markdown entry. Explore reads these before any new ticket;
+Learn writes back to them after QA passes.
+
+| topic-slug | summary | last touched |
+|------------|---------|--------------|
+| production-pipeline | Seven-stage pipeline shape and the docs/WORKFLOW sync invariant | 2026-05-09 (SMK-1) |

--- a/llm-wiki/production-pipeline.md
+++ b/llm-wiki/production-pipeline.md
@@ -1,0 +1,74 @@
+# Production pipeline
+
+**Summary:** Symphony drives every ticket through a seven-stage gated
+pipeline (Todo -> Explore -> In Progress -> Review -> QA -> Learn ->
+Done) implemented in the prompt, not the Python core. Three artefacts
+must stay synchronized: the prompt body in `WORKFLOW.example.md` /
+`WORKFLOW.file.example.md`, the operator guide in `docs/PIPELINE.md`,
+and the assertion list in `tests/test_workflow_pipeline_prompt.py`.
+Changing one without the others produces silent drift the orchestrator
+cannot detect (states are just opaque strings to the Python core).
+
+**Invariants & Constraints:**
+- `tracker.active_states` in both example WORKFLOW files must equal
+  `[Todo, Explore, "In Progress", Review, QA, Learn]` in that order.
+  `Done`, `Cancelled`, `Blocked` are terminal states, not active.
+- `docs/PIPELINE.md` is an operator guide, not a second source of truth.
+  Its diagram, stage table, and `active_states` quote must mirror
+  `WORKFLOW.file.example.md` verbatim. The acceptance test for any
+  pipeline-shape change is "every claim in PIPELINE.md matches the
+  active_states ordering and stage rules in the WORKFLOW example".
+- `tests/test_workflow_pipeline_prompt.py` parametrizes both example
+  WORKFLOW files and asserts: (a) every state in the seven-stage list
+  appears in `active_states`, (b) every stage heading (`TRIAGE`,
+  `EXPLORE`, `IMPLEMENT`, `REVIEW`, `QA`, `LEARN`, `DONE`) renders for
+  every state, (c) Explore mentions `llm-wiki` + `git log` + the brief
+  sections, (d) Learn mentions `llm-wiki` + `INDEX.md` + `Decision log`
+  + `Wiki Updates`, (e) QA carries the literal phrase
+  `THIS STAGE MUST EXECUTE REAL CODE` and `QA Evidence`, (f) Done
+  carries the `## As-Is -> To-Be Report` shape with the four `### As-Is
+  / ### To-Be / ### Reasoning / ### Evidence` subsections.
+- `llm-wiki/` lives at the workspace root parallel to `kanban/`. The
+  first Learn that runs creates the directory and seeds `INDEX.md`.
+- The diagram in `WORKFLOW.file.example.md:96-102` (and its mirror in
+  PIPELINE.md) shows two `+-> Blocked` branches, drawn after Review and
+  after QA. The QA failure path actually rewinds to `In Progress`, not
+  `Blocked`; the diagram's second Blocked branch represents Review's
+  out-of-scope escape, not a QA-driven Blocked. Treat the diagram as a
+  loose visual; the stage rules under each `### STAGE` heading are
+  authoritative.
+- Six-stage residue to grep for if you suspect drift: the literal string
+  `Todo / In Progress  ->  Review` (old diagram) and
+  `[Todo, "In Progress", Review, QA]` (old active_states quote).
+
+**Files of interest:**
+- `WORKFLOW.file.example.md:5` -- `active_states` for the file tracker.
+- `WORKFLOW.file.example.md:96-102` -- canonical seven-stage diagram.
+- `WORKFLOW.file.example.md:117-249` -- per-stage rules (TRIAGE / EXPLORE
+  / IMPLEMENT / REVIEW / QA / LEARN / DONE).
+- `WORKFLOW.example.md:6` -- same `active_states` list, Linear variant.
+- `WORKFLOW.example.md:110-302` -- Linear variant of the stage rules
+  (transitions via `linear_graphql`, stage notes via comments instead
+  of in-body markdown sections).
+- `docs/PIPELINE.md` -- operator guide. Diagram, stage table, llm-wiki
+  pointer, adoption checklist.
+- `docs/PIPELINE-DEMO.md` -- worked-example ticket. Note: still uses the
+  six-stage section names (`## Plan` instead of `## Domain Brief` +
+  `## Plan Candidates` + `## Recommendation`); only the Plan/Implementation/
+  Review/QA Evidence/As-Is->To-Be sections are asserted by the test
+  suite, so the demo is a partial example, not a full one.
+- `tests/test_workflow_pipeline_prompt.py:38-81` -- the literal phrase
+  list (`STAGE_HEADINGS`, `EXPLORE_HARD_RULES`, `LEARN_HARD_RULES`,
+  `QA_HARD_RULES`, `DONE_REPORT_SHAPE`) that any pipeline-prompt change
+  must keep satisfying.
+
+**Decision log:**
+- 2026-05-09 | SMK-1 | Brought `docs/PIPELINE.md` from 6 stages to 7
+  (added Explore + Learn rows, llm-wiki pointer, refreshed adoption
+  checklist). Did NOT update `docs/PIPELINE-DEMO.md` -- demo's section
+  names are still the six-stage set but the test suite only asserts
+  the subset that survived the rename, so the demo is a known partial
+  example. Leaving its full conversion to a separate ticket avoids
+  drive-by scope creep.
+
+**Last updated:** 2026-05-09 by SMK-1.


### PR DESCRIPTION
## Summary

Two doc commits that close the drift introduced by the seven-stage
pipeline switch (commit 8ea9b13), plus a stale-badge fix. No source
changes; full pytest suite (164 tests) is green.

- `787921a docs(pipeline): sync PIPELINE.md to seven stages + seed llm-wiki`
  Produced by an end-to-end run of the new pipeline against ticket SMK-1
  with `agent.kind: claude` (Triage -> Explore -> In Progress -> Review
  -> QA -> Learn -> Done in one pass, no retries). The commit body has
  the artefact list.
- `2588679 docs: bump test count badge to 164`
  README badge was lagging behind reality.

## Test plan

- [x] `pytest -q` — 164 passed (run on dev tip).
- [x] `symphony doctor ./WORKFLOW.md` — all PASS.
- [x] Real symphony dispatch with claude backend produced PIPELINE.md +
      llm-wiki/INDEX.md + llm-wiki/production-pipeline.md and walked
      every stage.

After merge: tag v0.1.0 on main and cut the first GitHub release.