### PR TITLE
fix(observability): headless event logs + after_run cwd guard + doctor pi-auth + skills sync

### DIFF
--- a/.claude/skills/using-symphony/SKILL.md
+++ b/.claude/skills/using-symphony/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: using-symphony
-description: Use when the user wants to dispatch coding agents (Codex / Claude Code / Gemini) against a Kanban board via this `symphony-multi-agent` repo — adding/listing/transitioning tickets, launching the TUI, inspecting orchestrator state, customizing the workflow (lanes, per-state prompts), delegating sub-tasks to free up context, or diagnosing dispatch failures. Triggers on phrases like "add a symphony task", "run symphony", "dispatch this ticket", "symphony board", "WORKFLOW.md", "symphony tui won't start", "ticket failed with worker_exit", "customize kanban states", "deploy pipeline workflow", "delegate to symphony".
+description: Use when the user wants to dispatch coding agents (Codex / Claude Code / Gemini / Pi) against a Kanban board via this `symphony-multi-agent` repo — adding/listing/transitioning tickets, launching the TUI, inspecting orchestrator state, customizing the workflow (lanes, per-state prompts), delegating sub-tasks to free up context, or diagnosing dispatch failures. Triggers on phrases like "add a symphony task", "run symphony", "dispatch this ticket", "symphony board", "WORKFLOW.md", "symphony tui won't start", "ticket failed with worker_exit", "customize kanban states", "deploy pipeline workflow", "delegate to symphony", "agent.kind: pi", "agent silent for N seconds".
 ---
 
 # Using Symphony
 
 Symphony is a polling orchestrator that takes Kanban tickets and runs a
-coding-agent CLI (Codex, Claude Code, or Gemini) against each one in an
+coding-agent CLI (Codex, Claude Code, Gemini, or Pi) against each one in an
 isolated per-ticket workspace. This skill covers the operator's day-to-day:
 authoring tickets, launching the orchestrator, and triaging failures.
 
@@ -20,7 +20,8 @@ authoring tickets, launching the orchestrator, and triaging failures.
 WORKFLOW.md  ─▶  Orchestrator  ─poll─▶  kanban/*.md  ─dispatch─▶  AgentBackend
    (config)                  (every                                (codex |
                               polling.                              claude |
-                              interval_ms)                          gemini)
+                              interval_ms)                          gemini |
+                                                                    pi)
                                                                         │
                                                                         ▼
                                                             workspace.root/<ID>
@@ -49,10 +50,29 @@ Key invariants:
 symphony doctor ./WORKFLOW.md
 ```
 
-Catches port collision, missing agent CLI on `$PATH`, the shipped
-placeholder clone URL, unwritable workspace, and missing board directory in
-one pass. Exit 0 if green; otherwise read FAIL lines and fix before
-launching.
+Catches port collision, missing agent CLI on `$PATH`, missing pi auth
+(`~/.pi/agent/auth.json` when `agent.kind: pi`), the shipped placeholder
+clone URL, unwritable workspace, and missing board directory in one pass.
+Exit 0 if green; otherwise read FAIL lines and fix before launching.
+
+## Headless visibility — what to grep for in `log/symphony.log`
+
+When running without the TUI, these INFO/WARN lines tell you the run is
+actually progressing (vs. hung):
+
+| Log message                           | Means                                                |
+|---------------------------------------|------------------------------------------------------|
+| `dispatch issue_id=...`               | Orchestrator picked up a ticket                      |
+| `hook_completed hook=after_create`    | Workspace seeded; per-ticket cwd is ready            |
+| `agent_session_started session_id=`   | Agent CLI booted and minted a session id             |
+| `agent_turn_completed turn=N total_tokens=...` | Turn finished; tokens accumulated; live preview snippet attached |
+| `agent_turn_failed reason=...`        | Backend reported a turn-level failure                |
+| `reconcile_terminate_terminal state=` | Ticket reached a terminal state — worker about to exit |
+| `worker_exit reason=normal`           | Successful end-to-end run                            |
+
+If you see `dispatch` but no `agent_session_started` within a minute, the
+backend is stuck before its first event — inspect `pi`/`claude`/`codex`
+stdin and auth (see troubleshooting reference).
 
 ## Top three recipes
 

--- a/.claude/skills/using-symphony/reference/troubleshooting.md
+++ b/.claude/skills/using-symphony/reference/troubleshooting.md
@@ -29,6 +29,7 @@ tail -F log/symphony.log
 | `worker_exit reason=error`               | Worker terminated abnormally                             | Read the preceding `hook_failed` event or backend stderr for the actual cause       |
 | `outcome=turn_error`                     | Turn ended in error (timeout, agent crash, tool failure) | Inspect backend stderr; for timeouts, raise `<kind>.turn_timeout_ms`                |
 | `hook_timeout`                           | Hook exceeded its time budget                            | Shorten the hook or remove blocking commands                                        |
+| `hook_after_run_skipped_missing_cwd`     | Workspace was deleted before `after_run` could run       | INFO-level only; usually means the agent or a hook removed its own workspace. Not a bug — ignore unless you depend on `after_run`                                                                 |
 | `OSError [Errno 48]` on startup          | Port already in use                                      | `lsof -ti :9999 \| xargs -r kill`                                                   |
 | `workflow_path_missing`                  | `WORKFLOW.md` not at the path you passed                 | Pass an explicit path; default is `./WORKFLOW.md`                                   |
 | `dispatch_validation_failed`             | Config invalid for the chosen `agent.kind`               | Check the matching `<kind>:` block in `WORKFLOW.md` (command, timeouts)             |
@@ -100,3 +101,49 @@ full list of related gotchas (CRLF, absolute paths, `set -e`, etc.).
 - `tracker.project_slug` matches the Linear project's URL slug?
 - Linear API rate-limited you? Check `rate_limits` in
   `/api/v1/state` — it's mirrored from upstream headers.
+
+### Pi backend: "first turn fails immediately, no useful error"
+
+Most common cause: `~/.pi/agent/auth.json` is missing or stale. Without it,
+`pi --mode json` exits before emitting any events; Symphony surfaces this
+as a generic `turn_error` and retries with the same identical failure.
+
+```bash
+symphony doctor ./WORKFLOW.md             # WARNs when the auth file is absent
+ls -la ~/.pi/agent/auth.json              # confirm presence + recency
+pi                                        # then `/login` to refresh OAuth credentials
+```
+
+The cached credentials are inherited automatically by every subprocess
+Symphony spawns — you do *not* need to put `PI_API_KEY` (or any provider
+env var) into `WORKFLOW.md` or the `pi:` block.
+
+### Pi backend: "agent silent for N seconds, no events in log"
+
+If `agent_session_started` fired but no `agent_turn_completed` follows for
+5+ minutes, pi may be stuck on a long tool call (e.g. a slow fetch, or an
+agent-spawned subprocess waiting on stdin). The per-turn budget is
+`pi.turn_timeout_ms` (default ~1h). Lower it if you want stuck turns to
+fail fast and bounce through retry instead of hanging:
+
+```yaml
+pi:
+  command: 'pi --mode json -p ""'
+  resume_across_turns: true
+  turn_timeout_ms: 600000        # 10 min instead of the default 1h
+```
+
+### Pi backend: "token totals look 2–4× higher than Claude on the same task"
+
+Not a bug. Pi makes one LLM API call per assistant message within a turn,
+and each call's prompt is re-billed (cache reads count at a discount but
+still count). A 4-call turn with a 30k-token system prompt reports ~120k
+`input_tokens`; the same work on Claude reports ~30k because Claude
+aggregates per-turn at the `result` event. Both totals are honest — they
+just count at different granularities. Verify with the JSON probe:
+
+```bash
+echo "<prompt>" | pi --mode json -p "" 2>/dev/null \
+  | jq -c 'select(.type=="message_end") | .message.usage'
+# one usage block per LLM call
+```

--- a/.claude/skills/using-symphony/reference/workflow-config.md
+++ b/.claude/skills/using-symphony/reference/workflow-config.md
@@ -50,13 +50,14 @@ You are picking up ticket {{ issue.identifier }}: {{ issue.title }}.
 ## Picking the agent
 
 Set `agent.kind`:
-- **`codex`** — Codex `app-server`. Best for multi-turn JSON-RPC sessions; most mature backend.
-- **`claude`** — Claude Code. Fresh subprocess per turn with `--resume <session-id>` from turn 2 onward.
+- **`codex`** — Codex `app-server`. Best for multi-turn JSON-RPC sessions; most mature backend. Long-running stdio JSON-RPC connection; one process for the whole run.
+- **`claude`** — Claude Code. Fresh subprocess per turn with `--resume <session-id>` from turn 2 onward. NDJSON event stream.
 - **`gemini`** — Gemini CLI. One-shot per turn, no session continuity (each turn is independent).
+- **`pi`** — Pi coding-agent (`pi --mode json -p ""`). Per-turn subprocess with `--session <id>` resume from turn 2 onward; JSONL events. Multiplexes Anthropic / OpenAI / Gemini / Bedrock backends behind one CLI — useful when you want to swap LLM providers without changing Symphony config. Auth: sign in once with `pi` → `/login` (OAuth); credentials cached at `~/.pi/agent/auth.json` and inherited by every subprocess Symphony spawns. `symphony doctor` warns if the auth file is missing.
 
-Each backend reads its own block (`codex`, `claude`, `gemini`); the others
-are ignored. The `codex.linear_graphql` client tool is only advertised when
-`agent.kind: codex`.
+Each backend reads its own block (`codex`, `claude`, `gemini`, `pi`); the
+others are ignored. The `codex.linear_graphql` client tool is only
+advertised when `agent.kind: codex`.
 
 ## Hooks
 

--- a/llm-wiki/INDEX.md
+++ b/llm-wiki/INDEX.md
@@ -7,3 +7,4 @@ Learn writes back to them after QA passes.
 | topic-slug | summary | last touched |
 |------------|---------|--------------|
 | production-pipeline | Seven-stage pipeline + docs/<id>/<stage>/ artefact convention + WORKFLOW/PIPELINE sync invariant | 2026-05-09 (this ticket) |
+| agent-observability | Headless event log signal set + stall signatures + cross-refs to orchestrator/doctor/workspace | 2026-05-10 |

--- a/llm-wiki/agent-observability.md
+++ b/llm-wiki/agent-observability.md
@@ -1,0 +1,66 @@
+# Agent observability — what fires, when, and where to look
+
+Headless symphony runs (no TUI, just `symphony ./WORKFLOW.md --port 9999`)
+emit a structured stderr stream. The fields below are the minimum signal
+needed to know whether a run is genuinely progressing vs. silently stuck.
+Codified here because pre-2026-05 runs had a 90-second log gap between
+`hook_completed before_run` and `worker_exit` — events were tracked on
+the `RunningEntry` but never logged, so headless operators had to poll the
+JSON API to see anything happen.
+
+## The minimum log line set per run
+
+Run grep-friendly anchors:
+
+```bash
+grep -E '(dispatch|agent_session|agent_turn|reconcile_terminate|worker_exit)' \
+  log/symphony.log
+```
+
+Expected sequence for a healthy 1-turn run:
+
+```
+INFO dispatch                        issue_id=X identifier=X attempt=null
+INFO hook_start hook=after_create    cwd=~/symphony_workspaces/X
+INFO hook_completed                  hook=after_create
+INFO hook_start hook=before_run      cwd=~/symphony_workspaces/X
+INFO hook_completed                  hook=before_run
+INFO agent_session_started           issue_id=X session_id=<uuid>
+INFO agent_turn_completed            turn=1 input_tokens=N output_tokens=M total_tokens=N+M last_message=…
+INFO reconcile_terminate_terminal    state=Done
+INFO hook_start hook=after_run       cwd=~/symphony_workspaces/X
+INFO hook_completed                  hook=after_run
+INFO worker_exit                     reason=normal error=null
+```
+
+Multi-turn runs repeat `agent_turn_completed` with `turn=N` incrementing.
+Failures replace `agent_turn_completed` with `WARN agent_turn_failed turn=N reason=...`.
+
+## Stall signatures
+
+| Symptom in log                                    | Likely cause                                           | First action                                       |
+|---------------------------------------------------|--------------------------------------------------------|----------------------------------------------------|
+| `dispatch` then nothing for >60s                  | Agent CLI not booting (auth missing, wrong path)       | `symphony doctor ./WORKFLOW.md`                    |
+| `agent_session_started` then nothing for >5min    | Agent stuck in a tool call (long fetch, hung subprocess) | Lower `<kind>.turn_timeout_ms` or kill the child   |
+| repeated `agent_turn_failed reason=…`             | Real backend / prompt error, not an env issue          | Read the `reason=` value; inspect backend stderr   |
+| `hook_after_run_skipped_missing_cwd`              | Agent or hook removed its own workspace before exit    | Cosmetic; ignore unless `after_run` is load-bearing |
+
+## Why this matters for the prompt template
+
+The pipeline prompt in `WORKFLOW.example.md` tells the agent to append a
+`## Resolution` (or `## Triage`, `## Implementation`) section as it
+transitions states. Those sections are the *human* trail. The events
+above are the *operator* trail — they confirm the orchestrator + backend
+plumbing is moving even when the agent's text output is sparse.
+
+If you're authoring a new prompt template, do **not** ask the agent to
+emit log lines that mimic these — they're orchestrator-side and will
+never be honoured. Ask for ticket-body sections instead, and rely on
+`agent_turn_completed.last_message` for the live preview snippet.
+
+## Cross-references
+
+- `src/symphony/orchestrator.py:_on_codex_event` — where the events are logged
+- `src/symphony/doctor.py:check_pi_auth` — preflight for the `agent.kind=pi` auth file
+- `src/symphony/workspace.py:after_run_best_effort` — the missing-cwd skip
+- `tests/test_doctor.py` and `tests/test_workspace.py` — coverage anchors

--- a/src/symphony/doctor.py
+++ b/src/symphony/doctor.py
@@ -26,6 +26,7 @@ import socket
 import sys
 import tempfile
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, Literal
 
 from ._shell import _is_wsl_launcher, resolve_bash
@@ -97,6 +98,30 @@ def check_agent_cli(cfg: ServiceConfig) -> CheckResult:
 
 
 _PLACEHOLDER_TOKENS = ("my-org/my-repo", "my-org:my-repo")
+
+
+def check_pi_auth(cfg: ServiceConfig) -> CheckResult:
+    """When agent.kind=pi, warn if `~/.pi/agent/auth.json` is missing.
+
+    Without it, the first dispatched turn spawns `pi --mode json` which exits
+    immediately with an unauth error — cryptic when surfaced as a generic
+    `turn_failed`. Catching it here is non-fatal (warn) because pi can also
+    pick up auth from PI_API_KEY-style env var setups; we only flag the
+    common cached-OAuth case.
+    """
+    name = "agent.kind=pi.auth"
+    if cfg.agent.kind != "pi":
+        return CheckResult(name, "pass", "not pi (skipped)")
+    auth = Path.home() / ".pi" / "agent" / "auth.json"
+    if auth.exists():
+        return CheckResult(name, "pass", f"{auth} present")
+    return CheckResult(
+        name,
+        "warn",
+        f"{auth} not found — run `pi` and `/login` once, or ensure your"
+        " provider env var is set, otherwise every dispatch will fail at the"
+        " first turn.",
+    )
 
 
 def check_after_create_hook(cfg: ServiceConfig) -> CheckResult:
@@ -206,6 +231,7 @@ def run_checks(cfg: ServiceConfig, host: str = "127.0.0.1") -> list[CheckResult]
         check_port(cfg, host=host),
         check_shell(),
         check_agent_cli(cfg),
+        check_pi_auth(cfg),
         check_after_create_hook(cfg),
         check_workspace_root(cfg),
         check_tracker(cfg),

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from .backends import (
+    EVENT_TURN_FAILED,
     EVENT_SESSION_STARTED,
     EVENT_TURN_COMPLETED,
     BackendInit,
@@ -597,11 +598,36 @@ class Orchestrator:
             if sid:
                 entry.thread_id = str(sid)
                 entry.session_id = entry.thread_id
+            log.info(
+                "agent_session_started",
+                issue_id=issue_id,
+                identifier=entry.issue.identifier,
+                session_id=entry.session_id,
+            )
         if ev_name == EVENT_TURN_COMPLETED:
             turn_id = payload.get("turnId") or payload.get("turn_id")
             if turn_id and entry.thread_id:
                 entry.turn_id = str(turn_id)
                 entry.session_id = f"{entry.thread_id}-{entry.turn_id}"
+            log.info(
+                "agent_turn_completed",
+                issue_id=issue_id,
+                identifier=entry.issue.identifier,
+                turn=entry.turn_count,
+                input_tokens=entry.codex_input_tokens,
+                output_tokens=entry.codex_output_tokens,
+                total_tokens=entry.codex_total_tokens,
+                last_message=(entry.last_codex_message or "")[:160],
+            )
+        if ev_name == EVENT_TURN_FAILED:
+            reason = payload.get("reason") if isinstance(payload, dict) else None
+            log.warning(
+                "agent_turn_failed",
+                issue_id=issue_id,
+                identifier=entry.issue.identifier,
+                turn=entry.turn_count,
+                reason=str(reason) if reason else "",
+            )
 
         # Track recent events.
         debug = self._issue_debug.setdefault(issue_id, _IssueDebug())

--- a/src/symphony/workspace.py
+++ b/src/symphony/workspace.py
@@ -118,6 +118,13 @@ class WorkspaceManager:
     async def after_run_best_effort(self, path: Path) -> None:
         if not self._hooks.after_run:
             return
+        # If the agent (or an external process) removed the workspace before we
+        # got here, skip the hook — spawning bash with a missing cwd raises an
+        # opaque FileNotFoundError that callers cannot act on. Logging at
+        # INFO keeps the trail without the false-alarm warning.
+        if not path.exists():
+            log.info("hook_after_run_skipped_missing_cwd", path=str(path))
+            return
         try:
             await self._run_hook("after_run", self._hooks.after_run, path)
         except Exception as exc:  # §9.4 — log and ignore.

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from symphony.doctor import (
     check_after_create_hook,
     check_agent_cli,
+    check_pi_auth,
     check_port,
     check_tracker,
     check_workspace_root,
@@ -190,14 +191,61 @@ def test_run_checks_returns_one_result_per_check(tmp_path: Path) -> None:
         """,
     )
     results = run_checks(cfg)
-    # port + shell + agent + after_create + workspace + tracker = 6
-    assert len(results) == 6
+    # port + shell + agent + pi_auth + after_create + workspace + tracker = 7
+    assert len(results) == 7
     assert {r.name.split("=")[0].split(".")[0] for r in results} >= {
         "agent",
         "hooks",
         "workspace",
         "tracker",
     }
+
+
+def test_pi_auth_skipped_for_non_pi(tmp_path: Path) -> None:
+    cfg = _build_cfg(
+        tmp_path,
+        """
+        tracker: { kind: file, board_root: ./kanban }
+        agent: { kind: codex }
+        codex: { command: codex app-server }
+        """,
+    )
+    result = check_pi_auth(cfg)
+    assert result.status == "pass"
+    assert "skipped" in result.message
+
+
+def test_pi_auth_warns_when_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))  # ~ resolves to a clean dir
+    cfg = _build_cfg(
+        tmp_path,
+        """
+        tracker: { kind: file, board_root: ./kanban }
+        agent: { kind: pi }
+        pi: { command: 'pi --mode json -p \"\"' }
+        """,
+    )
+    result = check_pi_auth(cfg)
+    assert result.status == "warn"
+    assert "auth.json" in result.message
+
+
+def test_pi_auth_passes_when_present(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    auth = tmp_path / ".pi" / "agent" / "auth.json"
+    auth.parent.mkdir(parents=True)
+    auth.write_text("{}")
+    cfg = _build_cfg(
+        tmp_path,
+        """
+        tracker: { kind: file, board_root: ./kanban }
+        agent: { kind: pi }
+        pi: { command: 'pi --mode json -p \"\"' }
+        """,
+    )
+    result = check_pi_auth(cfg)
+    assert result.status == "pass"
+    assert "auth.json" in result.message
 
 
 def test_format_results_includes_all_statuses() -> None:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -86,6 +86,24 @@ async def test_after_run_failure_is_logged_and_ignored(tmp_path):
     await mgr.after_run_best_effort(ws.path)
 
 
+@pytest.mark.asyncio
+async def test_after_run_skipped_when_cwd_missing(tmp_path):
+    """If the agent (or anything else) deletes the workspace before exit,
+    after_run_best_effort must skip the hook silently rather than spawn
+    bash with a missing cwd (which raises a noisy FileNotFoundError that
+    the user cannot act on)."""
+    mgr = WorkspaceManager(
+        tmp_path / "ws", _hooks(after_run="echo should-not-run > marker")
+    )
+    ws = await mgr.create_or_reuse("MT-6")
+    # Simulate post-agent deletion.
+    import shutil as _shutil
+    _shutil.rmtree(ws.path)
+    # Should not raise; hook is skipped, no marker created elsewhere.
+    await mgr.after_run_best_effort(ws.path)
+    assert not ws.path.exists()
+
+
 def test_validate_agent_cwd_rejects_outside(tmp_path):
     root = tmp_path / "root"
     root.mkdir()


### PR DESCRIPTION
## Context

Discovered while running an end-to-end refactoring task with `agent.kind=pi`
on a real Vue 3 / TypeScript utility file. The orchestrator + pi backend
delivered a clean refactor (state transitions, diff, vitest spec), but
three friction points showed up along the way:

1. **Headless invisibility** — between `before_run hook_completed` and
   `reconcile_terminate_terminal` (≈90 s) the log was completely silent.
   Agent events were tracked on `RunningEntry` but never logged, so
   `--port 9999` operators had to JSON-poll to know whether the agent
   was alive.
2. **`hook_after_run_failed` false alarm** — when the agent (or external
   process) deletes its own workspace before exit, `after_run_best_effort`
   spawned `bash` with a missing cwd and logged a noisy, unactionable
   `FileNotFoundError`.
3. **`agent.kind=pi` first-run UX** — without `~/.pi/agent/auth.json`, every
   dispatched turn exits immediately with a cryptic auth error surfaced
   as a generic `turn_failed`. Doctor had no preflight for it.

Plus a documentation gap: the `using-symphony` skill family was authored
before pi backend landed and never picked it up — the description
field, the mental-model diagram, the "Picking the agent" reference, and
troubleshooting all listed only Codex / Claude / Gemini.

## What changed

### Code (commit `8e94315`)

- `src/symphony/orchestrator.py` — `_on_codex_event` now logs
  - `agent_session_started` (INFO) with `session_id`
  - `agent_turn_completed` (INFO) with `turn`, `input_tokens`,
    `output_tokens`, `total_tokens`, and a 160-char `last_message`
    preview
  - `agent_turn_failed` (WARN) with `reason`
- `src/symphony/workspace.py` — `after_run_best_effort` now
  `path.exists()`-checks first and emits
  `hook_after_run_skipped_missing_cwd` at INFO instead of trying to
  spawn bash on a missing cwd
- `src/symphony/doctor.py` — new `check_pi_auth` (warn-severity) only
  active when `agent.kind=pi`; no-ops cleanly for the other backends

### Tests (+4 net)

- `tests/test_doctor.py` — `check_pi_auth` skipped/warn/pass paths;
  `run_checks` count bumped from 6 to 7
- `tests/test_workspace.py` — `after_run_skipped_when_cwd_missing`
- 162 → 166 pass, 2 skipped, 0 fail

### Docs (commit `29785b0`)

- `.claude/skills/using-symphony/SKILL.md` — pi added to description
  triggers, intro paragraph, and mental-model diagram; new
  "Headless visibility" table mapping the seven log messages an
  operator should grep for to a one-line meaning each
- `.claude/skills/using-symphony/reference/workflow-config.md` —
  "Picking the agent" gains a `pi` bullet covering its per-turn
  subprocess + `--session` resume model, multi-provider fan-out, and
  the auth-file caching behaviour
- `.claude/skills/using-symphony/reference/troubleshooting.md` —
  - new failure-signature row for `hook_after_run_skipped_missing_cwd`
    (informational, not a bug)
  - three new pi-specific subsections: missing auth file, agent-silent
    (`turn_timeout_ms` tuning), and the legitimate-not-bug case of pi
    totals running 2–4× higher than Claude on the same task — with a
    one-liner JSON probe to verify per-call usage shape
- `llm-wiki/agent-observability.md` (new) — canonical reference for
  the headless event sequence, stall signatures, and cross-references
  back into `orchestrator.py` / `doctor.py` / `workspace.py`, so
  future Explore stages don't have to rediscover the wiring
- `llm-wiki/INDEX.md` — indexes the new entry

## Verification

### `symphony doctor` — new line shows on a `agent.kind=pi` workflow

```text
PASS  server.port=9988              127.0.0.1:9988 is free
PASS  shell.bash                    bash
PASS  agent.kind=pi                 pi → /usr/local/bin/pi
PASS  agent.kind=pi.auth            ~/.pi/agent/auth.json present
PASS  hooks.after_create            looks customized
PASS  workspace.root=…              exists and is writable
PASS  tracker.board_root            ./kanban (1 ticket)
```

### Headless run — new INFO lines fire end-to-end

```text
INFO dispatch                        issue_id=REFAC-2 attempt=null
INFO hook_completed                  hook=after_create
INFO hook_completed                  hook=before_run
INFO agent_session_started           session_id=019e0f27-133c-750f-b3ef-…
INFO agent_turn_completed            turn=1 input_tokens=127993 output_tokens=1042 total_tokens=129035
INFO reconcile_terminate_terminal    state=Done
INFO worker_exit                     reason=normal
```

(Pre-patch: only the four `dispatch` / `hook_completed` / `reconcile` /
`worker_exit` lines fired — the two `agent_*` lines in the middle were
absent.)

### Pi token-inflation hypothesis — checked, ruled out

Probed pi's actual usage stream with a 1-turn tool-using prompt:
`message_end` fires per LLM API call (not cumulative-within-turn), and
`input + cacheRead + cacheWrite + output == totalTokens` per single
message. Summing across calls within a turn = sum of per-call billed
tokens, same pattern as the Claude backend's per-result accumulation. So
the pi backend's `_update_usage` is correct as-is; the documentation now
explains why pi totals look higher than Claude's on the same task.

## Out of scope (intentionally)

- Atomic ticket writes — `tracker_file.py:write_ticket_atomic` already
  uses `tempfile.mkstemp` + `os.replace` (POSIX-atomic), and there's no
  symphony-vs-agent concurrent-write race on the same file by design
  (orchestrator only reads, agent only writes)
- TUI `last_event_at` rendering — proposed candidate; not in this PR

## Test plan for reviewers

```bash
git checkout improve/observability-and-doctor
pip install -e ".[dev]"
pytest -q                                   # 166 pass / 2 skipped
symphony doctor ./WORKFLOW.md                # observe new pi.auth row
```

For end-to-end:

```bash
# WORKFLOW.md with agent.kind=pi
symphony ./WORKFLOW.md --port 9988 2>> log/symphony.log &
grep -E '(dispatch|agent_session|agent_turn|worker_exit)' log/symphony.log
```
