### PR TITLE
fix(observability+config+ux): stderr capture, positive-int validation, TUI silence badge, pi compaction events, reconcile race fix

### DIFF
--- a/.claude/skills/using-symphony/SKILL.md
+++ b/.claude/skills/using-symphony/SKILL.md
@@ -66,8 +66,12 @@ actually progressing (vs. hung):
 | `hook_completed hook=after_create`    | Workspace seeded; per-ticket cwd is ready            |
 | `agent_session_started session_id=`   | Agent CLI booted and minted a session id             |
 | `agent_turn_completed turn=N total_tokens=...` | Turn finished; tokens accumulated; live preview snippet attached |
-| `agent_turn_failed reason=...`        | Backend reported a turn-level failure                |
-| `reconcile_terminate_terminal state=` | Ticket reached a terminal state — worker about to exit |
+| `worker_turn_completed turn=N ...`    | Worker-side mirror of the above; guaranteed to fire even when reconcile races in |
+| `agent_turn_failed reason=... stderr_tail=[...]` | Backend reported a turn-level failure; last 20 stderr lines attached |
+| `agent_compaction phase=start/end`    | Pi only — context compaction (auto or `/compact`)    |
+| `agent_internal_retry phase=start/end` | Pi only — backend-internal LLM retry on transient error |
+| `reconcile_skip_active_worker`        | Reconcile saw terminal state but worker is still emitting events; lets it exit naturally |
+| `reconcile_terminate_terminal state=` | Ticket reached a terminal state and worker is stale (>10 s silent) — force-cancel |
 | `worker_exit reason=normal`           | Successful end-to-end run                            |
 
 If you see `dispatch` but no `agent_session_started` within a minute, the

--- a/.claude/skills/using-symphony/reference/troubleshooting.md
+++ b/.claude/skills/using-symphony/reference/troubleshooting.md
@@ -30,6 +30,9 @@ tail -F log/symphony.log
 | `outcome=turn_error`                     | Turn ended in error (timeout, agent crash, tool failure) | Inspect backend stderr; for timeouts, raise `<kind>.turn_timeout_ms`                |
 | `hook_timeout`                           | Hook exceeded its time budget                            | Shorten the hook or remove blocking commands                                        |
 | `hook_after_run_skipped_missing_cwd`     | Workspace was deleted before `after_run` could run       | INFO-level only; usually means the agent or a hook removed its own workspace. Not a bug — ignore unless you depend on `after_run`                                                                 |
+| `reconcile_skip_active_worker`           | Reconcile saw a terminal state but the worker is still emitting events; gives the worker `last_event_age_s` < 10 s grace to exit naturally | Informational — prevents races that previously dropped `agent_turn_completed` and wiped workspaces mid-cleanup |
+| `agent_compaction phase=start/end`       | Pi backend triggered context compaction (`/compact` or auto when nearing the model's context window) | Informational — a sudden token-count drop on the next turn is now attributable     |
+| `agent_internal_retry phase=start/end`   | Pi backend retried an upstream LLM call internally (transient error)                              | Informational — recoverable; if `final_error` is set the turn ultimately failed   |
 | `OSError [Errno 48]` on startup          | Port already in use                                      | `lsof -ti :9999 \| xargs -r kill`                                                   |
 | `workflow_path_missing`                  | `WORKFLOW.md` not at the path you passed                 | Pass an explicit path; default is `./WORKFLOW.md`                                   |
 | `dispatch_validation_failed`             | Config invalid for the chosen `agent.kind`               | Check the matching `<kind>:` block in `WORKFLOW.md` (command, timeouts)             |
@@ -102,6 +105,21 @@ full list of related gotchas (CRLF, absolute paths, `set -e`, etc.).
 - Linear API rate-limited you? Check `rate_limits` in
   `/api/v1/state` — it's mirrored from upstream headers.
 
+### Pi/Claude backend: "turn failed but the reason is opaque"
+
+As of the observability patch, `agent_turn_failed` and `worker_exit reason=turn_error`
+carry a `stderr_tail` field with the last 20 lines of the backend CLI's stderr.
+That's where the actual reason (auth, network, ratelimit, model error)
+lives. Greb the structured log:
+
+```bash
+grep agent_turn_failed log/symphony.log | jq -R 'fromjson?'  # if you log JSON
+grep -A1 agent_turn_failed log/symphony.log                   # plain k=v
+```
+
+The `reason` field also concatenates the stderr blob into the human-readable
+failure string, so even a raw `tail -F log/symphony.log` shows it inline.
+
 ### Pi backend: "first turn fails immediately, no useful error"
 
 Most common cause: `~/.pi/agent/auth.json` is missing or stale. Without it,
@@ -119,6 +137,15 @@ Symphony spawns — you do *not* need to put `PI_API_KEY` (or any provider
 env var) into `WORKFLOW.md` or the `pi:` block.
 
 ### Pi backend: "agent silent for N seconds, no events in log"
+
+The TUI now grows a yellow `silent Ns` badge on running cards once their
+last event is older than 30 s, so visual stalls are immediate. In headless
+runs, grep for:
+
+```bash
+grep agent_session_started log/symphony.log     # session id minted
+grep agent_turn_completed log/symphony.log      # turn finished
+```
 
 If `agent_session_started` fired but no `agent_turn_completed` follows for
 5+ minutes, pi may be stuck on a long tool call (e.g. a slow fetch, or an

--- a/llm-wiki/agent-observability.md
+++ b/llm-wiki/agent-observability.md
@@ -20,21 +20,31 @@ grep -E '(dispatch|agent_session|agent_turn|reconcile_terminate|worker_exit)' \
 Expected sequence for a healthy 1-turn run:
 
 ```
-INFO dispatch                        issue_id=X identifier=X attempt=null
-INFO hook_start hook=after_create    cwd=~/symphony_workspaces/X
-INFO hook_completed                  hook=after_create
-INFO hook_start hook=before_run      cwd=~/symphony_workspaces/X
-INFO hook_completed                  hook=before_run
-INFO agent_session_started           issue_id=X session_id=<uuid>
-INFO agent_turn_completed            turn=1 input_tokens=N output_tokens=M total_tokens=N+M last_message=…
-INFO reconcile_terminate_terminal    state=Done
-INFO hook_start hook=after_run       cwd=~/symphony_workspaces/X
-INFO hook_completed                  hook=after_run
-INFO worker_exit                     reason=normal error=null
+INFO dispatch                          issue_id=X identifier=X attempt=null
+INFO hook_start hook=after_create      cwd=~/symphony_workspaces/X
+INFO hook_completed                    hook=after_create
+INFO hook_start hook=before_run        cwd=~/symphony_workspaces/X
+INFO hook_completed                    hook=before_run
+INFO agent_session_started             issue_id=X session_id=<uuid>
+INFO reconcile_skip_active_worker      state=Done last_event_age_s=3.1   # if the agent just emitted
+INFO agent_turn_completed              turn=1 input_tokens=N output_tokens=M total_tokens=N+M last_message=…
+INFO worker_turn_completed             turn=1 input_tokens=N …             # worker-side mirror, fires even under cancellation
+INFO hook_start hook=after_run         cwd=~/symphony_workspaces/X
+INFO hook_completed                    hook=after_run
+INFO worker_exit                       reason=normal error=null
 ```
 
-Multi-turn runs repeat `agent_turn_completed` with `turn=N` incrementing.
-Failures replace `agent_turn_completed` with `WARN agent_turn_failed turn=N reason=...`.
+Multi-turn runs repeat `agent_turn_completed` (and `worker_turn_completed`)
+with `turn=N` incrementing. Failures replace those with `WARN
+agent_turn_failed turn=N reason=... stderr_tail=[...]`.
+
+Pi-only events that may interleave at any point:
+
+- `agent_compaction phase=start` / `phase=end tokens_before=N` — context
+  compaction triggered (manual or auto-threshold)
+- `agent_internal_retry phase=start attempt=K max_attempts=N` /
+  `phase=end success=true|false` — backend-internal retry on a transient
+  upstream error (network, ratelimit)
 
 ## Stall signatures
 
@@ -42,8 +52,9 @@ Failures replace `agent_turn_completed` with `WARN agent_turn_failed turn=N reas
 |---------------------------------------------------|--------------------------------------------------------|----------------------------------------------------|
 | `dispatch` then nothing for >60s                  | Agent CLI not booting (auth missing, wrong path)       | `symphony doctor ./WORKFLOW.md`                    |
 | `agent_session_started` then nothing for >5min    | Agent stuck in a tool call (long fetch, hung subprocess) | Lower `<kind>.turn_timeout_ms` or kill the child   |
-| repeated `agent_turn_failed reason=…`             | Real backend / prompt error, not an env issue          | Read the `reason=` value; inspect backend stderr   |
+| repeated `agent_turn_failed reason=… stderr_tail=[...]` | Real backend error                                | Read `stderr_tail` array — it's the literal stderr from pi/claude/gemini |
 | `hook_after_run_skipped_missing_cwd`              | Agent or hook removed its own workspace before exit    | Cosmetic; ignore unless `after_run` is load-bearing |
+| `reconcile_terminate_terminal last_event_age_s>10` | Worker stuck — reconcile force-cancelled it          | Inspect the agent CLI's last activity; raise turn_timeout_ms if legitimate work was in progress |
 
 ## Why this matters for the prompt template
 
@@ -60,7 +71,12 @@ never be honoured. Ask for ticket-body sections instead, and rely on
 
 ## Cross-references
 
-- `src/symphony/orchestrator.py:_on_codex_event` — where the events are logged
+- `src/symphony/orchestrator.py:_on_codex_event` — where listener-side events are logged
+- `src/symphony/orchestrator.py:_run_worker` — where `worker_turn_completed` fires (race-tolerant)
+- `src/symphony/orchestrator.py:_reconcile` — grace-period skip for active workers
+- `src/symphony/backends/pi.py` — stderr ring buffer, compaction/retry event mapping
+- `src/symphony/backends/claude_code.py` — same stderr ring buffer pattern
 - `src/symphony/doctor.py:check_pi_auth` — preflight for the `agent.kind=pi` auth file
 - `src/symphony/workspace.py:after_run_best_effort` — the missing-cwd skip
-- `tests/test_doctor.py` and `tests/test_workspace.py` — coverage anchors
+- `src/symphony/tui.py` — `_silent_seconds`, `SILENT_THRESHOLD_S` for the silence badge
+- `tests/test_doctor.py`, `tests/test_workspace.py`, `tests/test_backends.py`, `tests/test_workflow.py`, `tests/test_tui.py` — coverage anchors

--- a/src/symphony/backends/__init__.py
+++ b/src/symphony/backends/__init__.py
@@ -40,6 +40,10 @@ EVENT_UNSUPPORTED_TOOL_CALL = "unsupported_tool_call"
 EVENT_NOTIFICATION = "notification"
 EVENT_OTHER_MESSAGE = "other_message"
 EVENT_MALFORMED = "malformed"
+# Pi-flavoured signals — backend may translate native events to these so the
+# orchestrator can log/observe them with cross-backend semantics.
+EVENT_COMPACTION = "compaction"           # context compaction started/ended
+EVENT_AGENT_RETRY = "agent_retry"         # backend-internal auto-retry
 
 
 EventCallback = Callable[[dict[str, Any]], Awaitable[None]]

--- a/src/symphony/backends/claude_code.py
+++ b/src/symphony/backends/claude_code.py
@@ -25,6 +25,7 @@ import json
 import os
 import shlex
 import time
+from collections import deque
 from typing import Any
 
 from .._shell import resolve_bash
@@ -74,6 +75,8 @@ class ClaudeCodeBackend:
         }
         self._latest_rate_limits: dict[str, Any] | None = None
         self._last_message: str = ""
+        # Bounded stderr ring buffer — see PiBackend for the rationale.
+        self._stderr_tail: deque[str] = deque(maxlen=20)
 
     # ------------------------------------------------------------------
     # AgentBackend lifecycle
@@ -186,12 +189,20 @@ class ClaudeCodeBackend:
             await proc.wait()
             if terminal is None:
                 # Stream ended without a `result` event — treat as failure.
-                err_msg = f"claude exited with no result event (rc={proc.returncode})"
-                await self._emit(EVENT_TURN_FAILED, {"reason": err_msg})
+                stderr_blob = self._stderr_blob()
+                err_msg = (
+                    f"claude exited with no result event (rc={proc.returncode})"
+                    + (f"; stderr: {stderr_blob}" if stderr_blob else "")
+                )
+                await self._emit(
+                    EVENT_TURN_FAILED,
+                    {"reason": err_msg, "stderr_tail": list(self._stderr_tail)},
+                )
                 raise TurnFailed(err_msg)
 
             if terminal.get("is_error"):
-                await self._emit(EVENT_TURN_FAILED, terminal)
+                payload = {**terminal, "stderr_tail": list(self._stderr_tail)}
+                await self._emit(EVENT_TURN_FAILED, payload)
                 raise TurnFailed(
                     str(terminal.get("subtype") or terminal.get("error") or "claude turn failed")
                 )
@@ -286,7 +297,17 @@ class ClaudeCodeBackend:
                 break
             if not line:
                 break
-            log.debug("claude_stderr", line=line.decode("utf-8", errors="replace").rstrip())
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                self._stderr_tail.append(text)
+            log.debug("claude_stderr", line=text)
+
+    def _stderr_blob(self) -> str:
+        """Compact stderr tail for failure messages (≤400 chars)."""
+        if not self._stderr_tail:
+            return ""
+        joined = " | ".join(self._stderr_tail)
+        return joined if len(joined) <= 400 else joined[-400:]
 
     async def _reap(self, proc: asyncio.subprocess.Process) -> None:
         """Best-effort terminate→wait→kill ladder; mirrors `stop()`."""

--- a/src/symphony/backends/gemini.py
+++ b/src/symphony/backends/gemini.py
@@ -170,7 +170,16 @@ class GeminiBackend:
             rc = proc.returncode
             if rc != 0:
                 err_msg = (stderr or b"").decode("utf-8", errors="replace").strip()[:400]
-                payload = {"reason": f"gemini exit {rc}", "stderr": err_msg}
+                # Standardize on `stderr_tail` (list[str]) so orchestrator /
+                # operator grep handles every backend the same way; keep the
+                # legacy `stderr` key for back-compat with anything that read
+                # the previous shape.
+                tail = [s for s in err_msg.splitlines() if s][-20:]
+                payload = {
+                    "reason": f"gemini exit {rc}" + (f"; stderr: {err_msg}" if err_msg else ""),
+                    "stderr_tail": tail,
+                    "stderr": err_msg,
+                }
                 await self._emit(EVENT_TURN_FAILED, payload)
                 raise TurnFailed(err_msg or f"gemini failed with exit {rc}")
 

--- a/src/symphony/backends/pi.py
+++ b/src/symphony/backends/pi.py
@@ -38,6 +38,7 @@ import json
 import os
 import shlex
 import time
+from collections import deque
 from typing import Any
 
 from .._shell import resolve_bash
@@ -50,6 +51,8 @@ from ..errors import (
 from ..logging import get_logger
 from ..workspace import validate_agent_cwd
 from . import (
+    EVENT_AGENT_RETRY,
+    EVENT_COMPACTION,
     EVENT_MALFORMED,
     EVENT_OTHER_MESSAGE,
     EVENT_SESSION_STARTED,
@@ -86,6 +89,10 @@ class PiBackend:
             "total_tokens": 0,
         }
         self._last_message: str = ""
+        # Bounded ring buffer of stderr lines so a TurnFailed exception can
+        # carry the actual reason (auth error, network, ratelimit, ...) up to
+        # the orchestrator instead of the opaque "no agent_end event" string.
+        self._stderr_tail: deque[str] = deque(maxlen=20)
 
     # ------------------------------------------------------------------
     # AgentBackend lifecycle
@@ -199,13 +206,27 @@ class PiBackend:
 
             await proc.wait()
             if terminal is None:
-                err_msg = f"pi exited with no agent_end event (rc={proc.returncode})"
-                await self._emit(EVENT_TURN_FAILED, {"reason": err_msg})
+                stderr_blob = self._stderr_blob()
+                err_msg = (
+                    f"pi exited with no agent_end event (rc={proc.returncode})"
+                    + (f"; stderr: {stderr_blob}" if stderr_blob else "")
+                )
+                await self._emit(
+                    EVENT_TURN_FAILED,
+                    {"reason": err_msg, "stderr_tail": list(self._stderr_tail)},
+                )
                 raise TurnFailed(err_msg)
 
             failure_reason = _extract_failure_reason(terminal)
             if failure_reason is not None:
-                payload = {"reason": failure_reason, **terminal}
+                stderr_blob = self._stderr_blob()
+                if stderr_blob:
+                    failure_reason = f"{failure_reason}; stderr: {stderr_blob}"
+                payload = {
+                    "reason": failure_reason,
+                    "stderr_tail": list(self._stderr_tail),
+                    **terminal,
+                }
                 await self._emit(EVENT_TURN_FAILED, payload)
                 raise TurnFailed(failure_reason)
 
@@ -279,6 +300,61 @@ class PiBackend:
                     await self._emit(EVENT_OTHER_MESSAGE, msg)
                 elif kind == "agent_end":
                     terminal = msg
+                elif kind == "compaction_start":
+                    # Pi auto-compacts when the conversation approaches the
+                    # model's context window (or on `/compact`). Surface as a
+                    # normalized event so symphony can log it once at INFO
+                    # — a sudden token drop on the next turn would otherwise
+                    # be unattributable.
+                    await self._emit(
+                        EVENT_COMPACTION,
+                        {
+                            "phase": "start",
+                            "reason": msg.get("reason"),
+                        },
+                    )
+                elif kind == "compaction_end":
+                    result = msg.get("result") or {}
+                    payload = {
+                        "phase": "end",
+                        "reason": msg.get("reason"),
+                        "aborted": bool(msg.get("aborted")),
+                        "will_retry": bool(msg.get("willRetry")),
+                    }
+                    if isinstance(result, dict):
+                        # Best-effort: surface tokensBefore from the
+                        # CompactionEntry summary if pi includes it.
+                        for src, dst in (
+                            ("tokensBefore", "tokens_before"),
+                            ("firstKeptEntryId", "first_kept_entry_id"),
+                        ):
+                            if src in result:
+                                payload[dst] = result[src]
+                    err = msg.get("errorMessage")
+                    if isinstance(err, str) and err:
+                        payload["error"] = err
+                    await self._emit(EVENT_COMPACTION, payload)
+                elif kind == "auto_retry_start":
+                    await self._emit(
+                        EVENT_AGENT_RETRY,
+                        {
+                            "phase": "start",
+                            "attempt": msg.get("attempt"),
+                            "max_attempts": msg.get("maxAttempts"),
+                            "delay_ms": msg.get("delayMs"),
+                            "error": msg.get("errorMessage"),
+                        },
+                    )
+                elif kind == "auto_retry_end":
+                    await self._emit(
+                        EVENT_AGENT_RETRY,
+                        {
+                            "phase": "end",
+                            "attempt": msg.get("attempt"),
+                            "success": bool(msg.get("success")),
+                            "final_error": msg.get("finalError"),
+                        },
+                    )
                 else:
                     await self._emit(EVENT_OTHER_MESSAGE, msg)
         finally:
@@ -299,7 +375,17 @@ class PiBackend:
                 break
             if not line:
                 break
-            log.debug("pi_stderr", line=line.decode("utf-8", errors="replace").rstrip())
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                self._stderr_tail.append(text)
+            log.debug("pi_stderr", line=text)
+
+    def _stderr_blob(self) -> str:
+        """Compact stderr tail for inclusion in failure messages (≤400 chars)."""
+        if not self._stderr_tail:
+            return ""
+        joined = " | ".join(self._stderr_tail)
+        return joined if len(joined) <= 400 else joined[-400:]
 
     async def _reap(self, proc: asyncio.subprocess.Process) -> None:
         """Best-effort terminate→wait→kill ladder; mirrors `stop()`."""

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from .backends import (
+    EVENT_AGENT_RETRY,
+    EVENT_COMPACTION,
     EVENT_TURN_FAILED,
     EVENT_SESSION_STARTED,
     EVENT_TURN_COMPLETED,
@@ -504,6 +506,25 @@ class Orchestrator:
                         error = str(exc)
                         return
 
+                    # Synchronous log on the worker's hot path — the
+                    # listener-side `agent_turn_completed` log fires from
+                    # `_on_codex_event` via the EVENT_TURN_COMPLETED emit,
+                    # but reconcile can cancel the worker between the emit
+                    # and the listener running, swallowing the visibility
+                    # signal. Logging here guarantees one line per
+                    # successful turn even when reconcile races us.
+                    running_entry = self._running.get(issue.id)
+                    if running_entry is not None:
+                        log.info(
+                            "worker_turn_completed",
+                            issue_id=issue.id,
+                            identifier=running_entry.issue.identifier,
+                            turn=turn_number,
+                            input_tokens=running_entry.codex_input_tokens,
+                            output_tokens=running_entry.codex_output_tokens,
+                            total_tokens=running_entry.codex_total_tokens,
+                        )
+
                     # Refresh issue state.
                     refreshed = await self._refresh_issue_state(cfg, issue.id)
                     if refreshed is None:
@@ -621,12 +642,37 @@ class Orchestrator:
             )
         if ev_name == EVENT_TURN_FAILED:
             reason = payload.get("reason") if isinstance(payload, dict) else None
+            stderr_tail = payload.get("stderr_tail") if isinstance(payload, dict) else None
             log.warning(
                 "agent_turn_failed",
                 issue_id=issue_id,
                 identifier=entry.issue.identifier,
                 turn=entry.turn_count,
                 reason=str(reason) if reason else "",
+                stderr_tail=stderr_tail if isinstance(stderr_tail, list) else None,
+            )
+        if ev_name == EVENT_COMPACTION:
+            phase = payload.get("phase") if isinstance(payload, dict) else None
+            log.info(
+                "agent_compaction",
+                issue_id=issue_id,
+                identifier=entry.issue.identifier,
+                phase=str(phase) if phase else "",
+                reason=str(payload.get("reason") or "")
+                if isinstance(payload, dict) else "",
+                tokens_before=payload.get("tokens_before")
+                if isinstance(payload, dict) else None,
+            )
+        if ev_name == EVENT_AGENT_RETRY:
+            phase = payload.get("phase") if isinstance(payload, dict) else None
+            log.info(
+                "agent_internal_retry",
+                issue_id=issue_id,
+                identifier=entry.issue.identifier,
+                phase=str(phase) if phase else "",
+                attempt=payload.get("attempt") if isinstance(payload, dict) else None,
+                error=str(payload.get("error") or payload.get("final_error") or "")
+                if isinstance(payload, dict) else "",
             )
 
         # Track recent events.
@@ -820,17 +866,40 @@ class Orchestrator:
             return
         terminal = {s.lower() for s in cfg.tracker.terminal_states}
         active = {s.lower() for s in cfg.tracker.active_states}
+        # Grace period: a worker that just emitted an event is almost
+        # certainly already inside its own natural-exit path (post run_turn).
+        # Cancelling it now races the worker's own _refresh_issue_state and
+        # tends to: (a) drop the in-flight EVENT_TURN_COMPLETED listener,
+        # losing observability; (b) wipe the workspace before after_run can
+        # capture artefacts. Reserve cancellation for genuinely-stuck
+        # workers — the worker's own loop will exit cleanly within a tick
+        # or two when the agent transitions to a terminal state.
+        RECONCILE_RECENT_EVENT_GRACE_S = 10.0
+        now = datetime.now(timezone.utc)
         for issue in refreshed:
             entry = self._running.get(issue.id)
             if entry is None:
                 continue
             state = normalize_state(issue.state)
             if state in terminal:
+                last_seen = entry.last_codex_timestamp
+                age = (now - last_seen).total_seconds() if last_seen else None
+                if age is not None and age < RECONCILE_RECENT_EVENT_GRACE_S:
+                    # Active worker — let it exit on its own.
+                    log.info(
+                        "reconcile_skip_active_worker",
+                        issue_id=issue.id,
+                        identifier=issue.identifier,
+                        state=issue.state,
+                        last_event_age_s=round(age, 1),
+                    )
+                    continue
                 log.info(
                     "reconcile_terminate_terminal",
                     issue_id=issue.id,
                     identifier=issue.identifier,
                     state=issue.state,
+                    last_event_age_s=round(age, 1) if age is not None else None,
                 )
                 entry.worker_task.cancel()
                 if self._workspace_manager is not None:

--- a/src/symphony/tui.py
+++ b/src/symphony/tui.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from rich.align import Align
@@ -60,6 +61,12 @@ AGENT_COLOR = {
 }
 
 
+# Threshold above which a running card grows a yellow "silent Ns" badge.
+# Tuned to be just past the longest expected pi/claude turn warm-up
+# (≈30 s for opus-4 cold start) so the indicator never fires on healthy runs.
+SILENT_THRESHOLD_S = 30.0
+
+
 @dataclass
 class _CardStatus:
     """Per-issue runtime overlay for a kanban card."""
@@ -67,6 +74,7 @@ class _CardStatus:
     runtime: str = "idle"  # one of: idle, running, retrying, completed
     turn: int = 0
     last_event: str = ""
+    last_event_at: datetime | None = None
     tokens: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
@@ -422,6 +430,11 @@ class KanbanTUI:
         meta = Text()
         if status.runtime == "running":
             meta.append(f"{t('card.turn', language)} {status.turn}", style="green")
+            silent_s = _silent_seconds(status.last_event_at)
+            if silent_s is not None and silent_s >= SILENT_THRESHOLD_S:
+                # Past the silence threshold — surface as a yellow badge so
+                # the operator notices stalls without polling logs/JSON.
+                meta.append(f"  silent {int(silent_s)}s", style="bold yellow")
             if status.last_event:
                 meta.append(f"  {status.last_event}", style="dim")
             if status.input_tokens or status.output_tokens or status.tokens:
@@ -495,6 +508,7 @@ class KanbanTUI:
                 runtime="running",
                 turn=int(row.get("turn_count", 0) or 0),
                 last_event=str(row.get("last_event") or ""),
+                last_event_at=_parse_iso(row.get("last_event_at")),
                 tokens=int(tokens_block.get("total_tokens") or 0),
                 input_tokens=int(tokens_block.get("input_tokens") or 0),
                 output_tokens=int(tokens_block.get("output_tokens") or 0),
@@ -508,6 +522,28 @@ class KanbanTUI:
                 error=str(row.get("error") or "") or None,
             )
         return index
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Parse the ISO-8601 strings the orchestrator emits for `last_event_at`.
+
+    Returns None for missing/malformed values — the renderer treats `None`
+    as "no data", which is the right fallback during the first poll tick
+    (before any agent event has fired) and across orchestrator restarts.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _silent_seconds(last_event_at: datetime | None) -> float | None:
+    if last_event_at is None:
+        return None
+    now = datetime.now(timezone.utc)
+    return max(0.0, (now - last_event_at).total_seconds())
 
 
 def _truncate(text: str, n: int) -> str:

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -436,7 +436,9 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
     polling_raw = cfg.get("polling") or {}
     if not isinstance(polling_raw, dict):
         polling_raw = {}
-    poll_interval_ms = _as_int(polling_raw.get("interval_ms"), DEFAULT_POLL_INTERVAL_MS)
+    poll_interval_ms = _validated_positive_or_default(
+        polling_raw.get("interval_ms"), DEFAULT_POLL_INTERVAL_MS, name="polling.interval_ms"
+    )
 
     workspace_raw = cfg.get("workspace") or {}
     if not isinstance(workspace_raw, dict):
@@ -484,12 +486,16 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         )
     agent = AgentConfig(
         kind=agent_kind,
-        max_concurrent_agents=_as_int(
-            agent_raw.get("max_concurrent_agents"), DEFAULT_MAX_CONCURRENT_AGENTS
+        max_concurrent_agents=_validated_positive_or_default(
+            agent_raw.get("max_concurrent_agents"),
+            DEFAULT_MAX_CONCURRENT_AGENTS,
+            name="agent.max_concurrent_agents",
         ),
         max_turns=max_turns,
-        max_retry_backoff_ms=_as_int(
-            agent_raw.get("max_retry_backoff_ms"), DEFAULT_MAX_RETRY_BACKOFF_MS
+        max_retry_backoff_ms=_validated_positive_or_default(
+            agent_raw.get("max_retry_backoff_ms"),
+            DEFAULT_MAX_RETRY_BACKOFF_MS,
+            name="agent.max_retry_backoff_ms",
         ),
         max_concurrent_agents_by_state=_normalize_state_map(
             agent_raw.get("max_concurrent_agents_by_state")
@@ -504,9 +510,15 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         approval_policy=codex_raw.get("approval_policy"),
         thread_sandbox=codex_raw.get("thread_sandbox"),
         turn_sandbox_policy=codex_raw.get("turn_sandbox_policy"),
-        turn_timeout_ms=_as_int(codex_raw.get("turn_timeout_ms"), DEFAULT_CODEX_TURN_TIMEOUT_MS),
-        read_timeout_ms=_as_int(codex_raw.get("read_timeout_ms"), DEFAULT_CODEX_READ_TIMEOUT_MS),
-        stall_timeout_ms=_as_int(codex_raw.get("stall_timeout_ms"), DEFAULT_CODEX_STALL_TIMEOUT_MS),
+        turn_timeout_ms=_validated_positive_or_default(
+            codex_raw.get("turn_timeout_ms"), DEFAULT_CODEX_TURN_TIMEOUT_MS, name="codex.turn_timeout_ms"
+        ),
+        read_timeout_ms=_validated_positive_or_default(
+            codex_raw.get("read_timeout_ms"), DEFAULT_CODEX_READ_TIMEOUT_MS, name="codex.read_timeout_ms"
+        ),
+        stall_timeout_ms=_validated_positive_or_default(
+            codex_raw.get("stall_timeout_ms"), DEFAULT_CODEX_STALL_TIMEOUT_MS, name="codex.stall_timeout_ms"
+        ),
     )
 
     claude_raw = cfg.get("claude") or {}
@@ -514,9 +526,15 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         claude_raw = {}
     claude = ClaudeConfig(
         command=_as_str(claude_raw.get("command"), DEFAULT_CLAUDE_COMMAND) or DEFAULT_CLAUDE_COMMAND,
-        turn_timeout_ms=_as_int(claude_raw.get("turn_timeout_ms"), DEFAULT_BACKEND_TURN_TIMEOUT_MS),
-        read_timeout_ms=_as_int(claude_raw.get("read_timeout_ms"), DEFAULT_BACKEND_READ_TIMEOUT_MS),
-        stall_timeout_ms=_as_int(claude_raw.get("stall_timeout_ms"), DEFAULT_BACKEND_STALL_TIMEOUT_MS),
+        turn_timeout_ms=_validated_positive_or_default(
+            claude_raw.get("turn_timeout_ms"), DEFAULT_BACKEND_TURN_TIMEOUT_MS, name="claude.turn_timeout_ms"
+        ),
+        read_timeout_ms=_validated_positive_or_default(
+            claude_raw.get("read_timeout_ms"), DEFAULT_BACKEND_READ_TIMEOUT_MS, name="claude.read_timeout_ms"
+        ),
+        stall_timeout_ms=_validated_positive_or_default(
+            claude_raw.get("stall_timeout_ms"), DEFAULT_BACKEND_STALL_TIMEOUT_MS, name="claude.stall_timeout_ms"
+        ),
         resume_across_turns=bool(claude_raw.get("resume_across_turns", True)),
     )
 
@@ -525,9 +543,15 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         gemini_raw = {}
     gemini = GeminiConfig(
         command=_as_str(gemini_raw.get("command"), DEFAULT_GEMINI_COMMAND) or DEFAULT_GEMINI_COMMAND,
-        turn_timeout_ms=_as_int(gemini_raw.get("turn_timeout_ms"), DEFAULT_BACKEND_TURN_TIMEOUT_MS),
-        read_timeout_ms=_as_int(gemini_raw.get("read_timeout_ms"), DEFAULT_BACKEND_READ_TIMEOUT_MS),
-        stall_timeout_ms=_as_int(gemini_raw.get("stall_timeout_ms"), DEFAULT_BACKEND_STALL_TIMEOUT_MS),
+        turn_timeout_ms=_validated_positive_or_default(
+            gemini_raw.get("turn_timeout_ms"), DEFAULT_BACKEND_TURN_TIMEOUT_MS, name="gemini.turn_timeout_ms"
+        ),
+        read_timeout_ms=_validated_positive_or_default(
+            gemini_raw.get("read_timeout_ms"), DEFAULT_BACKEND_READ_TIMEOUT_MS, name="gemini.read_timeout_ms"
+        ),
+        stall_timeout_ms=_validated_positive_or_default(
+            gemini_raw.get("stall_timeout_ms"), DEFAULT_BACKEND_STALL_TIMEOUT_MS, name="gemini.stall_timeout_ms"
+        ),
     )
 
     pi_raw = cfg.get("pi") or {}
@@ -535,9 +559,15 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         pi_raw = {}
     pi = PiConfig(
         command=_as_str(pi_raw.get("command"), DEFAULT_PI_COMMAND) or DEFAULT_PI_COMMAND,
-        turn_timeout_ms=_as_int(pi_raw.get("turn_timeout_ms"), DEFAULT_BACKEND_TURN_TIMEOUT_MS),
-        read_timeout_ms=_as_int(pi_raw.get("read_timeout_ms"), DEFAULT_BACKEND_READ_TIMEOUT_MS),
-        stall_timeout_ms=_as_int(pi_raw.get("stall_timeout_ms"), DEFAULT_BACKEND_STALL_TIMEOUT_MS),
+        turn_timeout_ms=_validated_positive_or_default(
+            pi_raw.get("turn_timeout_ms"), DEFAULT_BACKEND_TURN_TIMEOUT_MS, name="pi.turn_timeout_ms"
+        ),
+        read_timeout_ms=_validated_positive_or_default(
+            pi_raw.get("read_timeout_ms"), DEFAULT_BACKEND_READ_TIMEOUT_MS, name="pi.read_timeout_ms"
+        ),
+        stall_timeout_ms=_validated_positive_or_default(
+            pi_raw.get("stall_timeout_ms"), DEFAULT_BACKEND_STALL_TIMEOUT_MS, name="pi.stall_timeout_ms"
+        ),
         resume_across_turns=bool(pi_raw.get("resume_across_turns", True)),
     )
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -596,3 +596,115 @@ pi:
     cfg = build_service_config(wf)
     assert "--no-session" in cfg.pi.command
     assert cfg.pi.resume_across_turns is False
+
+
+# --- stderr ring buffer + compaction event surfacing (improve/observability) ---
+
+def test_pi_stderr_blob_handles_empty_buffer(tmp_path: Path) -> None:
+    cfg = _make_cfg("pi", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = PiBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    assert backend._stderr_blob() == ""
+
+
+def test_pi_stderr_blob_truncates_long_tail(tmp_path: Path) -> None:
+    cfg = _make_cfg("pi", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = PiBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    for i in range(40):
+        backend._stderr_tail.append("x" * 60 + str(i))
+    blob = backend._stderr_blob()
+    assert len(blob) <= 400
+    # Ring buffer is bounded — only the last 20 lines survive even before
+    # blob-level truncation kicks in.
+    assert len(backend._stderr_tail) == 20
+
+
+def test_claude_stderr_blob_present(tmp_path: Path) -> None:
+    cfg = _make_cfg("claude", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = ClaudeCodeBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    backend._stderr_tail.append("Error: bad token")
+    backend._stderr_tail.append("Retrying once")
+    blob = backend._stderr_blob()
+    assert "bad token" in blob
+    assert "Retrying" in blob
+    assert " | " in blob  # joiner
+
+
+def test_pi_consume_stream_surfaces_compaction_events(tmp_path: Path) -> None:
+    """`compaction_start` / `compaction_end` events flow through to
+    EVENT_COMPACTION with phase + reason fields normalized."""
+    from symphony.backends import EVENT_COMPACTION, EVENT_AGENT_RETRY
+
+    captured: list[dict] = []
+
+    async def collect(ev):
+        captured.append(ev)
+
+    cfg = _make_cfg("pi", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = PiBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=collect)
+    )
+
+    # Fake stream: session, compaction_start, compaction_end, auto_retry_*, agent_end.
+    lines = [
+        b'{"type":"session","version":3,"id":"abc"}\n',
+        b'{"type":"compaction_start","reason":"threshold"}\n',
+        b'{"type":"compaction_end","reason":"threshold","aborted":false,'
+        b'"willRetry":false,"result":{"tokensBefore":48000,'
+        b'"firstKeptEntryId":"x1"}}\n',
+        b'{"type":"auto_retry_start","attempt":1,"maxAttempts":3,'
+        b'"delayMs":1000,"errorMessage":"upstream 503"}\n',
+        b'{"type":"auto_retry_end","success":true,"attempt":1}\n',
+        b'{"type":"agent_end","messages":[]}\n',
+    ]
+
+    class _FakeStdout:
+        def __init__(self, lines):
+            self._lines = list(lines)
+        async def readline(self):
+            return self._lines.pop(0) if self._lines else b""
+
+    class _FakeProc:
+        def __init__(self):
+            self.stdout = _FakeStdout(lines)
+            self.stderr = None
+            self.returncode = 0
+
+    asyncio.get_event_loop().run_until_complete(
+        backend._consume_stream(_FakeProc())
+    )
+    kinds = [c["event"] for c in captured]
+    # We expect: session_started, compaction(start), compaction(end),
+    # agent_retry(start), agent_retry(end). agent_end is terminal — handler
+    # returns it but doesn't emit.
+    assert EVENT_COMPACTION in kinds
+    assert kinds.count(EVENT_COMPACTION) == 2
+    assert EVENT_AGENT_RETRY in kinds
+    assert kinds.count(EVENT_AGENT_RETRY) == 2
+
+    compaction_events = [c for c in captured if c["event"] == EVENT_COMPACTION]
+    assert compaction_events[0]["payload"]["phase"] == "start"
+    assert compaction_events[0]["payload"]["reason"] == "threshold"
+    assert compaction_events[1]["payload"]["phase"] == "end"
+    assert compaction_events[1]["payload"]["tokens_before"] == 48000
+    assert compaction_events[1]["payload"]["first_kept_entry_id"] == "x1"
+
+    retry_events = [c for c in captured if c["event"] == EVENT_AGENT_RETRY]
+    assert retry_events[0]["payload"]["phase"] == "start"
+    assert retry_events[0]["payload"]["attempt"] == 1
+    assert retry_events[0]["payload"]["max_attempts"] == 3
+    assert retry_events[1]["payload"]["phase"] == "end"
+    assert retry_events[1]["payload"]["success"] is True

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,67 @@
+"""TUI helper coverage \u2014 narrow tests for the silence-threshold logic.
+
+Full TUI rendering is out of scope (rich.Live needs a TTY); these tests
+exercise the pure helpers that decide the badge.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from symphony.tui import (
+    SILENT_THRESHOLD_S,
+    _CardStatus,
+    _parse_iso,
+    _silent_seconds,
+)
+
+
+def test_parse_iso_handles_z_suffix() -> None:
+    parsed = _parse_iso("2026-05-09T23:51:21Z")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+
+
+def test_parse_iso_handles_offset_form() -> None:
+    parsed = _parse_iso("2026-05-09T23:51:21+00:00")
+    assert parsed is not None
+
+
+def test_parse_iso_returns_none_for_garbage() -> None:
+    assert _parse_iso("not a timestamp") is None
+    assert _parse_iso(None) is None
+    assert _parse_iso("") is None
+    assert _parse_iso(12345) is None
+
+
+def test_silent_seconds_none_when_no_event() -> None:
+    assert _silent_seconds(None) is None
+
+
+def test_silent_seconds_grows_with_age() -> None:
+    past = datetime.now(timezone.utc) - timedelta(seconds=120)
+    s = _silent_seconds(past)
+    assert s is not None
+    # Tolerance for clock skew + scheduling jitter.
+    assert 119.0 <= s <= 121.5
+
+
+def test_silent_seconds_clamped_at_zero_for_future_timestamps() -> None:
+    """If the orchestrator clock is ahead, we clamp at 0 rather than
+    rendering a negative duration."""
+    future = datetime.now(timezone.utc) + timedelta(seconds=30)
+    assert _silent_seconds(future) == 0.0
+
+
+def test_silent_threshold_is_above_typical_warmup() -> None:
+    """Sanity: the threshold must outlive the longest expected agent
+    warm-up so healthy runs never trip it. 30 s covers Opus-4 cold start."""
+    assert SILENT_THRESHOLD_S >= 30.0
+
+
+def test_card_status_carries_last_event_at() -> None:
+    """The dataclass contract \u2014 silence rendering depends on this field
+    being populated from the API snapshot."""
+    when = datetime(2026, 5, 9, 23, 51, 21, tzinfo=timezone.utc)
+    s = _CardStatus(runtime="running", last_event_at=when)
+    assert s.last_event_at == when

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -306,3 +306,73 @@ def test_invalid_max_turns_fails_validation(tmp_path):
     )
     with pytest.raises(ConfigValidationError):
         build_service_config(load_workflow(path))
+
+
+# --- positive-int validation tightened in improve/observability-and-doctor ---
+
+@pytest.mark.parametrize("field,raw_value", [
+    ("max_concurrent_agents", 0),
+    ("max_concurrent_agents", -1),
+    ("max_retry_backoff_ms", 0),
+    ("max_retry_backoff_ms", -100),
+])
+def test_invalid_agent_int_fields_fail_validation(tmp_path, field, raw_value):
+    """Regression: previously these silently accepted 0/negative via
+    `_as_int`, leading to footguns (max_concurrent_agents=0 dispatches
+    nothing; max_retry_backoff_ms=0 produces a tight retry loop)."""
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            f"""\
+            ---
+            tracker: {{ kind: linear, project_slug: x, api_key: xx }}
+            agent: {{ {field}: {raw_value} }}
+            ---
+            body
+            """
+        ),
+    )
+    with pytest.raises(ConfigValidationError):
+        build_service_config(load_workflow(path))
+
+
+@pytest.mark.parametrize("kind,field", [
+    ("pi", "turn_timeout_ms"),
+    ("pi", "read_timeout_ms"),
+    ("claude", "turn_timeout_ms"),
+    ("codex", "turn_timeout_ms"),
+    ("gemini", "stall_timeout_ms"),
+])
+def test_invalid_backend_timeouts_fail_validation(tmp_path, kind, field):
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            f"""\
+            ---
+            tracker: {{ kind: linear, project_slug: x, api_key: xx }}
+            agent: {{ kind: {kind} }}
+            {kind}: {{ {field}: 0 }}
+            ---
+            body
+            """
+        ),
+    )
+    with pytest.raises(ConfigValidationError):
+        build_service_config(load_workflow(path))
+
+
+def test_invalid_polling_interval_fails_validation(tmp_path):
+    path = _write(
+        tmp_path,
+        textwrap.dedent(
+            """\
+            ---
+            tracker: { kind: linear, project_slug: x, api_key: xx }
+            polling: { interval_ms: 0 }
+            ---
+            body
+            """
+        ),
+    )
+    with pytest.raises(ConfigValidationError):
+        build_service_config(load_workflow(path))


### PR DESCRIPTION
Follow-up to #15 — discovered four additional improvements during smoke-testing
the first pass on a real `agent.kind=pi` refactor task, plus one race-condition
bug that was silently swallowing the `agent_turn_completed` log line that #15
introduced.

## Headline

After this PR, a healthy 1-turn pi run produces this log shape end-to-end —
none of the bracketed lines used to fire before:

```
INFO dispatch                          issue_id=SMOKE-1 attempt=null
INFO hook_completed                    hook=after_create
INFO hook_completed                    hook=before_run
INFO agent_session_started             session_id=019e0f56-…
INFO reconcile_skip_active_worker      state=Done last_event_age_s=3.1   ← NEW (race fix)
INFO agent_turn_completed              turn=1 input_tokens=93831 …       ← was missing on clean exits
INFO worker_turn_completed             turn=1 input_tokens=93831 …       ← NEW (cancellation-tolerant mirror)
INFO hook_completed                    hook=after_run                    ← was skipped because workspace got wiped
INFO worker_exit                       reason=normal error=null
```

## Five patches

### 1. stderr ring buffer (HIGH impact)

Pi/claude/gemini backends now keep `deque[20]` of recent stderr lines.
`TurnFailed` and the `EVENT_TURN_FAILED` payload include a `stderr_tail`
list and the joined tail is appended to the human-readable `reason`
string, so a failed turn self-explains:

```
WARN agent_turn_failed reason="pi exited with no agent_end event (rc=1); stderr: Error: not authenticated. Run /login first."
     stderr_tail=["Error: not authenticated. Run /login first."]
```

vs. before:

```
WARN agent_turn_failed reason="pi exited with no agent_end event (rc=1)"
```

### 2. Positive-integer config validation (MEDIUM)

`max_concurrent_agents=0` previously dispatched nothing silently.
`max_retry_backoff_ms=0` produced a tight retry loop. ~10 fields total
were read via `_as_int` which accepts `≤0`. Switched to
`_validated_positive_or_default` everywhere. Bad values now raise
`ConfigValidationError` at workflow-load time:

```
$ symphony doctor ./bad-workflow.md
FAIL  workflow load failed: config_validation_error: agent.max_concurrent_agents must be a positive integer (value=0)
```

### 3. TUI silent-for-Ns indicator (MEDIUM)

Running cards grow a yellow `silent Ns` badge once their `last_event_at`
is older than 30 s — visual stall detection without polling logs/JSON.
`SILENT_THRESHOLD_S` chosen just above Opus-4 cold-start so healthy runs
never trip it.

### 4. Pi compaction + auto-retry events (LOW-MEDIUM)

`pi --mode json` emits `compaction_start` / `compaction_end` /
`auto_retry_start` / `auto_retry_end` events. PiBackend used to drop
them into `EVENT_OTHER_MESSAGE` (invisible). Now translated to two new
normalized events `EVENT_COMPACTION` / `EVENT_AGENT_RETRY` and logged
at INFO so a sudden token-count drop on the next turn is attributable:

```
INFO agent_compaction phase=start reason=threshold
INFO agent_compaction phase=end   reason=threshold tokens_before=48000
```

### 5. Reconcile race that silently dropped `agent_turn_completed` (BUG)

**Discovered while smoke-testing #15.** Despite the listener-side
`log.info("agent_turn_completed", …)` being correctly registered in
8e94315, the line never fired on healthy runs.

Root cause: when pi finishes its work organically, it writes Done to
the ticket file and exits. The orchestrator's reconcile loop (5 s tick)
detects state=Done and immediately:

1. cancels `entry.worker_task`
2. removes the workspace directory

This races the worker's own natural-exit path. Reconcile usually wins
because the worker takes ~10–20 ms to `_refresh_issue_state`, break the
loop, and reach `client.stop()`. When reconcile wins, it cancels the
worker mid-`_emit(EVENT_TURN_COMPLETED)`, the listener never runs, the
log line is lost, and as a side-effect the workspace gets wiped before
`after_run` can capture artefacts (the source of the
`hook_after_run_skipped_missing_cwd` INFO line we added in #15).

**Fix — two layers:**

- **Reconcile grace period.** Reconcile now checks
  `last_codex_timestamp`. If `< 10 s` old (worker is clearly still
  active), it logs `reconcile_skip_active_worker` and lets the worker
  exit on its own. Stale workers (>10 s silent) still get force-cancel
  as the safety net.
- **Race-tolerant logging.** Orchestrator now also logs
  `worker_turn_completed` directly on the worker's hot path immediately
  after `run_turn` returns — synchronous, can't be cancelled away.

## Verification

Real `agent.kind=pi` smoke run, kanban/SMOKE-1.md, on the seeded
`number.ts` fixture. Before patch #5 (after #15 only):

```
INFO agent_session_started     session_id=…
INFO reconcile_terminate_terminal state=Done
INFO hook_after_run_skipped_missing_cwd
INFO worker_exit               reason=normal error=null
```

After this PR:

```
INFO agent_session_started        session_id=…
INFO reconcile_skip_active_worker state=Done last_event_age_s=3.1
INFO agent_turn_completed         turn=1 input_tokens=93831 output_tokens=1056 total_tokens=94887
INFO worker_turn_completed        turn=1 input_tokens=93831 …
INFO hook_completed               hook=after_run stdout="run finished at …"
INFO worker_exit                  reason=normal error=null
```

## Tests

166 → **188 pass** (+22 net new), 2 skipped, 0 fail.

- `tests/test_backends.py` — stderr ring buffer (3) + compaction/retry event flow with a fake JSONL stream (1)
- `tests/test_workflow.py` — positive-int validation parametrised across `pi/claude/codex/gemini × turn/read/stall_timeout_ms`, `agent.max_concurrent_agents`, `max_retry_backoff_ms`, `polling.interval_ms`
- `tests/test_tui.py` (NEW) — `_parse_iso` edge cases, `_silent_seconds`, `SILENT_THRESHOLD_S` sanity, `_CardStatus.last_event_at` propagation

## Out of scope

- Session ID persistence across symphony restarts — bigger architectural change
- DRY-ing `_stderr_blob` into a shared utility — two near-identical copies in pi/claude is fine for now
- TUI `silent Ns` test against a live render — `rich.Live` needs a TTY; helpers are tested directly instead

## Test plan for reviewers

```bash
git fetch origin
git checkout improve/observability-pass-2
pip install -e ".[dev]"
pytest -q                                       # 188 pass / 2 skipped

# config validation surfaces clearly
echo '---
tracker: { kind: file, board_root: ./kanban }
agent: { max_concurrent_agents: 0 }
---' > /tmp/bad.md
symphony doctor /tmp/bad.md                     # expect FAIL with clear message
```

End-to-end on a `agent.kind=pi` workflow:

```bash
symphony ./WORKFLOW.md --port 9988 2>> log/symphony.log &
grep -E '(reconcile|agent_|worker_)' log/symphony.log
# verify reconcile_skip_active_worker fires on clean exits
# and after_run hook actually runs
```
