### PR TITLE
fix(codex): parse v2 token usage shape; orchestrator: log worker_turn_started

### DIFF
--- a/src/symphony/backends/codex.py
+++ b/src/symphony/backends/codex.py
@@ -466,11 +466,31 @@ class CodexAppServerBackend:
     async def _handle_notification(self, msg: dict[str, Any]) -> None:
         method = msg.get("method") or msg.get("event") or ""
         params = msg.get("params") or msg.get("payload") or msg
-        # ----- token usage (unchanged in v2) -----
+        # ----- token usage -----
+        # Two payload shapes seen in the wild:
+        #   1. Legacy (≤0.129):  params.totals.{input_tokens,output_tokens,total_tokens}
+        #   2. v2 (0.130+):       params.tokenUsage.total.{inputTokens,outputTokens,
+        #                          totalTokens, cachedInputTokens, reasoningOutputTokens}
+        # Both are reported as ABSOLUTE cumulative totals — we overwrite
+        # rather than accumulate.
         if method == NOTIF_THREAD_TOKEN_USAGE or method.endswith(
             "/tokenUsage/updated"
         ):
-            self._update_tokens_absolute(params.get("totals") or params)
+            handled = False
+            # Try v2 shape first (more recent codex builds).
+            if isinstance(params, dict):
+                tu = params.get("tokenUsage")
+                if isinstance(tu, dict):
+                    block = tu.get("total") or tu.get("last")
+                    if isinstance(block, dict):
+                        self._update_tokens_from_v2_block(block)
+                        handled = True
+            # Fall back to legacy `totals` (or top-level snake_case).
+            if not handled:
+                self._update_tokens_absolute(
+                    params.get("totals") if isinstance(params, dict) else None
+                    or params
+                )
             return
         # ----- rate limits (v2: account/rateLimits/updated) -----
         if method == NOTIF_RATE_LIMITS or method.endswith("/rateLimits"):
@@ -517,6 +537,38 @@ class CodexAppServerBackend:
         for key in ("input_tokens", "output_tokens", "total_tokens"):
             if isinstance(payload.get(key), (int, float)):
                 self._latest_usage[key] = int(payload[key])
+
+    def _update_tokens_from_v2_block(self, usage: dict[str, Any]) -> None:
+        """Codex 0.130+ thread/tokenUsage/updated.tokenUsage.total shape.
+
+        Fields seen in the wild (camelCase, captured from a real run):
+          inputTokens, cachedInputTokens, outputTokens,
+          reasoningOutputTokens, totalTokens
+
+        Symphony's three-bucket model has no separate cache or reasoning
+        buckets, so cached input is folded into input_tokens and reasoning
+        output is folded into output_tokens. The reported totalTokens is
+        used as-is when present (it already reflects the sum on codex's
+        side); when absent we recompute from the folded buckets.
+
+        These notifications report ABSOLUTE cumulative totals (not deltas),
+        so we overwrite rather than accumulate.
+        """
+        if not isinstance(usage, dict):
+            return
+        in_t = int(usage.get("inputTokens") or 0)
+        cached = int(usage.get("cachedInputTokens") or 0)
+        out_t = int(usage.get("outputTokens") or 0)
+        reasoning = int(usage.get("reasoningOutputTokens") or 0)
+        folded_in = in_t + cached
+        folded_out = out_t + reasoning
+        total = usage.get("totalTokens")
+        folded_total = (
+            int(total) if isinstance(total, (int, float)) else folded_in + folded_out
+        )
+        self._latest_usage["input_tokens"] = folded_in
+        self._latest_usage["output_tokens"] = folded_out
+        self._latest_usage["total_tokens"] = folded_total
 
     async def _handle_approval(self, params: dict[str, Any]) -> None:
         # Best-effort auto-approve. The legacy `respondToApproval` method is

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -499,6 +499,18 @@ class Orchestrator:
                         prompt = first_prompt
 
                     self._running[issue.id].turn_count = turn_number
+                    # Symmetry with worker_turn_completed — a single line per
+                    # turn-start so multi-turn runs (especially slow ones
+                    # like gemini -p where a single turn can take 60-90s)
+                    # don't look stuck between turns.
+                    log.info(
+                        "worker_turn_started",
+                        issue_id=issue.id,
+                        identifier=self._running[issue.id].issue.identifier,
+                        turn=turn_number,
+                        max_turns=cfg.agent.max_turns,
+                        is_continuation=is_continuation,
+                    )
                     try:
                         await client.run_turn(prompt=prompt, is_continuation=is_continuation)
                     except (TurnTimeout, TurnFailed, TurnCancelled, TurnInputRequired) as exc:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -708,3 +708,116 @@ def test_pi_consume_stream_surfaces_compaction_events(tmp_path: Path) -> None:
     assert retry_events[0]["payload"]["max_attempts"] == 3
     assert retry_events[1]["payload"]["phase"] == "end"
     assert retry_events[1]["payload"]["success"] is True
+
+
+# --- Codex 0.130+ thread/tokenUsage/updated v2 schema (telemetry-bug regression) ---
+
+@pytest.mark.asyncio
+async def test_codex_handles_v2_token_usage_camelcase_shape(tmp_path: Path) -> None:
+    """Regression: codex 0.130 changed the `thread/tokenUsage/updated`
+    payload schema. Before this fix, every codex turn reported 0 tokens
+    because the dispatcher only knew the legacy `params.totals.{snake_case}`
+    shape, while codex now sends `params.tokenUsage.total.{camelCase}`.
+
+    Probe shape captured from a real symphony+codex run:
+      {method: thread/tokenUsage/updated, params: {threadId, turnId,
+        tokenUsage: {total: {totalTokens, inputTokens, cachedInputTokens,
+                              outputTokens, reasoningOutputTokens},
+                     last: {...}, modelContextWindow: 258400}}}
+    """
+    cfg = _make_cfg("codex", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = CodexAppServerBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    await backend._handle_notification(
+        {
+            "method": NOTIF_THREAD_TOKEN_USAGE,
+            "params": {
+                "threadId": "019e0f77-db36-7183-b09c-da8e511f56a5",
+                "turnId": "019e0f77-e068-7572-84ad-575586b5c63b",
+                "tokenUsage": {
+                    "total": {
+                        "totalTokens": 32595,
+                        "inputTokens": 32325,
+                        "cachedInputTokens": 3456,
+                        "outputTokens": 270,
+                        "reasoningOutputTokens": 170,
+                    },
+                    "last": {
+                        "totalTokens": 999,  # ignored — total wins
+                        "inputTokens": 999,
+                        "outputTokens": 99,
+                    },
+                    "modelContextWindow": 258400,
+                },
+            },
+        }
+    )
+    # cachedInputTokens folds into input_tokens; reasoningOutputTokens folds
+    # into output_tokens; totalTokens used as-is.
+    assert backend.latest_usage == {
+        "input_tokens": 32325 + 3456,   # 35781
+        "output_tokens": 270 + 170,     # 440
+        "total_tokens": 32595,
+    }
+
+
+@pytest.mark.asyncio
+async def test_codex_v2_falls_back_to_last_when_total_absent(tmp_path: Path) -> None:
+    """When `tokenUsage.total` is missing, fall back to `tokenUsage.last`."""
+    cfg = _make_cfg("codex", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = CodexAppServerBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    await backend._handle_notification(
+        {
+            "method": NOTIF_THREAD_TOKEN_USAGE,
+            "params": {
+                "tokenUsage": {
+                    "last": {
+                        "inputTokens": 100,
+                        "outputTokens": 20,
+                        "totalTokens": 120,
+                    }
+                },
+            },
+        }
+    )
+    assert backend.latest_usage == {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "total_tokens": 120,
+    }
+
+
+@pytest.mark.asyncio
+async def test_codex_legacy_totals_path_still_works(tmp_path: Path) -> None:
+    """Legacy snake_case `params.totals.*` shape must still parse — covers
+    older codex builds and the upstream mock_codex test fixture."""
+    cfg = _make_cfg("codex", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = CodexAppServerBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    await backend._handle_notification(
+        {
+            "method": NOTIF_THREAD_TOKEN_USAGE,
+            "params": {
+                "totals": {
+                    "input_tokens": 50,
+                    "output_tokens": 10,
+                    "total_tokens": 60,
+                }
+            },
+        }
+    )
+    assert backend.latest_usage == {
+        "input_tokens": 50,
+        "output_tokens": 10,
+        "total_tokens": 60,
+    }


### PR DESCRIPTION
Two follow-ups discovered by post-merge real-CLI smoke testing of #16
against `codex 0.130.0`, `claude 2.1.138`, `gemini 0.41.2`, and `pi 0.74.0`.

## Headline

Real codex run, before vs. after this PR:

| | Before | After |
|---|---|---|
| `agent_turn_completed` | `input_tokens=0 output_tokens=0 total_tokens=0` | `input_tokens=231738 output_tokens=595 total_tokens=131350` |
| `worker_turn_started` | (no such log line) | `worker_turn_started turn=1 max_turns=2 is_continuation=false` |

## Bug A — codex backend reports 0 tokens for every turn

Codex 0.130 changed the `thread/tokenUsage/updated` notification schema.
Symphony's dispatcher only knew the legacy shape, so usage silently broke
on upgrade.

```yaml
# Legacy (≤0.129)
params:
  totals:
    input_tokens: 32325
    output_tokens: 270
    total_tokens: 32595

# v2 (0.130+) — captured from a real symphony+codex run
params:
  threadId: 019e0f77-…
  turnId: 019e0f77-…
  tokenUsage:
    total:
      totalTokens: 32595
      inputTokens: 32325
      cachedInputTokens: 3456
      outputTokens: 270
      reasoningOutputTokens: 170
    last: { … same shape, per-turn instead of cumulative … }
    modelContextWindow: 258400
```

Two things changed at once:

- wrapper key: `totals` → `tokenUsage`, with `total` / `last` sub-keys
- field naming: `snake_case` → `camelCase`, with two new fields
  (`cachedInputTokens`, `reasoningOutputTokens`)

Fix:

- New `_update_tokens_from_v2_block` handler. Prefers `tokenUsage.total`
  (cumulative); falls back to `tokenUsage.last` if total is absent. Folds
  `cachedInputTokens` into `input_tokens` and `reasoningOutputTokens`
  into `output_tokens` (symphony has only three buckets); uses codex's
  reported `totalTokens` as-is.
- Legacy path preserved unchanged so older codex builds and the
  `mock_codex` test fixture keep working.

## Bug B — multi-turn runs look stuck between turns

After a turn completes, the worker enters its loop body for turn N+1 but
emits no log line until that turn's first agent event arrives. For slow
backends (`gemini -p ""` is 60–90 s/turn) this looks identical to a
hang. Added `worker_turn_started` (INFO) symmetric with the existing
`worker_turn_completed`, fired synchronously on the worker's hot path
right before `client.run_turn(...)`. Carries `turn`, `max_turns`,
`is_continuation` so operators can watch a 4-turn run progress 1→4 even
when each turn takes minutes.

## Verification

Real codex 0.130 smoke run, `agent.kind=codex`, 1-turn task:

```
INFO dispatch                          issue_id=CDX-V1
INFO hook_completed                    hook=after_create
INFO hook_completed                    hook=before_run
INFO agent_session_started             session_id=019e0f7a-2fc4-…
INFO worker_turn_started               turn=1 max_turns=2 is_continuation=false  ← NEW (Bug B)
INFO agent_turn_completed              turn=1 input_tokens=231738 output_tokens=595 total_tokens=131350  ← was 0/0/0 (Bug A)
INFO worker_turn_completed             turn=1 input_tokens=231738 output_tokens=595 total_tokens=131350
INFO worker_exit                       reason=normal error=null
```

## Tests

188 → **191 pass** (+3), 2 skipped, 0 fail.

- `test_codex_handles_v2_token_usage_camelcase_shape` — the real-world
  shape captured from a live run, including cache + reasoning folding
- `test_codex_v2_falls_back_to_last_when_total_absent` — `tokenUsage.last`
  fallback when cumulative isn't reported
- `test_codex_legacy_totals_path_still_works` — ensures the snake_case
  `totals` shape (mock_codex fixture, older codex builds) keeps parsing

## Why this wasn't caught before

The codex e2e smoke we ran in #16 verified that `agent_turn_completed`
fires end-to-end and didn't notice the 0/0/0 token values were anomalous.
This PR's smoke run paired the new log with **expected non-zero token
counts**, which immediately revealed the dispatch mismatch. Lesson: smoke
runs should assert non-trivial values, not just presence.

## Test plan for reviewers

```bash
git fetch origin
git checkout fix/codex-tokens-and-turn-visibility
pip install -e ".[dev]"
pytest -q                                         # 191 pass / 2 skipped

# Real CLI verify (requires `codex` 0.130+):
mkdir -p board && symphony board init ./board >/dev/null
symphony board new T1 "verify token telemetry"
symphony ./WORKFLOW.md --port 9988 2>> log/symphony.log &
# After ~1 min:
grep agent_turn_completed log/symphony.log
# Expect non-zero input_tokens / output_tokens / total_tokens.
```
