### PR TITLE
feat(workflow): v0.6.0 — accuracy + harness upgrade (11 items)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ htmlcov/
 
 # Runtime cache written by tui-open.sh on each launch (contains absolute paths)
 /.tui-launcher.command
+kanban_demo_claude/
+kanban_demo_codex/
+tmp_workspaces/
+WORKFLOW.demo.*.md
+/.symphony*-demo/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,90 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-05-17 — Workflow accuracy + harness upgrade
+
+Eleven coordinated changes across the agent prompts and the orchestrator
+to make ticket outcomes more predictable and the system observable. Plan
+doc lives at `docs/improvements/workflow-v0.5.2.md`.
+
+### Added — Prompt contracts (agent-visible)
+- **Plan emits a Definition of Done** (`A1`): `plan.md` now requires two
+  new sections — `## Acceptance Tests` (test signatures, one per AC) and
+  `## Done Signals` (observable file paths, stdout substrings, exit
+  codes, HTTP shapes). `qa.md` scores them in a new `## AC Scorecard`
+  sub-block; missing rows fail QA. No more guessing what "done" means.
+- **Rewinds scope to flagged items** (`A2` — prompt half): when the
+  orchestrator dispatches a Review → In Progress or QA → In Progress
+  rewind, it injects `SYMPHONY_REWIND_SCOPE` as JSON. `in-progress.md`
+  step 2 instructs the agent to touch only those files; touching others
+  appends a `## Scope Expansion` rationale (non-blocking).
+- **Explore emits a scored reuse inventory** (`A3`):
+  `reuse-inventory.md` becomes a required output with a
+  `candidate | path:line | reuse_fit | adapt_cost | notes` table.
+  `plan.md` gains a `reuse_from` column and requires `## Plan Rationale`
+  when any `reuse_fit >= 0.7` row is rejected.
+- **Review emits a dedicated Security Audit** (`B2`): `review.md` adds a
+  `## Security Audit` section with exactly 7 rows (secrets,
+  input-validation, sql-injection, xss, csrf, authz, rate-limit). Any
+  `fail` row auto-promotes to a CRITICAL row in `## Review Findings`
+  and triggers rewind.
+- **Wiki entries record observability hooks** (`B3`): the Learn wiki
+  template adds an `**Observability hooks:**` block under
+  `## Technical Reference` (log / metric / trace anchors with
+  `path:line`). `plan.md` candidate table gains an `observability`
+  column so Plan declares intent up front. Both KO and EN templates
+  updated.
+
+### Added — Harness (orchestrator / hooks)
+- **System-side conflict pre-check at dispatch** (`C1`): the orchestrator
+  parses `## Touched Files` from every in-flight ticket and refuses to
+  dispatch a candidate whose touched paths overlap. The candidate is
+  moved to `Blocked` with an auto-generated `## Conflict` section. The
+  agent-side conflict pre-check in `in-progress.md` step 1 is removed.
+- **Adaptive token budget feedback to prompts** (`C3`): per-state EMA
+  (alpha 0.3) of completion tokens persists to `.symphony/token_ema.json`
+  across orchestrator restarts. Dispatch injects `SYMPHONY_TOKEN_EMA`
+  and `SYMPHONY_TOKEN_BUDGET` so the agent sees both the historical
+  per-stage cost and the hard cap.
+- **TDD enforcement marker in after_run hook** (`B1`): the per-turn
+  commit subject is prefixed `[no-test]` when the diff has production
+  code outside `tests/ docs/ kanban/ .symphony/` and no paired test
+  file. `review.md` step 3 scans for the marker and promotes each
+  occurrence to a HIGH severity finding (docs-only turns exempted).
+- **Backend stall-progress predicate is abstract** (`C2`): the meta-event
+  filter that fixed OLV-002 lives on a `BaseAgentBackend` superclass via
+  `is_progress_event(event)`. `ClaudeCodeBackend` and
+  `CodexAppServerBackend` override; `pi.py` and `gemini.py` inherit the
+  conservative default (every event counts as progress). New backends
+  opt in by overriding one method.
+- **`after_create` hook extracted to a versioned script** (`C4`): the
+  200-line bash heredoc previously embedded in WORKFLOW.md is now
+  `scripts/symphony-setup-worktree.sh`. The hook is a one-liner that
+  invokes the script. Cross-platform behaviour (Git Bash on Windows
+  with `mklink /J`) preserved.
+- **`symphony wiki-sweep` CLI + scheduled invocation** (`C5`): new
+  subcommand scans `docs/llm-wiki/` for duplicate slugs, INDEX↔file
+  orphans, missing files, and entries older than 90 days. Exit code is
+  non-zero on duplicate / orphan / missing-file findings. The
+  orchestrator runs the sweep after every Nth `Done` transition
+  (default `wiki.sweep_every_n: 10`; set 0 to disable). The Learn
+  prompt is reduced to per-ticket integrity updates plus the sweep
+  delegation, saving model tokens.
+
+### Fixed
+- `after_run` hook now uses a POSIX-portable `IFS=` trick
+  (`NL=$(printf '\nx'); NL=${NL%x}`) so the YAML literal block parses
+  cleanly. The previous `IFS='\n'` literal terminated the YAML block
+  prematurely on the bare closing quote at column 0.
+
+### Note
+- This release ships the eleven items as one logical bundle because the
+  prompt contracts depend on the harness-injected env vars (`A2` ↔
+  orchestrator, `B1` prompt half ↔ `after_run` marker). Partial rollout
+  is not supported — upgrade `WORKFLOW.md` and the package together.
+
+## [Pre-0.6.0]
+
 ### Added
 - macOS host wake-lock: while the orchestrator (and the `service start`
   detached child) is running, Symphony spawns `caffeinate -d -i -w <pid>`

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -99,8 +99,8 @@ hooks:
           ;;
       esac
       case "$f" in
-        tests/*|docs/*|kanban/*|.symphony/*)
-          : # carve-out: never counts as production change
+        tests/*|docs/*|kanban/*|.symphony/*|*.md|LICENSE|LICENSE.*|NOTICE|CHANGELOG*|README*|AGENTS.md|GEMINI.md)
+          : # carve-out: docs/license/wiki edits never count as production change
           ;;
         *)
           PROD_CHANGED=1

--- a/WORKFLOW.example.md
+++ b/WORKFLOW.example.md
@@ -26,6 +26,13 @@ tracker:
 polling:
   interval_ms: 30000
 
+# Wiki integrity sweep — see `symphony wiki-sweep --help`. The orchestrator
+# runs the sweep automatically after every Nth `Done` transition. Set
+# `sweep_every_n: 0` to disable; the manual CLI still works either way.
+wiki:
+  sweep_every_n: 10
+  root: ./docs/llm-wiki
+
 workspace:
   root: ~/symphony_workspaces
 
@@ -38,46 +45,13 @@ hooks:
   # If your code lives in a *different* remote than where WORKFLOW.md
   # sits (common with Linear setups where the config repo is config-only),
   # replace the worktree commands with a `git clone <remote> .` instead.
+  # Body extracted to scripts/symphony-setup-worktree.sh — see C4 in
+  # docs/improvements/workflow-v0.5.2.md. The script worktree-adds the
+  # ticket branch, records basesha/basebranch/mergetargetbranch, and (when
+  # a host-owned `kanban/` exists) symlinks/junctions it back. Linear
+  # trackers read from their API so the symlink loop is a no-op here.
   after_create: |
-    set -euo pipefail
-    ISSUE_ID="$(basename "$PWD")"
-    HOST_REPO="${SYMPHONY_WORKFLOW_DIR:?SYMPHONY_WORKFLOW_DIR not set}"
-    WORKTREE_PATH="$PWD"
-    BRANCH="symphony/${ISSUE_ID}"
-    cd "$HOST_REPO"
-    BASE_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || git branch --show-current 2>/dev/null || true)"
-    FEATURE_BASE_BRANCH="${SYMPHONY_FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
-    MERGE_TARGET_BRANCH="${SYMPHONY_MERGE_TARGET_BRANCH:-${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}}"
-    # `git worktree add` (git >= 2.30) tolerates an existing *empty* target
-    # directory — which is exactly what Symphony pre-creates as the workspace.
-    # We rely on that here to avoid an rmdir that on Windows races against
-    # the file-indexer / AV scan and used to trip the dispatcher into a
-    # `Device or resource busy` retry loop.
-    #
-    # A prior crashed attempt may have left `.git/worktrees/<ID>` registered;
-    # detach it first so the next `add` doesn't fail with
-    # "missing but already registered" or "already checked out".
-    git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
-    git worktree prune 2>/dev/null || true
-    if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
-      git worktree add "$WORKTREE_PATH" "$BRANCH"
-    elif [ -n "$FEATURE_BASE_BRANCH" ]; then
-      git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$FEATURE_BASE_BRANCH"
-    else
-      git worktree add "$WORKTREE_PATH" -b "$BRANCH"
-    fi
-    # Record the fork point so commit_workspace_on_done can `git reset --soft`
-    # back to it and squash all per-turn work into a single ticket commit.
-    # Use --worktree so the value is scoped to .git/worktrees/<ID>/config.gitwt;
-    # writing without the flag leaks into the host repo's shared .git/config
-    # and corrupts auto_commit for unrelated workspaces nested in the host.
-    git -C "$WORKTREE_PATH" config extensions.worktreeConfig true
-    git -C "$WORKTREE_PATH" config --worktree symphony.basesha "$(git -C "$WORKTREE_PATH" rev-parse HEAD)"
-    git -C "$WORKTREE_PATH" config --worktree symphony.basebranch "${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
-    git -C "$WORKTREE_PATH" config --worktree symphony.mergetargetbranch "${MERGE_TARGET_BRANCH:-}"
-    # Linear tracker reads from its API, not the file system, so no
-    # symlink-back step is needed. (For tracker.kind=file, symlink only
-    # host-owned board roots such as kanban — see WORKFLOW.file.example.md.)
+    bash "$SYMPHONY_WORKFLOW_DIR/scripts/symphony-setup-worktree.sh"
   before_run: |
     # NEVER `git reset --hard` inside a worktree — it discards in-progress
     # work between turns. Just refresh remotes; let the agent decide if/when
@@ -97,12 +71,88 @@ hooks:
       echo "run finished at $(date) (no changes)"
       exit 0
     fi
+    # Classify the staged diff so the wip subject carries machine-readable
+    # markers. `[no-test]` = production code changed with no paired test
+    # file in the same diff (workflow-v0.5.2 § B1 — review.md promotes it
+    # to a HIGH finding). `[scope-expand]` = a rewind dispatch (set by the
+    # orchestrator when SYMPHONY_REWIND_SCOPE is exported) but the diff
+    # touched a file outside the parsed scope list (workflow-v0.5.2 § A2).
+    # Both markers can stack.
+    STAGED_FILES="$(git diff --cached --name-only 2>/dev/null || true)"
+    PROD_CHANGED=0
+    TESTS_CHANGED=0
+    SCOPE_EXPAND=0
+    SCOPE_FILES=""
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ]; then
+      SCOPE_FILES="$(printf '%s' "$SYMPHONY_REWIND_SCOPE" \
+        | tr ',' '\n' \
+        | sed -n 's/.*"file"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+    fi
+    NL=$(printf '\nx'); NL=${NL%x}
+    OLDIFS="$IFS"
+    IFS="$NL"
+    for f in $STAGED_FILES; do
+      [ -n "$f" ] || continue
+      case "$f" in
+        tests/*|*_test.py|*.test.ts|*.test.tsx|*_test.go)
+          TESTS_CHANGED=1
+          ;;
+      esac
+      case "$f" in
+        tests/*|docs/*|kanban/*|.symphony/*)
+          : # carve-out: never counts as production change
+          ;;
+        *)
+          PROD_CHANGED=1
+          ;;
+      esac
+      if [ -n "$SCOPE_FILES" ] && [ "$SCOPE_EXPAND" = 0 ]; then
+        in_scope=0
+        for s in $SCOPE_FILES; do
+          if [ "$f" = "$s" ]; then
+            in_scope=1
+            break
+          fi
+        done
+        if [ "$in_scope" = 0 ]; then
+          SCOPE_EXPAND=1
+        fi
+      fi
+    done
+    IFS="$OLDIFS"
+    PREFIX=""
+    if [ "$PROD_CHANGED" = 1 ] && [ "$TESTS_CHANGED" = 0 ]; then
+      PREFIX="${PREFIX}[no-test]"
+    fi
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ] && [ "$SCOPE_EXPAND" = 1 ]; then
+      PREFIX="${PREFIX}[scope-expand]"
+    fi
     # Honors any pre-commit hooks in the host repo — if they fail, this
     # turn's snapshot fails and the next turn picks up where files are.
     MSG="$(sed -n '1{s/^[[:space:]]*//;s/[[:space:]]*$//;p;q;}' .symphony/commit-message.txt 2>/dev/null || true)"
     [ -n "$MSG" ] || MSG="turn $(date -u +%FT%TZ)"
     case "$MSG" in wip:*) COMMIT_MSG="$MSG" ;; *) COMMIT_MSG="wip: $MSG" ;; esac
     LAST="$(git log -1 --format=%s 2>/dev/null || echo "")"
+    # On amend, preserve any markers the previous turn already set so a
+    # later test-passing turn doesn't drop the historical `[no-test]`.
+    # Markers are sticky within a wip subject.
+    PRIOR_PREFIX=""
+    case "$LAST" in
+      *"[no-test]"*) PRIOR_PREFIX="${PRIOR_PREFIX}[no-test]" ;;
+    esac
+    case "$LAST" in
+      *"[scope-expand]"*) PRIOR_PREFIX="${PRIOR_PREFIX}[scope-expand]" ;;
+    esac
+    MERGED_PREFIX=""
+    case "$PRIOR_PREFIX$PREFIX" in
+      *"[no-test]"*) MERGED_PREFIX="${MERGED_PREFIX}[no-test]" ;;
+    esac
+    case "$PRIOR_PREFIX$PREFIX" in
+      *"[scope-expand]"*) MERGED_PREFIX="${MERGED_PREFIX}[scope-expand]" ;;
+    esac
+    if [ -n "$MERGED_PREFIX" ]; then
+      COMMIT_MSG="${MERGED_PREFIX} ${COMMIT_MSG}"
+    fi
     if [ "${LAST#wip:}" != "$LAST" ]; then
       git -c user.email=symphony@local -c user.name=symphony \
           commit --amend -m "$COMMIT_MSG" >/dev/null 2>&1 || true

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -25,6 +25,13 @@ tracker:
 polling:
   interval_ms: 30000
 
+# Wiki integrity sweep — see `symphony wiki-sweep --help`. The orchestrator
+# runs the sweep automatically after every Nth `Done` transition. Set
+# `sweep_every_n: 0` to disable; the manual CLI still works either way.
+wiki:
+  sweep_every_n: 10
+  root: ./docs/llm-wiki
+
 workspace:
   root: ~/symphony_workspaces
   # Re-run after_create when reusing an existing ticket workspace. Use this
@@ -40,91 +47,14 @@ hooks:
   #
   # If your code lives in a *different* remote than the WORKFLOW.md repo,
   # replace the worktree commands with `git clone <remote> .` instead.
+  # Body extracted to scripts/symphony-setup-worktree.sh — see C4 in
+  # docs/improvements/workflow-v0.5.2.md. The script provisions the
+  # `symphony/<ID>` worktree, records basesha/basebranch/mergetargetbranch,
+  # symlinks (or Windows-junctions) `kanban/` back to the host so
+  # FileBoardTracker sees state transitions, and primes a `.venv` when
+  # `.[dev]` is installable from the host repo.
   after_create: |
-    set -euo pipefail
-    ISSUE_ID="$(basename "$PWD")"
-    HOST_REPO="${SYMPHONY_WORKFLOW_DIR:?SYMPHONY_WORKFLOW_DIR not set}"
-    WORKTREE_PATH="$PWD"
-    BRANCH="symphony/${ISSUE_ID}"
-    cd "$HOST_REPO"
-    BASE_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || git branch --show-current 2>/dev/null || true)"
-    FEATURE_BASE_BRANCH="${SYMPHONY_FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
-    MERGE_TARGET_BRANCH="${SYMPHONY_MERGE_TARGET_BRANCH:-${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}}"
-    # `git worktree add` (git >= 2.30) tolerates an existing *empty* target
-    # directory — which is exactly what Symphony pre-creates as the workspace.
-    # We rely on that here to avoid an rmdir that on Windows races against
-    # the file-indexer / AV scan and used to trip the dispatcher into a
-    # `Device or resource busy` retry loop.
-    #
-    # A prior crashed attempt may have left `.git/worktrees/<ID>` registered;
-    # detach it first so the next `add` doesn't fail with
-    # "missing but already registered" or "already checked out".
-    git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
-    git worktree prune 2>/dev/null || true
-    if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
-      git worktree add "$WORKTREE_PATH" "$BRANCH"
-    elif [ -n "$FEATURE_BASE_BRANCH" ]; then
-      git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$FEATURE_BASE_BRANCH"
-    else
-      git worktree add "$WORKTREE_PATH" -b "$BRANCH"
-    fi
-    cd "$WORKTREE_PATH"
-    # Record the fork point so commit_workspace_on_done can `git reset --soft`
-    # back to it and squash all per-turn work into a single ticket commit.
-    # Use --worktree so the value is scoped to .git/worktrees/<ID>/config.gitwt;
-    # writing without the flag leaks into the host repo's shared .git/config
-    # and corrupts auto_commit for unrelated workspaces nested in the host.
-    git config extensions.worktreeConfig true
-    git config --worktree symphony.basesha "$(git rev-parse HEAD)"
-    git config --worktree symphony.basebranch "${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
-    git config --worktree symphony.mergetargetbranch "${MERGE_TARGET_BRANCH:-}"
-    # Link tracker-managed directories back to host so agent state
-    # transitions are visible to Symphony's FileBoardTracker (which reads
-    # board_root from the host repo, not from this worktree's checkout).
-    #
-    # Cross-platform: on POSIX use `ln -s`; on Windows Git Bash without
-    # admin / Developer Mode, `ln -s` silently *copies* the source, leaving
-    # the worktree's kanban/ as a divergent real directory — the tracker
-    # never sees the agent's Done transition and dispatches forever. The
-    # portable fix is a Windows directory junction (`mklink /J`), which
-    # behaves like a real directory to every tool, works cross-volume, and
-    # needs no elevation.
-    _symphony_link_dir() {
-      local target="$1" source="$2"
-      rm -rf "$target"
-      if [ "${OS:-}" = "Windows_NT" ] && command -v cmd.exe >/dev/null 2>&1; then
-        # MSYS bash mangles backslashes inside `cmd.exe //c "..."` argument
-        # strings (e.g. `\U` in `\Users` becomes garbled), so route through
-        # a tiny .bat that takes %1/%2 — bat files receive properly quoted
-        # args untouched. Also handles paths containing spaces.
-        local target_win source_win bat bat_win
-        target_win="$(cygpath -w "$(realpath -m "$target")")"
-        source_win="$(cygpath -w "$source")"
-        bat="${TEMP:-/tmp}/symphony-link-$$-$RANDOM.bat"
-        printf '@echo off\r\nmklink /J %%1 %%2\r\n' > "$bat"
-        bat_win="$(cygpath -w "$bat")"
-        cmd.exe //c "$bat_win" "$target_win" "$source_win" >/dev/null
-        rm -f "$bat"
-      else
-        ln -s "$source" "$target"
-      fi
-    }
-    for dir in kanban; do
-      [ -e "$HOST_REPO/$dir" ] || continue
-      # Hide host-owned symlink/junction roots from this worktree's git
-      # status. Otherwise a reused workspace can record kanban as a 120000
-      # symlink blob and delete the real tree on the ticket branch.
-      tracked_file="$(git rev-parse --git-path "symphony-${dir}-tracked")"
-      git ls-files -z -- "$dir" > "$tracked_file" || true
-      if [ -s "$tracked_file" ]; then
-        xargs -0 git update-index --skip-worktree -- < "$tracked_file" || true
-      fi
-      rm -f "$tracked_file"
-      exclude_file="$(git rev-parse --git-path info/exclude)"
-      mkdir -p "$(dirname "$exclude_file")"
-      grep -qxF "$dir" "$exclude_file" 2>/dev/null || echo "$dir" >> "$exclude_file"
-      _symphony_link_dir "$dir" "$HOST_REPO/$dir"
-    done
+    bash "$SYMPHONY_WORKFLOW_DIR/scripts/symphony-setup-worktree.sh"
   before_run: |
     # NEVER `git reset --hard` inside a worktree — it discards in-progress
     # work between turns. Just refresh remotes; let the agent decide if/when
@@ -158,12 +88,88 @@ hooks:
       echo "run finished at $(date) (no changes)"
       exit 0
     fi
+    # Classify the staged diff so the wip subject carries machine-readable
+    # markers. `[no-test]` = production code changed with no paired test
+    # file in the same diff (workflow-v0.5.2 § B1 — review.md promotes it
+    # to a HIGH finding). `[scope-expand]` = a rewind dispatch (set by the
+    # orchestrator when SYMPHONY_REWIND_SCOPE is exported) but the diff
+    # touched a file outside the parsed scope list (workflow-v0.5.2 § A2).
+    # Both markers can stack.
+    STAGED_FILES="$(git diff --cached --name-only 2>/dev/null || true)"
+    PROD_CHANGED=0
+    TESTS_CHANGED=0
+    SCOPE_EXPAND=0
+    SCOPE_FILES=""
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ]; then
+      SCOPE_FILES="$(printf '%s' "$SYMPHONY_REWIND_SCOPE" \
+        | tr ',' '\n' \
+        | sed -n 's/.*"file"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+    fi
+    NL=$(printf '\nx'); NL=${NL%x}
+    OLDIFS="$IFS"
+    IFS="$NL"
+    for f in $STAGED_FILES; do
+      [ -n "$f" ] || continue
+      case "$f" in
+        tests/*|*_test.py|*.test.ts|*.test.tsx|*_test.go)
+          TESTS_CHANGED=1
+          ;;
+      esac
+      case "$f" in
+        tests/*|docs/*|kanban/*|.symphony/*)
+          : # carve-out: never counts as production change
+          ;;
+        *)
+          PROD_CHANGED=1
+          ;;
+      esac
+      if [ -n "$SCOPE_FILES" ] && [ "$SCOPE_EXPAND" = 0 ]; then
+        in_scope=0
+        for s in $SCOPE_FILES; do
+          if [ "$f" = "$s" ]; then
+            in_scope=1
+            break
+          fi
+        done
+        if [ "$in_scope" = 0 ]; then
+          SCOPE_EXPAND=1
+        fi
+      fi
+    done
+    IFS="$OLDIFS"
+    PREFIX=""
+    if [ "$PROD_CHANGED" = 1 ] && [ "$TESTS_CHANGED" = 0 ]; then
+      PREFIX="${PREFIX}[no-test]"
+    fi
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ] && [ "$SCOPE_EXPAND" = 1 ]; then
+      PREFIX="${PREFIX}[scope-expand]"
+    fi
     # Honors any pre-commit hooks in the host repo — if they fail, this
     # turn's snapshot fails and the next turn picks up where files are.
     MSG="$(sed -n '1{s/^[[:space:]]*//;s/[[:space:]]*$//;p;q;}' .symphony/commit-message.txt 2>/dev/null || true)"
     [ -n "$MSG" ] || MSG="turn $(date -u +%FT%TZ)"
     case "$MSG" in wip:*) COMMIT_MSG="$MSG" ;; *) COMMIT_MSG="wip: $MSG" ;; esac
     LAST="$(git log -1 --format=%s 2>/dev/null || echo "")"
+    # On amend, preserve any markers the previous turn already set so a
+    # later test-passing turn doesn't drop the historical `[no-test]`.
+    # Markers are sticky within a wip subject.
+    PRIOR_PREFIX=""
+    case "$LAST" in
+      *"[no-test]"*) PRIOR_PREFIX="${PRIOR_PREFIX}[no-test]" ;;
+    esac
+    case "$LAST" in
+      *"[scope-expand]"*) PRIOR_PREFIX="${PRIOR_PREFIX}[scope-expand]" ;;
+    esac
+    MERGED_PREFIX=""
+    case "$PRIOR_PREFIX$PREFIX" in
+      *"[no-test]"*) MERGED_PREFIX="${MERGED_PREFIX}[no-test]" ;;
+    esac
+    case "$PRIOR_PREFIX$PREFIX" in
+      *"[scope-expand]"*) MERGED_PREFIX="${MERGED_PREFIX}[scope-expand]" ;;
+    esac
+    if [ -n "$MERGED_PREFIX" ]; then
+      COMMIT_MSG="${MERGED_PREFIX} ${COMMIT_MSG}"
+    fi
     if [ "${LAST#wip:}" != "$LAST" ]; then
       git -c user.email=symphony@local -c user.name=symphony \
           commit --amend -m "$COMMIT_MSG" >/dev/null 2>&1 || true

--- a/WORKFLOW.file.example.md
+++ b/WORKFLOW.file.example.md
@@ -116,8 +116,8 @@ hooks:
           ;;
       esac
       case "$f" in
-        tests/*|docs/*|kanban/*|.symphony/*)
-          : # carve-out: never counts as production change
+        tests/*|docs/*|kanban/*|.symphony/*|*.md|LICENSE|LICENSE.*|NOTICE|CHANGELOG*|README*|AGENTS.md|GEMINI.md)
+          : # carve-out: docs/license/wiki edits never count as production change
           ;;
         *)
           PROD_CHANGED=1

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -123,8 +123,8 @@ hooks:
           ;;
       esac
       case "$f" in
-        tests/*|docs/*|kanban/*|.symphony/*)
-          : # carve-out: never counts as production change
+        tests/*|docs/*|kanban/*|.symphony/*|*.md|LICENSE|LICENSE.*|NOTICE|CHANGELOG*|README*|AGENTS.md|GEMINI.md)
+          : # carve-out: docs/license/wiki edits never count as production change
           ;;
         *)
           PROD_CHANGED=1

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -25,6 +25,15 @@ tracker:
 polling:
   interval_ms: 30000
 
+# Wiki integrity sweep — runs `symphony wiki-sweep` automatically after every
+# Nth `Done` transition. The sweep flags duplicate slugs, INDEX↔file orphans,
+# missing files, and entries older than 90 days (idempotently appends
+# ` (stale?)` to their INDEX row). Set `sweep_every_n: 0` to disable. The
+# operator can also run `symphony wiki-sweep --root docs/llm-wiki` manually.
+wiki:
+  sweep_every_n: 10
+  root: ./docs/llm-wiki
+
 workspace:
   root: ~/symphony_workspaces
   reuse_policy: refresh
@@ -40,113 +49,14 @@ hooks:
   # IMPORTANT: only host-owned board roots such as kanban/ are symlinked
   # back to the host repo. docs/ stays branch-local so review/QA evidence
   # and wiki updates are reviewable deliverables.
+  # Body extracted to scripts/symphony-setup-worktree.sh so the hook stays
+  # one line and the worktree-setup logic is versioned, lintable, and
+  # testable on its own. Edit the script to change worktree provisioning,
+  # symlink behaviour, or venv install. SYMPHONY_WORKFLOW_DIR points at
+  # this WORKFLOW.md's directory; the script expects to be invoked from
+  # the ticket workspace cwd that Symphony pre-creates.
   after_create: |
-    set -euo pipefail
-    ISSUE_ID="$(basename "$PWD")"
-    HOST_REPO="${SYMPHONY_WORKFLOW_DIR:?SYMPHONY_WORKFLOW_DIR not set}"
-    WORKTREE_PATH="$PWD"
-    BRANCH="symphony/${ISSUE_ID}"
-    # Symphony pre-creates the workspace dir; git worktree add refuses to
-    # populate an existing path, so drop the empty dir first.
-    cd "$HOST_REPO"
-    BASE_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || git branch --show-current 2>/dev/null || true)"
-    FEATURE_BASE_BRANCH="${SYMPHONY_FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
-    MERGE_TARGET_BRANCH="${SYMPHONY_MERGE_TARGET_BRANCH:-${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}}"
-    # `git worktree add` (git >= 2.30) tolerates an existing *empty* target
-    # directory, which is exactly what Symphony pre-creates here. Trying to
-    # rmdir it first runs straight into Windows file-indexer / AV scans that
-    # hold a transient handle on the fresh dir and used to trip the
-    # dispatcher into a retry loop with `Device or resource busy`. Skipping
-    # the rmdir avoids the race entirely.
-    #
-    # A prior crashed attempt may have left `.git/worktrees/<ID>` registered;
-    # detach it first so the next `add` doesn't fail with
-    # "missing but already registered" or "already checked out". `remove`
-    # tolerates a non-existent path (returns non-zero, ignored); `prune`
-    # mops up any leftover admin files.
-    git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
-    git worktree prune 2>/dev/null || true
-    # Reuse the branch if a prior worktree was reaped without prune.
-    if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
-      git worktree add "$WORKTREE_PATH" "$BRANCH"
-    elif [ -n "$FEATURE_BASE_BRANCH" ]; then
-      git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$FEATURE_BASE_BRANCH"
-    else
-      git worktree add "$WORKTREE_PATH" -b "$BRANCH"
-    fi
-    cd "$WORKTREE_PATH"
-    # Record the fork point so commit_workspace_on_done can `git reset --soft`
-    # back to it and squash all per-turn work into a single ticket commit.
-    # Use --worktree so the value is scoped to .git/worktrees/<ID>/config.gitwt;
-    # writing without the flag leaks into the host repo's shared .git/config
-    # and corrupts auto_commit for unrelated workspaces nested in the host.
-    git config extensions.worktreeConfig true
-    git config --worktree symphony.basesha "$(git rev-parse HEAD)"
-    git config --worktree symphony.basebranch "${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
-    git config --worktree symphony.mergetargetbranch "${MERGE_TARGET_BRANCH:-}"
-    # Link shared board directories back to host so agent state changes are
-    # visible to Symphony's file tracker (which reads host board_root).
-    #
-    # Cross-platform: on POSIX use `ln -s`; on Windows Git Bash without
-    # admin / Developer Mode, `ln -s` silently *copies* the source, leaving
-    # the worktree's kanban/ as a divergent real directory — the tracker
-    # never sees the agent's Done transition and dispatches forever. The
-    # portable fix is a Windows directory junction (`mklink /J`), which
-    # behaves like a real directory to every tool, works cross-volume, and
-    # needs no elevation.
-    _symphony_link_dir() {
-      local target="$1" source="$2"
-      rm -rf "$target"
-      if [ "${OS:-}" = "Windows_NT" ] && command -v cmd.exe >/dev/null 2>&1; then
-        # MSYS bash mangles backslashes inside `cmd.exe //c "..."` argument
-        # strings (e.g. `\U` in `\Users` becomes garbled), so route through
-        # a tiny .bat that takes %1/%2 — bat files receive properly quoted
-        # args untouched. Also handles paths containing spaces.
-        local target_win source_win bat bat_win
-        target_win="$(cygpath -w "$(realpath -m "$target")")"
-        source_win="$(cygpath -w "$source")"
-        bat="${TEMP:-/tmp}/symphony-link-$$-$RANDOM.bat"
-        printf '@echo off\r\nmklink /J %%1 %%2\r\n' > "$bat"
-        bat_win="$(cygpath -w "$bat")"
-        cmd.exe //c "$bat_win" "$target_win" "$source_win" >/dev/null
-        rm -f "$bat"
-      else
-        ln -s "$source" "$target"
-      fi
-    }
-    for dir in kanban; do
-      [ -e "$HOST_REPO/$dir" ] || continue
-      tracked_file="$(git rev-parse --git-path "symphony-${dir}-tracked")"
-      git ls-files -z -- "$dir" > "$tracked_file" || true
-      if [ -s "$tracked_file" ]; then
-        xargs -0 git update-index --skip-worktree -- < "$tracked_file" || true
-      fi
-      rm -f "$tracked_file"
-      exclude_file="$(git rev-parse --git-path info/exclude)"
-      mkdir -p "$(dirname "$exclude_file")"
-      grep -qxF "$dir" "$exclude_file" 2>/dev/null || echo "$dir" >> "$exclude_file"
-      _symphony_link_dir "$dir" "$HOST_REPO/$dir"
-    done
-    # Pick the first available Python interpreter. `python3.11` is preferred
-    # because the project pins to >= 3.11, but we tolerate any newer 3.x so
-    # the hook does not break on fresh hosts that only ship 3.12+.
-    PYTHON=""
-    for candidate in python3.11 python3.12 python3.13 python3 python; do
-      if command -v "$candidate" >/dev/null 2>&1; then
-        PYTHON="$candidate"; break
-      fi
-    done
-    if [ -z "$PYTHON" ]; then
-      echo "after_create: no python3 on PATH; skipping venv install." >&2
-    else
-      "$PYTHON" -m venv .venv
-      # `python -m pip` survives the venv-script path differences between
-      # POSIX (`.venv/bin/pip`) and Windows (`.venv/Scripts/pip.exe`).
-      .venv/*/python -m pip install --quiet -e '.[dev]' 2>/dev/null \
-        || .venv/bin/python -m pip install --quiet -e '.[dev]' 2>/dev/null \
-        || .venv/Scripts/python -m pip install --quiet -e '.[dev]' 2>/dev/null \
-        || echo "after_create: pip install failed; agent will fall back to host python." >&2
-    fi
+    bash "$SYMPHONY_WORKFLOW_DIR/scripts/symphony-setup-worktree.sh"
   before_run: |
     # NEVER `git reset --hard` inside a worktree — discards mid-run work.
     set -uo pipefail
@@ -178,15 +88,119 @@ hooks:
       echo "run finished at $(date -u +%FT%TZ) (no changes)"
       exit 0
     fi
+    # Classify the staged diff so the wip subject carries machine-readable
+    # markers. `[no-test]` = production code changed with no paired test
+    # file in the same diff (workflow-v0.5.2 § B1 — review.md promotes it
+    # to a HIGH finding). `[scope-expand]` = a rewind dispatch (set by the
+    # orchestrator when SYMPHONY_REWIND_SCOPE is exported) but the diff
+    # touched a file outside the parsed scope list (workflow-v0.5.2 § A2).
+    # Both markers can stack.
+    STAGED_FILES="$(git diff --cached --name-only 2>/dev/null || true)"
+    PROD_CHANGED=0
+    TESTS_CHANGED=0
+    SCOPE_EXPAND=0
+    SCOPE_FILES=""
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ]; then
+      # SYMPHONY_REWIND_SCOPE is JSON: extract `"file": "..."` values without
+      # a jq dependency. POSIX sed; tolerant of escaped quotes inside `fix`.
+      SCOPE_FILES="$(printf '%s' "$SYMPHONY_REWIND_SCOPE" \
+        | tr ',' '\n' \
+        | sed -n 's/.*"file"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+    fi
+    # `IFS=$'\n'` is bash-only; the POSIX-portable equivalent is the
+    # printf trick below (command substitution strips a trailing newline,
+    # so we append a sentinel byte and strip it back off). Inline literal
+    # newlines also break the YAML literal block — the closing quote at
+    # column 0 prematurely terminates the `|` scalar.
+    NL=$(printf '\nx'); NL=${NL%x}
+    OLDIFS="$IFS"
+    IFS="$NL"
+    for f in $STAGED_FILES; do
+      [ -n "$f" ] || continue
+      case "$f" in
+        tests/*|*_test.py|*.test.ts|*.test.tsx|*_test.go)
+          TESTS_CHANGED=1
+          ;;
+      esac
+      case "$f" in
+        tests/*|docs/*|kanban/*|.symphony/*)
+          : # carve-out: never counts as production change
+          ;;
+        *)
+          PROD_CHANGED=1
+          ;;
+      esac
+      if [ -n "$SCOPE_FILES" ] && [ "$SCOPE_EXPAND" = 0 ]; then
+        in_scope=0
+        for s in $SCOPE_FILES; do
+          if [ "$f" = "$s" ]; then
+            in_scope=1
+            break
+          fi
+        done
+        if [ "$in_scope" = 0 ]; then
+          SCOPE_EXPAND=1
+        fi
+      fi
+    done
+    IFS="$OLDIFS"
+    PREFIX=""
+    if [ "$PROD_CHANGED" = 1 ] && [ "$TESTS_CHANGED" = 0 ]; then
+      PREFIX="${PREFIX}[no-test]"
+    fi
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ] && [ "$SCOPE_EXPAND" = 1 ]; then
+      PREFIX="${PREFIX}[scope-expand]"
+    fi
     # Honors any pre-commit hooks in the host repo — if they fail, this
     # turn's snapshot fails and the next turn picks up where files are.
     LAST="$(git log -1 --format=%s 2>/dev/null || echo "")"
+    # On amend, preserve markers the previous turn set AND fold in markers
+    # detected this turn so a later prod-only turn still gets `[no-test]`.
+    PRIOR_PREFIX=""
+    case "$LAST" in
+      *"[no-test]"*) PRIOR_PREFIX="${PRIOR_PREFIX}[no-test]" ;;
+    esac
+    case "$LAST" in
+      *"[scope-expand]"*) PRIOR_PREFIX="${PRIOR_PREFIX}[scope-expand]" ;;
+    esac
+    MERGED_PREFIX=""
+    case "$PRIOR_PREFIX$PREFIX" in
+      *"[no-test]"*) MERGED_PREFIX="${MERGED_PREFIX}[no-test]" ;;
+    esac
+    case "$PRIOR_PREFIX$PREFIX" in
+      *"[scope-expand]"*) MERGED_PREFIX="${MERGED_PREFIX}[scope-expand]" ;;
+    esac
     if [ "${LAST#wip:}" != "$LAST" ]; then
+      # Re-derive the timestamp portion from the existing subject (drop
+      # any prefixes, then drop the leading `wip: `). Falls back to a
+      # fresh stamp when parsing fails.
+      STRIPPED="$LAST"
+      while :; do
+        case "$STRIPPED" in
+          "[no-test]"*) STRIPPED="${STRIPPED#"[no-test]"}" ;;
+          "[scope-expand]"*) STRIPPED="${STRIPPED#"[scope-expand]"}" ;;
+          " "*) STRIPPED="${STRIPPED# }" ;;
+          *) break ;;
+        esac
+      done
+      case "$STRIPPED" in
+        wip:*) STRIPPED="${STRIPPED#wip:}" ;;
+      esac
+      STRIPPED="${STRIPPED# }"
+      [ -n "$STRIPPED" ] || STRIPPED="turn $(date -u +%FT%TZ)"
+      SUBJECT="wip: $STRIPPED"
+      if [ -n "$MERGED_PREFIX" ]; then
+        SUBJECT="${MERGED_PREFIX} ${SUBJECT}"
+      fi
       git -c user.email=symphony@local -c user.name=symphony \
-          commit --amend --no-edit >/dev/null 2>&1 || true
+          commit --amend -m "$SUBJECT" >/dev/null 2>&1 || true
     else
+      SUBJECT="wip: turn $(date -u +%FT%TZ)"
+      if [ -n "$PREFIX" ]; then
+        SUBJECT="${PREFIX} ${SUBJECT}"
+      fi
       git -c user.email=symphony@local -c user.name=symphony \
-          commit -m "wip: turn $(date -u +%FT%TZ)" >/dev/null 2>&1 || true
+          commit -m "$SUBJECT" >/dev/null 2>&1 || true
     fi
     echo "run finished at $(date -u +%FT%TZ)"
   before_remove: |

--- a/docs/improvements/workflow-v0.5.2.md
+++ b/docs/improvements/workflow-v0.5.2.md
@@ -1,0 +1,364 @@
+# Symphony Workflow Improvements (v0.5.2 → v0.6.0)
+
+This doc is the canonical brief for the 11-item workflow / harness upgrade
+landing on `feat/workflow-accuracy-and-harness-upgrades`. Subagents read this
+file (not chat history) for scope, contracts, and acceptance criteria.
+
+Each item below has: goal, contract (what artefact / API exists when done),
+files to touch, and an "out of scope" line to keep blast radius small.
+
+The pipeline order is unchanged:
+`Todo -> Explore -> Plan -> In Progress -> Review -> QA -> Learn -> Merge Gate -> Done`.
+
+---
+
+## A. Agent goal-achievement (prompts)
+
+### A1. Plan stage emits an executable Definition of Done
+
+**Goal**: QA never has to guess what "done" means. Plan writes signals;
+QA scores against them.
+
+**Contract**:
+- `plan.md` prompt requires two new sections after `## Plan`:
+  - `## Acceptance Tests` — bullet list of test signatures (path + function
+    name or `pytest -k "expr"`), one per AC. Empty list is invalid → set
+    state back to Explore with `## Plan Gaps`.
+  - `## Done Signals` — observable signals: file paths that must exist,
+    stdout substrings, exit codes, HTTP status + body shape. One bullet
+    per signal. Cap at 8 lines.
+- `qa.md` step 8 (`## QA Evidence`) gains a required `## AC Scorecard`
+  sub-block: table `signal | source | result (pass/fail) | evidence path`.
+  Every `## Done Signals` row must appear; missing rows fail QA.
+
+**Files**:
+- `docs/symphony-prompts/file/stages/plan.md`
+- `docs/symphony-prompts/file/stages/qa.md`
+- `docs/symphony-prompts/file/base.md` (length cap table: add the two
+  new sections, cap 10 lines each)
+
+**Out of scope**: changing Plan's `## Plan Candidates` / `## Recommendation`
+sections; touching Linear-tracker prompts.
+
+---
+
+### A2. Rewind turns scope diff to flagged items
+
+**Goal**: rewinds (Review→In Progress, QA→In Progress) stop touching files
+outside the finding scope.
+
+**Contract**:
+- Orchestrator injects `SYMPHONY_REWIND_SCOPE` env var on rewind dispatch.
+  Value = JSON of the most recent `## Review Findings` or `## QA Failure`
+  rows: `[{"severity": "...", "file": "path", "line": 42, "fix": "..."}]`.
+  Empty / non-rewind turns: env var unset.
+- `in-progress.md` prompt step 2 references `$SYMPHONY_REWIND_SCOPE` when
+  set: "implement only fixes for those files; if you need to touch a file
+  not listed, append `## Scope Expansion` with a one-line rationale and
+  proceed".
+- WORKFLOW.md `after_run` hook compares `git diff --name-only` against the
+  parsed scope file list. Files outside the scope cause the wip commit
+  subject to be prefixed `[scope-expand]` (not a failure, a marker).
+
+**Files**:
+- `src/symphony/orchestrator.py` (env injection at dispatch)
+- `docs/symphony-prompts/file/stages/in-progress.md`
+- `WORKFLOW.md`, `WORKFLOW.example.md`, `WORKFLOW.file.example.md`
+  (`after_run` hook adds the marker logic)
+
+**Out of scope**: blocking commits on scope expansion; rewriting orchestrator
+rewind-detection logic (already exists at `_is_rewind_transition`).
+
+---
+
+### A3. Explore emits a scored reuse inventory
+
+**Goal**: Plan can no longer silently re-write code that already exists.
+
+**Contract**:
+- `explore.md` step 5 makes `reuse-inventory.md` a **required** output (not
+  optional "drop material") with this table:
+  `candidate | path:line | reuse_fit (0-1) | adapt_cost (low/med/high) | notes`
+- `plan.md` candidate table gains a `reuse_from` column. For each candidate
+  with `reuse_from = none`, the agent must add a one-line rationale under
+  `## Plan Rationale` explaining why any inventory row with `reuse_fit >= 0.7`
+  was rejected.
+
+**Files**:
+- `docs/symphony-prompts/file/stages/explore.md`
+- `docs/symphony-prompts/file/stages/plan.md`
+
+**Out of scope**: enforcing the rationale programmatically (prompt-level for
+now); changing how Explore discovers reuse candidates.
+
+---
+
+## B. Best-practice enforcement
+
+### B1. TDD enforcement marker
+
+**Goal**: code changes without a paired test diff become a visible Review
+finding instead of silent.
+
+**Contract**:
+- WORKFLOW.md `after_run` hook classifies changed files: if any file outside
+  `tests/`, `docs/`, `kanban/`, `.symphony/` changed and no file under
+  `tests/` (or matching `*test*.py`, `*.test.ts`, `*_test.go`) changed in
+  the same diff, prefix the wip commit subject with `[no-test]`.
+- `review.md` step 3 adds: "scan `git log --format=%s symphony.basesha..HEAD`
+  for `[no-test]` markers; each one becomes a HIGH severity row in the
+  finding table unless the In Progress turn is documentation-only."
+
+**Files**:
+- `WORKFLOW.md`, `WORKFLOW.example.md`, `WORKFLOW.file.example.md`
+- `docs/symphony-prompts/file/stages/review.md`
+
+**Out of scope**: refusing the commit; auto-running tests in the hook.
+
+---
+
+### B2. Review stage emits a dedicated Security Audit
+
+**Goal**: the 7-item security checklist is a deliverable, not a footnote.
+
+**Contract**:
+- `review.md` requires a `## Security Audit` section before `## Review`
+  with this exact 7-row table (one row per item, in this order):
+  `check | verdict (pass/fail/n/a) | evidence (path:line or "n/a")`.
+  Checks: `secrets`, `input-validation`, `sql-injection`, `xss`, `csrf`,
+  `authz`, `rate-limit`.
+- Any `fail` row auto-promotes to a CRITICAL row in `## Review Findings`
+  and triggers Review → In Progress rewind.
+- `n/a` is acceptable but the evidence column must explain why (e.g.,
+  `n/a — docs-only change`).
+
+**Files**:
+- `docs/symphony-prompts/file/stages/review.md`
+- `docs/symphony-prompts/file/base.md` (length cap table: `## Security Audit`
+  exactly 7 rows; no spillover allowed)
+
+**Out of scope**: language-specific security tooling integration; coupling to
+external SAST.
+
+---
+
+### B3. Observability hooks in wiki entries
+
+**Goal**: every Learn wiki entry records the observability surface of the
+code it documents.
+
+**Contract**:
+- `learn.md` wiki template (both KO and EN) adds under `## Technical
+  Reference`:
+  ```
+  **Observability hooks:**
+  - log: `<event_name>` at `path:line` — what it signals
+  - metric: `<metric_name>` at `path:line` — what it counts
+  - trace: `<span_name>` at `path:line` — what it spans
+  ```
+  Use `- none` if the code has no observability surface (acceptable for
+  pure utility modules); QA / Review do not enforce on `none`.
+- `plan.md` candidate table adds an `observability` column (`add`,
+  `change`, `none`) so Plan declares intent up front.
+
+**Files**:
+- `docs/symphony-prompts/file/stages/learn.md`
+- `docs/symphony-prompts/file/stages/plan.md`
+
+**Out of scope**: shipping a logging library; auto-instrumenting.
+
+---
+
+## C. Harness
+
+### C1. Conflict pre-check at dispatch (system-level)
+
+**Goal**: orchestrator refuses to dispatch a ticket whose `## Touched Files`
+overlap an in-flight ticket. Move the contract out of the agent prompt
+where it can be forgotten / miscounted.
+
+**Contract**:
+- New helper `orchestrator._touched_files_for(issue) -> set[str]` parses
+  the `## Touched Files` bullet list from the ticket markdown body.
+- `_dispatch_one` (or equivalent) before claiming the issue: build the
+  union of `_touched_files_for(other)` for `other` in `_running ∪ _retry`,
+  intersect with the candidate's set. On non-empty intersection: set the
+  ticket to `Blocked`, append `## Conflict` with the other ticket's id and
+  the overlapping paths, skip dispatch.
+- Once enforced system-side, `in-progress.md` step 1 (the agent-side
+  conflict pre-check) is removed.
+
+**Files**:
+- `src/symphony/orchestrator.py`
+- `tests/test_orchestrator_dispatch.py` (new test: two tickets with
+  overlapping Touched Files → only one dispatches)
+- `docs/symphony-prompts/file/stages/in-progress.md` (remove step 1)
+
+**Out of scope**: parsing the markdown body for any other section; lifting
+other agent-side preconditions.
+
+---
+
+### C2. Backend stall-progress predicate abstraction
+
+**Goal**: the meta-event filter that fixed OLV-002 (commit `499e787`) lives
+only in `claude_code.py`. Lift it to the backend base class so future
+backends can override consistently.
+
+**Contract**:
+- New method on the backend base class:
+  `def is_progress_event(self, event: dict) -> bool`. Default returns
+  `True` (no filter, conservative).
+- `claude_code.py` overrides it with the existing `type == "assistant"`
+  predicate (move the current inline check into this method).
+- `pi.py`, `gemini.py`, `codex.py` keep the default for now (they were
+  not affected by the bug), but the override hook exists.
+- The orchestrator / dispatcher only resets `last_progress_timestamp`
+  when `backend.is_progress_event(event)` is True.
+
+**Files**:
+- `src/symphony/backends/__init__.py` (or wherever the base class lives —
+  inspect first; may need to introduce a thin base)
+- `src/symphony/backends/claude_code.py`
+- `tests/test_backends.py` (new: predicate behaviour per backend)
+
+**Out of scope**: changing stall_timeout_ms semantics; adding new
+backends.
+
+---
+
+### C3. Adaptive token budget per state
+
+**Goal**: dispatch tells the agent how many tokens the stage usually costs
+so prompts can self-regulate verbosity. Memory-of-past-runs only — no
+hard cap change.
+
+**Contract**:
+- New EMA (alpha = 0.3, simple Python) of completion tokens per state,
+  persisted in the state file (extend whatever JSON the orchestrator
+  already writes; if none, add `.symphony/token_ema.json`).
+- On dispatch, orchestrator injects two env vars: `SYMPHONY_TOKEN_EMA`
+  (the rolling mean for this state, int) and `SYMPHONY_TOKEN_BUDGET`
+  (the configured hard cap from `agent.max_total_tokens_by_state`).
+- `base.md` reads them in a new top-of-file directive:
+  `Soft budget for this stage: ~{{ token_ema }} tokens (hard cap
+  {{ token_budget }}). Stay concise; cite path:line, defer to details.md.`
+  Gracefully render nothing when the env vars are unset.
+
+**Files**:
+- `src/symphony/orchestrator.py` (EMA update on turn completion;
+  env injection on dispatch)
+- `src/symphony/prompt.py` (template context: token_ema, token_budget)
+- `docs/symphony-prompts/file/base.md`
+- `tests/test_orchestrator_dispatch.py` (EMA persists and updates)
+
+**Out of scope**: changing hard caps; per-ticket budget overrides.
+
+---
+
+### C4. Extract after_create hook to a shell script
+
+**Goal**: 200-line bash heredoc in WORKFLOW.md becomes a versioned,
+testable shell script. Hook stays one line.
+
+**Contract**:
+- New file `scripts/symphony-setup-worktree.sh` — verbatim copy of the
+  current `after_create` body, with a shebang and `set -euo pipefail`.
+- WORKFLOW.md, WORKFLOW.example.md, WORKFLOW.file.example.md `after_create`
+  becomes: `bash "$SYMPHONY_WORKFLOW_DIR/scripts/symphony-setup-worktree.sh"`.
+- Script is `chmod +x` and committed.
+- README mentions the script under "Hooks" so users editing it know
+  where to look.
+
+**Files**:
+- `scripts/symphony-setup-worktree.sh` (new, +x)
+- `WORKFLOW.md`, `WORKFLOW.example.md`, `WORKFLOW.file.example.md`
+- `README.md` (one-line pointer)
+
+**Out of scope**: rewriting in Python; splitting into smaller scripts;
+changing what the hook does.
+
+---
+
+### C5. Wiki-sweep cron CLI
+
+**Goal**: per-ticket wiki integrity sweep (dup/orphan/stale/contradiction)
+moves out of Learn prompt into a scheduled CLI.
+
+**Contract**:
+- New CLI: `symphony wiki-sweep [--root docs/llm-wiki] [--dry-run]`.
+  Implements the same four checks Learn currently does (duplicate slugs,
+  orphans missing INDEX rows, INDEX rows missing files, entries with
+  `Last updated > 90 days` → append ` (stale?)` idempotently).
+- Orchestrator runs the sweep automatically after every Nth `Done`
+  transition (default `wiki.sweep_every_n: 10` in WORKFLOW.md, set to 0
+  to disable).
+- `learn.md` step 4 is reduced to: "if this ticket invalidates a wiki
+  entry, update it and log the prior wrong claim; cross-entry
+  contradictions noticed in passing → append `## Wiki Conflict` to the
+  ticket. Bulk dup/orphan/stale sweep is handled by `symphony
+  wiki-sweep`."
+
+**Files**:
+- `src/symphony/wiki_sweep.py` (new module)
+- `src/symphony/cli.py` (register `wiki-sweep` subcommand)
+- `src/symphony/orchestrator.py` (post-Done counter + sweep dispatch)
+- `tests/test_wiki_sweep.py` (new)
+- `docs/symphony-prompts/file/stages/learn.md`
+- `WORKFLOW.md` (add `wiki.sweep_every_n: 10` block with a comment)
+
+**Out of scope**: rewriting wiki integrity rules; moving INDEX format.
+
+---
+
+## Cross-cutting
+
+### Release
+
+- `pyproject.toml` and `src/symphony/__init__.py` bump to `0.6.0` in
+  lockstep (memory `project_symphony_version_source_of_truth`).
+  Rationale: 6 prompt-contract changes + 5 harness-API changes → minor,
+  not patch. Bumps go in their own `chore(release): v0.6.0` commit on
+  top of the feature commits.
+- `CHANGELOG.md` gets a `## v0.6.0` block summarizing each of the 11
+  items in plain language (PM-readable per memory
+  `project_kanban_audience_includes_pms`).
+
+### Testing
+
+- All existing tests must still pass. Run `pytest -q`.
+- New tests required: C1 (dispatch conflict), C2 (predicate), C3 (EMA
+  persist), C5 (wiki-sweep).
+- Prompt-only changes (A1, A2, A3, B1-prompt, B2, B3) update
+  `tests/test_workflow_pipeline_prompt.py` if it asserts specific
+  section names.
+
+### Docs language
+
+- Prompts ship bilingual blocks where `{% if language == 'ko' %}` is
+  already used (base.md, learn.md). New prompt sections must follow the
+  same i18n pattern (memory
+  `project_language_split_chrome_vs_docs`).
+
+### Publicity guardrails
+
+This repo is going public (memory `project_repo_going_public`). Every
+example in WORKFLOW.example.md must work from a fresh clone; the
+extracted shell script (C4) must be POSIX-portable and handle the
+Windows / Git Bash branch already present in the current hook.
+
+---
+
+## Owners (subagent dispatch map)
+
+| Group | Items                                  | Files (broad)                                            |
+|-------|----------------------------------------|----------------------------------------------------------|
+| G1    | A1, A2-prompt, A3, B1-prompt, B2, B3   | `docs/symphony-prompts/file/**`                          |
+| G2    | C1, C3, A2-orch, B1-hook               | `src/symphony/orchestrator.py`, `src/symphony/prompt.py`, WORKFLOW*.md `after_run` |
+| G3    | C2                                     | `src/symphony/backends/**`, `tests/test_backends.py`     |
+| G4    | C4, C5                                 | `scripts/`, `src/symphony/wiki_sweep.py`, `src/symphony/cli.py`, WORKFLOW*.md `after_create` |
+| Final | release + integration + review + PR    | `pyproject.toml`, `src/symphony/__init__.py`, `CHANGELOG.md` |
+
+G2 + G4 both edit WORKFLOW*.md: G2 owns `after_run` blocks; G4 owns
+`after_create` block + new `wiki:` config block. No overlapping line
+ranges.

--- a/docs/improvements/workflow-v0.5.2.md
+++ b/docs/improvements/workflow-v0.5.2.md
@@ -408,7 +408,63 @@ not blockers for v0.6.0; future tickets:
   Plan Candidates as bullets, not a table — both columns silently
   absent. Either (a) update prompts with an explicit table template,
   or (b) drop "column" wording and accept bullet-per-candidate with
-  inline `(reuse_from=foo)` tags.
+  inline `(reuse_from=foo)` tags. **Fixed in this PR** by adopting (a).
+  Run 2 confirmed both backends emit the full 3-row table.
+
+---
+
+## Post-fix live re-verification (2026-05-17, run 2)
+
+Re-ran both backends after the C1 / C3 / A3 / B1 fixes landed,
+max_turns=2 (Explore→Plan only) to cut cost. Both reset to a clean
+workspace + EMA before launch.
+
+**C1 regex (`(new)` annotation)** — confirmed parser extracts both
+`src/demo_math.py` and `tests/test_demo_math.py` from the live claude
+ticket body where the pre-fix parser returned `set()`.
+
+**C3 EMA source-state attribution** — confirmed on BOTH backends:
+
+| Backend | Run 1 EMA keys (BUG) | Run 2 EMA keys (FIX) |
+|---------|----------------------|----------------------|
+| claude  | `plan, in progress, review` | `explore, plan` |
+| codex   | `in progress, plan, review` | `explore, plan` |
+
+Each key now matches the stage that ACTUALLY consumed the tokens
+(captured at `worker_turn_started`, not at `EVENT_TURN_COMPLETED`).
+
+**A3 explicit Plan candidate table** — confirmed on BOTH backends.
+Both emitted the spec table header `| option | summary | reuse_from |
+observability |` with three rows (A chosen, B/C rejected). The
+pre-fix prompt let claude fall back to bullets; the new explicit
+template anchors the format.
+
+**B1 marker bash classifier** — verified through 10 hermetic shell
+tests covering prod-only, paired-test, root *.md carve-outs, scope
+expansion under SYMPHONY_REWIND_SCOPE, and marker stacking. Live agent
+runs never naturally fire the marker because both backends practice
+TDD (src + test added in the same turn).
+
+## Out-of-scope findings (filed, not in this PR)
+
+- **Codex sandbox blocks symlinked board writes.** Codex Review turn
+  4 burned 11.9M tokens producing a clean review draft but could not
+  persist the `## Security Audit` / `## Review` sections back to
+  `kanban_demo_codex/DEMO-LIVE-002.md` because that path resolves
+  outside the codex sandbox writable root once symlink resolution
+  runs. Pre-existing codex backend integration issue; unrelated to
+  v0.6.0 prompt contracts. Workaround: bind-mount the host board path
+  into codex's writable roots more aggressively, or stop using
+  symlinks for the board injection.
+
+- **EMA last-writer-wins under multiple co-located orchestrators.**
+  Two demo orchestrators sharing the same `.symphony/token_ema.json`
+  see only their own in-memory EMA dict, so the second persist
+  overwrites the first. Production runs each have an isolated
+  `.symphony/` directory next to their WORKFLOW.md, so this is a
+  test-harness curiosity, not a runtime defect. If multi-tenant
+  orchestrators ever share state, switch to read-modify-write under a
+  flock or move per-state EMA into a per-orchestrator namespace.
 
 Two HIGH items from the same review were fixed in the v0.6.0 bundle:
 - C1 backticked-path-with-spaces regex (split into

--- a/docs/improvements/workflow-v0.5.2.md
+++ b/docs/improvements/workflow-v0.5.2.md
@@ -225,6 +225,16 @@ backends can override consistently.
 **Out of scope**: changing stall_timeout_ms semantics; adding new
 backends.
 
+**Implementation note (spec deviation, intentional)**: the brief said
+`codex.py` keeps the default predicate, but the existing tests
+`test_on_codex_event_extracts_nested_item_preview_without_stall_progress`
+and `test_codex_other_message_with_input_only_token_growth_does_not_advance_progress`
+prove codex's OTHER_MESSAGE bucket carries both real assistant previews
+and tool / item notifications. Removing the filter regresses those tests.
+`CodexAppServerBackend` therefore overrides `is_progress_event` with the
+same `type == "assistant"` predicate as claude. Pi and gemini still
+inherit the default.
+
 ---
 
 ### C3. Adaptive token budget per state
@@ -362,3 +372,33 @@ Windows / Git Bash branch already present in the current hook.
 G2 + G4 both edit WORKFLOW*.md: G2 owns `after_run` blocks; G4 owns
 `after_create` block + new `wiki:` config block. No overlapping line
 ranges.
+
+---
+
+## Post-review follow-ups (filed but not in v0.6.0)
+
+Code review on 2026-05-17 flagged the following MEDIUM items. They are
+not blockers for v0.6.0; future tickets:
+
+- **C1 retry overlap is best-effort.** Retry-queue entries don't carry
+  the full `Issue` body, so the conflict pre-check only inspects
+  entries that are also in `_running`. Pulling the body from the
+  tracker at dispatch time would make this complete; deferred to keep
+  the dispatch hot path single-source.
+- **C3 dispatch env mutates process-global `os.environ`.** Safe under
+  `max_concurrent_agents=1` (current default). Future `>1` concurrency
+  needs per-subprocess `env=` instead of in-place mutation.
+- **C3 EMA `.json.tmp` rename on Windows.** POSIX rename is atomic; on
+  Windows the rename can fail if a concurrent reader holds the file.
+  Best-effort log only; no data loss.
+
+Two HIGH items from the same review were fixed in the v0.6.0 bundle:
+- C1 backticked-path-with-spaces regex (split into
+  `_BULLET_PATH_BACKTICK_RE` + `_BULLET_PATH_PLAIN_RE`).
+- C5 `_done_count` persistence (mirrors the EMA load/persist pattern;
+  survives orchestrator restarts so sweep cadence holds).
+
+One MEDIUM item also fixed in the bundle:
+- B1 docs-only carve-out expanded to include `*.md`, `LICENSE*`,
+  `NOTICE`, `CHANGELOG*`, `README*`, `AGENTS.md`, `GEMINI.md` so root
+  documentation edits don't trip the `[no-test]` marker.

--- a/docs/improvements/workflow-v0.5.2.md
+++ b/docs/improvements/workflow-v0.5.2.md
@@ -391,6 +391,24 @@ not blockers for v0.6.0; future tickets:
 - **C3 EMA `.json.tmp` rename on Windows.** POSIX rename is atomic; on
   Windows the rename can fail if a concurrent reader holds the file.
   Best-effort log only; no data loss.
+- **C3 EMA records the destination state, not the source state.** Live
+  claude demo (2026-05-17) revealed that `_update_token_ema` uses
+  `entry.issue.state` at `EVENT_TURN_COMPLETED` time — but the agent
+  flips `state:` in the ticket body before the turn ends, so the EMA
+  for an Explore-stage run lands under `"plan"`, the Plan-stage run
+  under `"in progress"`, and so on. The dispatched env var
+  `SYMPHONY_TOKEN_EMA` therefore over-references the prior stage's
+  cost when the budget directive is read. Functionally still works
+  (every stage gets some signal), but the mapping is shifted by one.
+  Fix is to capture the state at turn START (`worker_turn_started`)
+  and record against THAT state in `_update_token_ema`.
+- **A3 candidate-table format unspecified.** `plan.md` asks for a
+  `reuse_from` column and `observability` column, but the prompt does
+  not specify a table format. Live claude demo (2026-05-17) emitted
+  Plan Candidates as bullets, not a table — both columns silently
+  absent. Either (a) update prompts with an explicit table template,
+  or (b) drop "column" wording and accept bullet-per-candidate with
+  inline `(reuse_from=foo)` tags.
 
 Two HIGH items from the same review were fixed in the v0.6.0 bundle:
 - C1 backticked-path-with-spaces regex (split into

--- a/docs/symphony-prompts/file/base.md
+++ b/docs/symphony-prompts/file/base.md
@@ -81,10 +81,13 @@ the end: `_세부: docs/<id>/<stage>/details.md_`.
 | `## Plan Candidates`    | ≤ 8 lines (1-2 per option)             | per-option diff sketches            |
 | `## Recommendation`     | ≤ 5 lines                              | first-failing-test full text        |
 | `## Plan`               | ≤ 10 lines                             | full step list, risk notes, fallback commands |
+| `## Acceptance Tests`   | ≤ 10 lines (1 bullet per AC)           | per-test setup / fixtures           |
+| `## Done Signals`       | ≤ 8 lines (1 bullet per signal)        | full payload bodies, long curl logs |
 | `## Implementation`     | ≤ 10 lines                             | per-file change list, helper names  |
+| `## Security Audit`     | exactly 7 rows (1 per check, no spillover) | per-check reasoning, suppression rationale |
 | `## Review`             | ≤ 6 rows in severity table             | full check-list reasoning, fix diffs |
 | `## Review Findings`    | severity table only (≤ 6 rows, 1 line each) | full check-list reasoning, fix diffs go to `docs/{{ issue.identifier }}/review/details.md` |
-| `## QA Evidence`        | header + commands + 1-line `**판정**` + AC table | raw pytest/curl/Playwright output |
+| `## QA Evidence`        | header + commands + 1-line `**판정**` + AC table + AC Scorecard | raw pytest/curl/Playwright output |
 | `## Learnings`          | ≤ 8 lines (3-4 bullets)                | extended rationale, follow-ups      |
 | `## Wiki Updates`       | ≤ 4 lines                              | n/a (wiki is the source of truth)   |
 | As-Is → To-Be Report    | ≤ 20 lines across all 4 sub-sections   | full evidence dump under docs/      |
@@ -134,10 +137,13 @@ the end: `_details: docs/<id>/<stage>/details.md_`.
 | `## Plan Candidates`    | ≤ 8 lines (1-2 per option)             | per-option diff sketches            |
 | `## Recommendation`     | ≤ 5 lines                              | first-failing-test full text        |
 | `## Plan`               | ≤ 10 lines                             | full step list, risk notes, fallback commands |
+| `## Acceptance Tests`   | ≤ 10 lines (1 bullet per AC)           | per-test setup / fixtures           |
+| `## Done Signals`       | ≤ 8 lines (1 bullet per signal)        | full payload bodies, long curl logs |
 | `## Implementation`     | ≤ 10 lines                             | per-file change list, helper names  |
+| `## Security Audit`     | exactly 7 rows (1 per check, no spillover) | per-check reasoning, suppression rationale |
 | `## Review`             | ≤ 6 rows in severity table             | full check-list reasoning, fix diffs |
 | `## Review Findings`    | severity table only (≤ 6 rows, 1 line each) | full check-list reasoning, fix diffs go to `docs/{{ issue.identifier }}/review/details.md` |
-| `## QA Evidence`        | header + commands + 1-line `**Verdict**` + AC table | raw pytest/curl/Playwright output |
+| `## QA Evidence`        | header + commands + 1-line `**Verdict**` + AC table + AC Scorecard | raw pytest/curl/Playwright output |
 | `## Learnings`          | ≤ 8 lines (3-4 bullets)                | extended rationale, follow-ups      |
 | `## Wiki Updates`       | ≤ 4 lines                              | n/a (wiki is the source of truth)   |
 | As-Is → To-Be Report    | ≤ 20 lines across all 4 sub-sections   | full evidence dump under docs/      |

--- a/docs/symphony-prompts/file/stages/explore.md
+++ b/docs/symphony-prompts/file/stages/explore.md
@@ -6,7 +6,9 @@ Research the ticket through three lenses in one turn: **domain expert** (what do
 2. Open `docs/llm-wiki/INDEX.md` (path defaults to ./docs/llm-wiki/ but respects $LLM_WIKI_PATH). Read every entry plausibly related to the ticket and follow links into the entry files. If `docs/llm-wiki/` does not exist yet, note that and continue — Learn will seed it later.
 3. Skim git history in adjacent areas: for each file the ticket likely touches, run `git log --oneline -- <path>` and read the one or two most relevant commits in full (`git show <sha>`). Capture *why* prior changes were made, not just what.
 4. Read the actual source files end-to-end (not just hunks) so the brief reflects current state, not stale memory.
-5. Drop boost material — citations, vendor-doc snippets, candidate helpers, reuse inventory — into `docs/{{ issue.identifier }}/explore/` (e.g. `notes.md`, `vendor-docs.md`, `reuse-inventory.md`). The brief sections below cite these files.
+5. Drop boost material — citations, vendor-doc snippets, candidate helpers — into `docs/{{ issue.identifier }}/explore/` (e.g. `notes.md`, `vendor-docs.md`). The brief sections below cite these files. **Required**: write `docs/{{ issue.identifier }}/explore/reuse-inventory.md` with this table (one row per candidate; `- none` line if nothing exists):
+   `candidate | path:line | reuse_fit (0-1) | adapt_cost (low/med/high) | notes`
+   Plan reads this file to justify any `reuse_from = none` choice.
 6. Apply each lens explicitly and append three sections to the ticket:
    - `## Domain Brief` — key facts, invariants, and references (`path:line`, wiki entry titles, commit SHAs) the implementer must know before writing code. Include a `## Touched Files` bullet list (repo-relative paths, ≤12; group by directory if more) so other in-flight tickets can detect overlap.
    - `## Plan Candidates` — 2-3 concrete approaches with trade-offs (complexity, blast radius, reversibility). Name files touched and tests added per option.

--- a/docs/symphony-prompts/file/stages/in-progress.md
+++ b/docs/symphony-prompts/file/stages/in-progress.md
@@ -2,24 +2,28 @@
 
 You are the implementer. Ship the smallest change that satisfies the brief.
 
-1. **Conflict pre-check.** Scan `kanban/*.md` for tickets with `state:`
-   `In Progress`, `Review`, or `QA` whose `## Touched Files` overlap this
-   ticket's `## Touched Files`. On overlap, set state to `Blocked`, append
-   `## Conflict` with the other ticket id, overlapping path(s), and a
-   one-line reason ("waiting on <ID> to finish editing <path>"); STOP.
-2. **Read the plan first.** Re-read the most recent `## Plan` and
+1. **Read the plan first.** Re-read the most recent `## Plan` and
    `docs/{{ issue.identifier }}/plan/implementation-plan.md` if it exists.
    That plan should be enough to implement. Use Explore notes, llm-wiki, or
    other docs only as reference material when the plan is ambiguous or
    missing a required detail. If `## Plan` is missing, set state to `Plan`,
-   append `## Plan Missing`, and stop. If the most recent ticket section is
-   `## QA Failure` or `## Review Findings`, scope this turn to ONLY those
-   flagged items — no drive-by changes. Fresh context means earlier
+   append `## Plan Missing`, and stop. Fresh context means earlier
    conversation is gone; the markdown is the contract.
-3. Implement the chosen option from `## Plan` (or, on rewind,
-   only the flagged failure items above). Do not reopen the plan unless
-   the brief got a fact wrong — then append a one-line `## Plan Adjustment`
-   and proceed.
+2. **Rewind scope.** If `$SYMPHONY_REWIND_SCOPE` is set (Symphony injects
+   it on Review→In Progress / QA→In Progress rewinds), it is a JSON array
+   of `{severity, file, line, fix}` rows from the most recent
+   `## Review Findings` or `## QA Failure`. Implement only fixes for those
+   files. If you genuinely need to touch a file not listed, append
+   `## Scope Expansion` with a one-line rationale per extra file and
+   proceed — this does not block, but Symphony marks the wip commit
+   `[scope-expand]`. When the env var is unset, follow `## Plan` normally;
+   if the most recent ticket section is `## QA Failure` or
+   `## Review Findings` and the env var is missing, fall back to scoping
+   the turn to those flagged items.
+3. Implement the chosen option from `## Plan` (or, on rewind, only the
+   flagged failure items above). Do not reopen the plan unless the brief
+   got a fact wrong — then append a one-line `## Plan Adjustment` and
+   proceed.
 4. TDD loop: write the failing test the brief specified, make it pass,
    refactor. No production code without a test exercising it.
 5. Pair the change with user-facing docs at

--- a/docs/symphony-prompts/file/stages/learn.md
+++ b/docs/symphony-prompts/file/stages/learn.md
@@ -52,6 +52,12 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    **Files of interest:**
    - `path/to/file.py:123` — what the line region does.
 
+   **Observability hooks:**
+   - log: `<event_name>` at `path:line` — 어떤 상황을 신호하는지
+   - metric: `<metric_name>` at `path:line` — 무엇을 세는지
+   - trace: `<span_name>` at `path:line` — 어디서 어디까지 감싸는지
+   (코드가 순수 유틸리티라 관측 표면이 없다면 `- none` 한 줄로 충분. QA/Review는 `none`을 강제하지 않는다.)
+
    **Decision log:**
    - YYYY-MM-DD | <issue.identifier> | what changed and why.
 
@@ -113,6 +119,12 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    **Files of interest:**
    - `path/to/file.py:123` — what the line region does.
 
+   **Observability hooks:**
+   - log: `<event_name>` at `path:line` — what it signals
+   - metric: `<metric_name>` at `path:line` — what it counts
+   - trace: `<span_name>` at `path:line` — what it spans
+   (If the code has no observability surface — a pure utility module — write `- none` and stop. QA/Review do not enforce on `none`.)
+
    **Decision log:**
    - YYYY-MM-DD | <issue.identifier> | what changed and why.
 
@@ -132,12 +144,10 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    If the entry has no `## Getting the Feel` section, add one this turn. If it already exists, touch it only when this ticket invalidated the analogy or core flow — small wording tweaks are out of scope (a Decision log row is enough).
 {% endif %}
 
-4. Wiki integrity sweep before transitioning:
-   - Duplicates: merge same-slug rows into the entry with newer Last updated, absorb distinct Invariants/Decision log rows, `git rm` the loser file and drop its INDEX row.
-   - Orphans: every `docs/llm-wiki/*.md` (except `INDEX.md`) has an INDEX row; every INDEX row has a file. Reconcile both directions.
-   - Stale: if Last updated > 90 days, append ` (stale?)` to the INDEX summary cell (idempotent).
-   - Contradictions: if this ticket disproves an entry, update it and log the prior wrong claim; for cross-entry conflicts noticed in passing, append a `## Wiki Conflict` section to the ticket pointing at both files.
-   - Beginner block sanity: every existing `## 감 잡기` / `## Getting the Feel` still has 3-5 flow steps, exactly five terms, one-sentence takeaway. Fix only obvious shape violations; rewriting prose is out of scope unless this ticket changed the underlying truth.
+4. Wiki integrity (lightweight at the ticket level):
+   - If this ticket invalidated an entry, update it now and log the prior wrong claim in the Decision log. This is the only sweep work Learn owns at the per-ticket level.
+   - If you noticed a cross-entry contradiction in passing, append `## Wiki Conflict` to the ticket pointing at both files (do not fix it here).
+   - Bulk dup/orphan/stale/missing-file sweeping is handled by `symphony wiki-sweep` (run automatically every `wiki.sweep_every_n` Done transitions; also `symphony wiki-sweep --root docs/llm-wiki --dry-run` on demand). Do NOT re-do those checks by hand.
 5. Append `## Learnings` to the ticket — 3-4 bullets of new facts/constraints/surprises.
 6. Append `## Wiki Updates` to the ticket — paths created/modified/removed, one line each with a changelog tag (`merged`, `created`, `marked stale`, `dropped orphan row`, `updated invariant`, `added beginner block`, `refreshed beginner block`).
 {% if agent.auto_merge_on_done %}

--- a/docs/symphony-prompts/file/stages/plan.md
+++ b/docs/symphony-prompts/file/stages/plan.md
@@ -21,12 +21,23 @@ execute by reading only `## Plan`. Do not write production code in this stage.
    - acceptance criteria, user-visible behavior, rollback/risk notes.
    If any bullet would be vague ("wire it up", "handle errors", "make UI
    nice"), replace it with concrete files, commands, states, or payloads.
-   The candidate table inside `## Plan` (or `## Plan Candidates` if you
-   refresh it) must carry two extra columns:
-   `... | reuse_from | observability`
+   The candidate set inside `## Plan` (or `## Plan Candidates` if you
+   refresh it) MUST be a Markdown table — not a bullet list — using
+   exactly this header (extra columns allowed at the end):
+
+   ```
+   | option | summary | reuse_from | observability |
+   |--------|---------|------------|---------------|
+   | A      | ...     | path:line  | add           |
+   | B      | ...     | none       | none          |
+   ```
+
    - `reuse_from`: a `path:line` from `reuse-inventory.md`, or `none`.
    - `observability`: `add`, `change`, or `none` — declares whether this
      candidate adds, modifies, or skips logs/metrics/traces.
+   - Live agent demo (2026-05-17) showed bullets silently dropping
+     both columns; the explicit header above is non-optional so Plan
+     Rationale and Learn can rely on the columns existing.
 5. Append `## Acceptance Tests` — one bullet per AC, each a runnable test
    signature (e.g. `tests/test_foo.py::test_bar` or
    `pytest -k "expr"` / `npm test -- --grep "..."`). Empty list is invalid:

--- a/docs/symphony-prompts/file/stages/plan.md
+++ b/docs/symphony-prompts/file/stages/plan.md
@@ -3,9 +3,9 @@
 Turn Explore into a professional implementation plan that the next agent can
 execute by reading only `## Plan`. Do not write production code in this stage.
 
-1. Read `docs/{{ issue.identifier }}/explore/`, `## Domain Brief`,
-   `## Plan Candidates`, `## Recommendation`, and any `## Triage` /
-   `## Reproduction` sections.
+1. Read `docs/{{ issue.identifier }}/explore/` (including the required
+   `reuse-inventory.md`), `## Domain Brief`, `## Plan Candidates`,
+   `## Recommendation`, and any `## Triage` / `## Reproduction` sections.
 2. Choose or refine the recommended approach. If the Explore brief missed a
    blocking fact, set state to `Blocked` and append `## Plan Blocker` with
    the exact missing input. Do not guess.
@@ -21,5 +21,22 @@ execute by reading only `## Plan`. Do not write production code in this stage.
    - acceptance criteria, user-visible behavior, rollback/risk notes.
    If any bullet would be vague ("wire it up", "handle errors", "make UI
    nice"), replace it with concrete files, commands, states, or payloads.
-5. Set state to `In Progress`. In Progress must read this `## Plan` before
+   The candidate table inside `## Plan` (or `## Plan Candidates` if you
+   refresh it) must carry two extra columns:
+   `... | reuse_from | observability`
+   - `reuse_from`: a `path:line` from `reuse-inventory.md`, or `none`.
+   - `observability`: `add`, `change`, or `none` — declares whether this
+     candidate adds, modifies, or skips logs/metrics/traces.
+5. Append `## Acceptance Tests` — one bullet per AC, each a runnable test
+   signature (e.g. `tests/test_foo.py::test_bar` or
+   `pytest -k "expr"` / `npm test -- --grep "..."`). Empty list is invalid:
+   set state back to `Explore`, append `## Plan Gaps` with what is missing,
+   and STOP.
+6. Append `## Done Signals` — one bullet per observable signal QA can check
+   (file path that must exist, stdout substring, exit code, HTTP status +
+   body shape). Cap 8 lines. QA scores against this list row-for-row.
+7. If you rejected any `reuse-inventory.md` row with `reuse_fit >= 0.7`,
+   append `## Plan Rationale` with one line per rejected row explaining
+   why (e.g. `path:line — reuse_fit 0.8 rejected: API shape mismatch`).
+8. Set state to `In Progress`. In Progress must read this `## Plan` before
    editing code.

--- a/docs/symphony-prompts/file/stages/qa.md
+++ b/docs/symphony-prompts/file/stages/qa.md
@@ -24,7 +24,9 @@ You are the QA gate. Execute real code against both builds and prove the diff wo
 
 7. Bug repro closure (only if `bug` label): re-run `docs/{{ issue.identifier }}/reproduce/repro.spec.ts` against To-Be, save to `docs/{{ issue.identifier }}/qa/repro-after.log`, and require it to pass. Never skip.
 
-8. Append `## QA Evidence` with: payload data source (DB tool + query, or `synthesized from <schema file>`), boot recipe used, exact commands run with exit codes, a `scenario × {As-Is status, As-Is ms, To-Be status, To-Be ms, verdict}` matrix, the repro re-run result line for `bug` tickets, and paths under `docs/{{ issue.identifier }}/qa/`.
+8. Append `## QA Evidence` with: payload data source (DB tool + query, or `synthesized from <schema file>`), boot recipe used, exact commands run with exit codes, a `scenario × {As-Is status, As-Is ms, To-Be status, To-Be ms, verdict}` matrix, the repro re-run result line for `bug` tickets, and paths under `docs/{{ issue.identifier }}/qa/`. Inside the same `## QA Evidence` section, add a required `## AC Scorecard` sub-block:
+   `signal | source (Plan ## Done Signals row) | result (pass/fail) | evidence path`
+   Every row in the Plan's `## Done Signals` must appear here. A missing or `fail` row fails QA — proceed to step 9.
 
 9. On any failure (correctness, latency, repro, or any server-reported HIGH issue): set state to `In Progress`, append `## QA Failure` naming the scenario and exact field/status/latency/severity that regressed, stop. Never silence, retry, or skip.
 

--- a/docs/symphony-prompts/file/stages/review.md
+++ b/docs/symphony-prompts/file/stages/review.md
@@ -15,6 +15,15 @@ You are the reviewer. Find issues; do not fix them.
    plumbing unless the ticket is explicitly about Symphony setup.
 3. Apply the checklist: clarity, naming, error handling, security,
    performance, simplicity, no dead code, no debug prints, no secrets.
+   Then scan `git log --format=%s $(git config symphony.basesha)..HEAD`
+   for `[no-test]` commit-subject markers (Symphony's `after_run` hook
+   prefixes wip commits that changed production code without a paired
+   test). Each `[no-test]` marker becomes a HIGH severity row in
+   `## Review Findings` (file: the unpaired production path; fix: "add a
+   test exercising this change") UNLESS the In Progress turn was
+   documentation-only (only `docs/`, `kanban/`, `.symphony/` paths
+   changed in that commit). Note the exemption in `## Review` if you
+   apply it.
 4. Use live HTTP proof only when this ticket changed runtime API behavior
    or its acceptance criteria explicitly require endpoint execution. For
    docs-only API mapping / scenario-definition tickets, verify against
@@ -24,22 +33,38 @@ You are the reviewer. Find issues; do not fix them.
    (To-Be) with curl/httpie/`requests` and save under
    `docs/{{ issue.identifier }}/verify/`: `baseline.json`, `pr.json`,
    `diff.txt`, `curl.log`.
-5. Classify findings into a severity table: `severity | file:line | fix`.
-   Cap at 6 rows in the body; spillover goes to
+5. **Security Audit (mandatory, before `## Review`).** Append a
+   `## Security Audit` section with exactly this 7-row table — same row
+   order, no extras, no spillover:
+   `check | verdict (pass/fail/n/a) | evidence (path:line or "n/a — <reason>")`
+   - `secrets`
+   - `input-validation`
+   - `sql-injection`
+   - `xss`
+   - `csrf`
+   - `authz`
+   - `rate-limit`
+   `n/a` is acceptable but the evidence cell must explain why (e.g.
+   `n/a — docs-only change`). Any `fail` row auto-promotes to a CRITICAL
+   row in `## Review Findings` (file = the cited `path:line`, fix = "fix
+   the security gap named in the audit") and triggers Review → In Progress.
+6. Classify findings into a severity table: `severity | file:line | fix`.
+   Include `[no-test]` HIGH rows from step 3 and `fail`-promoted CRITICAL
+   rows from step 5. Cap at 6 rows in the body; spillover goes to
    `docs/{{ issue.identifier }}/review/details.md`.
-6. **If any CRITICAL, HIGH, or MEDIUM finding exists:** set state back to
+7. **If any CRITICAL, HIGH, or MEDIUM finding exists:** set state back to
    `In Progress`, append `## Review Findings` with the Plain-Korean
    header + the severity table (referencing any verify artefacts under
    `docs/{{ issue.identifier }}/verify/`), and STOP. Do NOT fix findings
    inside Review — that is In Progress's job, with a fresh context.
    Symphony dispatches a new fix turn automatically.
-7. If prior `## Review Findings` are resolved and no CRITICAL, HIGH, or
+8. If prior `## Review Findings` are resolved and no CRITICAL, HIGH, or
    MEDIUM finding remains, do not append another `## Review Findings`
    section. Append `## Review` and set state to `QA` in the same turn;
    staying in `Review` after a clean review is a workflow failure.
-8. If the only findings are LOW (or none): append `## Review` with the
+9. If the only findings are LOW (or none): append `## Review` with the
    Plain-Korean header + the same severity table — flag deferred LOW
    items in the same section so Learn can address them — and set state
    to `QA`.
-9. If something is genuinely out of scope or unfixable: set state to
-   `Blocked` and append `## Blocker` explaining what is needed.
+10. If something is genuinely out of scope or unfixable: set state to
+    `Blocked` and append `## Blocker` explaining what is needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "symphony-multi-agent"
-version = "0.5.1"
+version = "0.6.0"
 description = "Multi-agent fork of OpenAI Symphony — supports Codex CLI, Claude Code CLI, Gemini CLI, and Pi CLI behind a single orchestrator with a Jira-style CLI Kanban TUI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/symphony-setup-worktree.sh
+++ b/scripts/symphony-setup-worktree.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Symphony after_create hook — extracted from WORKFLOW.md.
+#
+# Attach the empty ticket workspace as a git worktree of the host repo on a
+# per-ticket `symphony/<ID>` branch, symlink (or junction on Windows) any
+# host-owned board roots back into the worktree, and prime a Python venv for
+# the agent. Behaviour is identical to the inline hook that previously lived
+# inside WORKFLOW.md — see workflow-v0.5.2.md (C4) for the rationale.
+#
+# Env vars consumed (Symphony injects these before invoking the hook):
+#   SYMPHONY_WORKFLOW_DIR        Path to the host repo containing WORKFLOW.md.
+#   SYMPHONY_FEATURE_BASE_BRANCH Optional override for the new branch's start point.
+#   SYMPHONY_MERGE_TARGET_BRANCH Optional override for the Learn-gate merge target.
+set -euo pipefail
+ISSUE_ID="$(basename "$PWD")"
+HOST_REPO="${SYMPHONY_WORKFLOW_DIR:?SYMPHONY_WORKFLOW_DIR not set}"
+WORKTREE_PATH="$PWD"
+BRANCH="symphony/${ISSUE_ID}"
+# Symphony pre-creates the workspace dir; git worktree add refuses to
+# populate an existing path, so drop the empty dir first.
+cd "$HOST_REPO"
+BASE_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || git branch --show-current 2>/dev/null || true)"
+FEATURE_BASE_BRANCH="${SYMPHONY_FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
+MERGE_TARGET_BRANCH="${SYMPHONY_MERGE_TARGET_BRANCH:-${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}}"
+# `git worktree add` (git >= 2.30) tolerates an existing *empty* target
+# directory, which is exactly what Symphony pre-creates here. Trying to
+# rmdir it first runs straight into Windows file-indexer / AV scans that
+# hold a transient handle on the fresh dir and used to trip the
+# dispatcher into a retry loop with `Device or resource busy`. Skipping
+# the rmdir avoids the race entirely.
+#
+# A prior crashed attempt may have left `.git/worktrees/<ID>` registered;
+# detach it first so the next `add` doesn't fail with
+# "missing but already registered" or "already checked out". `remove`
+# tolerates a non-existent path (returns non-zero, ignored); `prune`
+# mops up any leftover admin files.
+git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+git worktree prune 2>/dev/null || true
+# Reuse the branch if a prior worktree was reaped without prune.
+if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  git worktree add "$WORKTREE_PATH" "$BRANCH"
+elif [ -n "$FEATURE_BASE_BRANCH" ]; then
+  git worktree add "$WORKTREE_PATH" -b "$BRANCH" "$FEATURE_BASE_BRANCH"
+else
+  git worktree add "$WORKTREE_PATH" -b "$BRANCH"
+fi
+cd "$WORKTREE_PATH"
+# Record the fork point so commit_workspace_on_done can `git reset --soft`
+# back to it and squash all per-turn work into a single ticket commit.
+# Use --worktree so the value is scoped to .git/worktrees/<ID>/config.gitwt;
+# writing without the flag leaks into the host repo's shared .git/config
+# and corrupts auto_commit for unrelated workspaces nested in the host.
+git config extensions.worktreeConfig true
+git config --worktree symphony.basesha "$(git rev-parse HEAD)"
+git config --worktree symphony.basebranch "${FEATURE_BASE_BRANCH:-${BASE_BRANCH:-}}"
+git config --worktree symphony.mergetargetbranch "${MERGE_TARGET_BRANCH:-}"
+# Link shared board directories back to host so agent state changes are
+# visible to Symphony's file tracker (which reads host board_root).
+#
+# Cross-platform: on POSIX use `ln -s`; on Windows Git Bash without
+# admin / Developer Mode, `ln -s` silently *copies* the source, leaving
+# the worktree's kanban/ as a divergent real directory — the tracker
+# never sees the agent's Done transition and dispatches forever. The
+# portable fix is a Windows directory junction (`mklink /J`), which
+# behaves like a real directory to every tool, works cross-volume, and
+# needs no elevation.
+_symphony_link_dir() {
+  local target="$1" source="$2"
+  rm -rf "$target"
+  if [ "${OS:-}" = "Windows_NT" ] && command -v cmd.exe >/dev/null 2>&1; then
+    # MSYS bash mangles backslashes inside `cmd.exe //c "..."` argument
+    # strings (e.g. `\U` in `\Users` becomes garbled), so route through
+    # a tiny .bat that takes %1/%2 — bat files receive properly quoted
+    # args untouched. Also handles paths containing spaces.
+    local target_win source_win bat bat_win
+    target_win="$(cygpath -w "$(realpath -m "$target")")"
+    source_win="$(cygpath -w "$source")"
+    bat="${TEMP:-/tmp}/symphony-link-$$-$RANDOM.bat"
+    printf '@echo off\r\nmklink /J %%1 %%2\r\n' > "$bat"
+    bat_win="$(cygpath -w "$bat")"
+    cmd.exe //c "$bat_win" "$target_win" "$source_win" >/dev/null
+    rm -f "$bat"
+  else
+    ln -s "$source" "$target"
+  fi
+}
+for dir in kanban; do
+  [ -e "$HOST_REPO/$dir" ] || continue
+  tracked_file="$(git rev-parse --git-path "symphony-${dir}-tracked")"
+  git ls-files -z -- "$dir" > "$tracked_file" || true
+  if [ -s "$tracked_file" ]; then
+    xargs -0 git update-index --skip-worktree -- < "$tracked_file" || true
+  fi
+  rm -f "$tracked_file"
+  exclude_file="$(git rev-parse --git-path info/exclude)"
+  mkdir -p "$(dirname "$exclude_file")"
+  grep -qxF "$dir" "$exclude_file" 2>/dev/null || echo "$dir" >> "$exclude_file"
+  _symphony_link_dir "$dir" "$HOST_REPO/$dir"
+done
+# Pick the first available Python interpreter. `python3.11` is preferred
+# because the project pins to >= 3.11, but we tolerate any newer 3.x so
+# the hook does not break on fresh hosts that only ship 3.12+.
+PYTHON=""
+for candidate in python3.11 python3.12 python3.13 python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    PYTHON="$candidate"; break
+  fi
+done
+if [ -z "$PYTHON" ]; then
+  echo "after_create: no python3 on PATH; skipping venv install." >&2
+else
+  # Hide the worker venv from the worktree's git status so per-turn
+  # commit hooks (and `git status` invariants in tests) don't see it.
+  exclude_file="$(git rev-parse --git-path info/exclude)"
+  mkdir -p "$(dirname "$exclude_file")"
+  grep -qxF ".venv" "$exclude_file" 2>/dev/null || echo ".venv" >> "$exclude_file"
+  "$PYTHON" -m venv .venv
+  # `python -m pip` survives the venv-script path differences between
+  # POSIX (`.venv/bin/pip`) and Windows (`.venv/Scripts/pip.exe`).
+  .venv/*/python -m pip install --quiet -e '.[dev]' 2>/dev/null \
+    || .venv/bin/python -m pip install --quiet -e '.[dev]' 2>/dev/null \
+    || .venv/Scripts/python -m pip install --quiet -e '.[dev]' 2>/dev/null \
+    || echo "after_create: pip install failed; agent will fall back to host python." >&2
+fi

--- a/src/symphony/__init__.py
+++ b/src/symphony/__init__.py
@@ -1,3 +1,3 @@
 """Symphony — coding agent orchestration service (SPEC v1)."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/src/symphony/backends/__init__.py
+++ b/src/symphony/backends/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+from typing import Any, Awaitable, Callable, Protocol, cast, runtime_checkable
 
 from ..errors import ConfigValidationError
 from ..workflow import ServiceConfig
@@ -125,26 +125,62 @@ class AgentBackend(Protocol):
     @property
     def latest_rate_limits(self) -> dict[str, Any] | None: ...
 
+    def is_progress_event(self, event: dict[str, Any]) -> bool: ...
+
+
+class BaseAgentBackend:
+    """Shared default behaviour for concrete backends.
+
+    Concrete backends inherit this so any future cross-cutting default
+    (currently just `is_progress_event`) lives in one place rather than
+    being copy-pasted into each driver.
+
+    Backends still match the `AgentBackend` Protocol structurally — the
+    base class is purely additive and does not constrain construction.
+    """
+
+    def is_progress_event(self, event: dict[str, Any]) -> bool:
+        """Return True when an event should reset the stall-progress timer.
+
+        Default is conservative: every event counts as progress so a new
+        backend doesn't accidentally trigger spurious stall cancellations.
+        Backends that produce keepalive / tool-echo events between real
+        model output (e.g. claude stream-json `user` frames carrying
+        `tool_result` echoes) override this to filter them out — see
+        `ClaudeCodeBackend.is_progress_event` for the canonical example.
+        """
+        del event
+        return True
+
 
 def build_backend(init: BackendInit) -> AgentBackend:
-    """Factory: pick a concrete backend by `agent.kind`."""
+    """Factory: pick a concrete backend by `agent.kind`.
+
+    Each concrete backend inherits `is_progress_event` from
+    `BaseAgentBackend` and structurally satisfies `AgentBackend`. Pyright
+    does not always trace Protocol membership through a non-Protocol base
+    class for methods that are only inherited (no override), so we `cast`
+    here to declare the structural compatibility explicitly. Runtime
+    duck-typing through `isinstance(..., AgentBackend)` still works
+    thanks to `@runtime_checkable`.
+    """
     kind = init.cfg.agent.kind
     if kind == "codex":
         from .codex import CodexAppServerBackend
 
-        return CodexAppServerBackend(init)
+        return cast(AgentBackend, CodexAppServerBackend(init))
     if kind == "claude":
         from .claude_code import ClaudeCodeBackend
 
-        return ClaudeCodeBackend(init)
+        return cast(AgentBackend, ClaudeCodeBackend(init))
     if kind == "gemini":
         from .gemini import GeminiBackend
 
-        return GeminiBackend(init)
+        return cast(AgentBackend, GeminiBackend(init))
     if kind == "pi":
         from .pi import PiBackend
 
-        return PiBackend(init)
+        return cast(AgentBackend, PiBackend(init))
     raise ConfigValidationError(
         f"unknown agent.kind {kind!r}; expected codex, claude, gemini, or pi"
     )

--- a/src/symphony/backends/claude_code.py
+++ b/src/symphony/backends/claude_code.py
@@ -44,6 +44,7 @@ from . import (
     EVENT_TURN_COMPLETED,
     EVENT_TURN_FAILED,
     BackendInit,
+    BaseAgentBackend,
     TurnResult,
 )
 
@@ -64,7 +65,7 @@ def _utc_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
-class ClaudeCodeBackend:
+class ClaudeCodeBackend(BaseAgentBackend):
     """One subprocess per turn; speaks Claude Code stream-json."""
 
     def __init__(self, init: BackendInit) -> None:
@@ -127,6 +128,19 @@ class ClaudeCodeBackend:
     @property
     def latest_rate_limits(self) -> dict[str, Any] | None:
         return dict(self._latest_rate_limits) if self._latest_rate_limits is not None else None
+
+    def is_progress_event(self, event: dict[str, Any]) -> bool:
+        """Only count claude `assistant` stream-json frames as progress.
+
+        The catch-all `EVENT_OTHER_MESSAGE` path also carries `user` frames
+        whose payload is a `tool_result` echo. Resetting the stall timer
+        on every echo masked a real 18-minute model stall in OLV-002
+        (commit 499e787). Restrict the predicate to real assistant output;
+        the orchestrator additionally treats lifecycle events and OUTPUT
+        token deltas as progress so this filter only narrows the catch-all
+        OTHER_MESSAGE bucket.
+        """
+        return event.get("type") == "assistant"
 
     async def initialize(self) -> dict[str, Any]:
         return {"agent": "claude_code"}

--- a/src/symphony/backends/codex.py
+++ b/src/symphony/backends/codex.py
@@ -51,6 +51,7 @@ from . import (
     EVENT_TURN_INPUT_REQUIRED,
     EVENT_UNSUPPORTED_TOOL_CALL,
     BackendInit,
+    BaseAgentBackend,
     ToolDescriptor,
     TurnResult,
 )
@@ -212,8 +213,21 @@ def _coerce_turn(result: Any) -> dict[str, Any]:
     return turn if isinstance(turn, dict) else {}
 
 
-class CodexAppServerBackend:
+class CodexAppServerBackend(BaseAgentBackend):
     """One subprocess instance per worker run; speaks Codex JSON-RPC."""
+
+    def is_progress_event(self, event: dict[str, Any]) -> bool:
+        """Treat only `type=="assistant"` OTHER_MESSAGE payloads as progress.
+
+        Codex app-server emits `OTHER_MESSAGE` for both real assistant
+        previews (which set `payload.type=="assistant"`) and tool / item
+        notifications (which do not). The orchestrator separately treats
+        OUTPUT token deltas as progress, so this predicate only narrows
+        the catch-all bucket. Matches the pre-abstraction inline filter
+        the orchestrator used to apply unconditionally; preserves the
+        OLV-002 / IB-006 fix semantics for codex.
+        """
+        return event.get("type") == "assistant"
 
     def __init__(self, init: BackendInit) -> None:
         validate_agent_cwd(init.cwd, init.workspace_root)
@@ -634,10 +648,11 @@ class CodexAppServerBackend:
                         handled = True
             # Fall back to legacy `totals` (or top-level snake_case).
             if not handled:
-                self._update_tokens_absolute(
-                    params.get("totals") if isinstance(params, dict) else None
-                    or params
-                )
+                totals: Any = None
+                if isinstance(params, dict):
+                    totals = params.get("totals") or params
+                if isinstance(totals, dict):
+                    self._update_tokens_absolute(totals)
             return
         # ----- rate limits (v2: account/rateLimits/updated) -----
         if method == NOTIF_RATE_LIMITS or method.endswith("/rateLimits"):

--- a/src/symphony/backends/gemini.py
+++ b/src/symphony/backends/gemini.py
@@ -39,6 +39,7 @@ from . import (
     EVENT_TURN_COMPLETED,
     EVENT_TURN_FAILED,
     BackendInit,
+    BaseAgentBackend,
     TurnResult,
 )
 
@@ -56,7 +57,7 @@ def _utc_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
-class GeminiBackend:
+class GeminiBackend(BaseAgentBackend):
     """One subprocess per turn; captures stdout as the turn result."""
 
     def __init__(self, init: BackendInit) -> None:

--- a/src/symphony/backends/pi.py
+++ b/src/symphony/backends/pi.py
@@ -59,6 +59,7 @@ from . import (
     EVENT_TURN_COMPLETED,
     EVENT_TURN_FAILED,
     BackendInit,
+    BaseAgentBackend,
     TurnResult,
 )
 
@@ -77,7 +78,7 @@ def _utc_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
-class PiBackend:
+class PiBackend(BaseAgentBackend):
     """One subprocess per turn; speaks pi --mode json JSONL."""
 
     def __init__(self, init: BackendInit) -> None:

--- a/src/symphony/cli.py
+++ b/src/symphony/cli.py
@@ -17,7 +17,7 @@ import signal
 import sys
 from pathlib import Path
 
-from . import wiki_sweep
+from . import wiki_sweep as wiki_sweep
 from .errors import SymphonyError
 from .keep_awake import KeepAwake
 from .logging import configure_logging

--- a/src/symphony/cli.py
+++ b/src/symphony/cli.py
@@ -6,6 +6,7 @@ Subcommands:
     symphony board ...             file-tracker board helper
     symphony doctor [WORKFLOW]     preflight checks for WORKFLOW.md
     symphony service ...           managed background orchestrator + viewer
+    symphony wiki-sweep ...        scan docs/llm-wiki/ for dup/orphan/stale rows
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import signal
 import sys
 from pathlib import Path
 
+from . import wiki_sweep
 from .errors import SymphonyError
 from .keep_awake import KeepAwake
 from .logging import configure_logging
@@ -202,6 +204,43 @@ async def _run(args: argparse.Namespace) -> int:
     return 0
 
 
+def _wiki_sweep_main(argv: list[str]) -> int:
+    """`symphony wiki-sweep` — pure subcommand. No orchestrator boot."""
+    _wiki_sweep = wiki_sweep
+
+    parser = argparse.ArgumentParser(
+        prog="symphony wiki-sweep",
+        description=(
+            "Scan a docs/llm-wiki/ tree for duplicate slugs, INDEX↔file "
+            "orphans, missing files, and entries older than "
+            f"{_wiki_sweep.STALE_AFTER_DAYS} days. Non-zero exit if any "
+            "duplicate / orphan / missing-file is found."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        default="docs/llm-wiki",
+        help="wiki directory to sweep (default: docs/llm-wiki)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report only; do not append stale markers to INDEX.md",
+    )
+    args = parser.parse_args(argv)
+
+    root_path = Path(args.root).expanduser()
+    if not root_path.is_absolute():
+        root_path = (Path.cwd() / root_path).resolve()
+    else:
+        root_path = root_path.resolve()
+
+    report = _wiki_sweep.sweep(root_path, dry_run=args.dry_run)
+    for line in report.summary_lines():
+        print(line)
+    return 0 if report.is_clean() else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     raw_argv = argv if argv is not None else sys.argv[1:]
     if raw_argv and raw_argv[0] == "board":
@@ -216,6 +255,8 @@ def main(argv: list[str] | None = None) -> int:
         from . import service
 
         return service.main(raw_argv[1:])
+    if raw_argv and raw_argv[0] == "wiki-sweep":
+        return _wiki_sweep_main(raw_argv[1:])
     if raw_argv and raw_argv[0] == "tui":
         # Rewrite `symphony tui [...args]` as `symphony --tui [...args]`.
         raw_argv = ["--tui", *raw_argv[1:]]

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -125,13 +125,20 @@ _QA_FAILURE_HEADING_RE = re.compile(
 _NEXT_HEADING_RE = re.compile(r"^##\s+\S", re.MULTILINE)
 # Bullet list rows: `- path/to/file.py` (optionally with surrounding backticks).
 # Two forms, tried in order:
-#   1. `- \`path with spaces/foo.py\` — note`  (backticks delimit; spaces OK)
-#   2. `- path/to/file.py — note`              (no backticks; first token only)
+#   1. `- \`path with spaces/foo.py\` <anything>`  (backticks delimit; spaces OK
+#      inside; ANY trailing annotation like `(new)`, `(deleted)`, `— note`
+#      after the closing backtick is accepted and ignored)
+#   2. `- path/to/file.py <anything>`              (no backticks; first token only)
+#
+# The lenient trailing-content match is intentional — real agent output
+# routinely uses `(new)`, `(deleted)`, `(M)`, `- modified` and similar
+# annotations after the path. A strict `$` anchor would silently drop
+# real entries from the conflict pre-check (verified live 2026-05-17).
 _BULLET_PATH_BACKTICK_RE = re.compile(
-    r"^\s*[-*]\s+`(?P<path>[^`]+)`\s*(?:[—\-].*)?$"
+    r"^\s*[-*]\s+`(?P<path>[^`]+)`"
 )
 _BULLET_PATH_PLAIN_RE = re.compile(
-    r"^\s*[-*]\s+(?P<path>[^\s`]+)\s*(?:[—\-].*)?$"
+    r"^\s*[-*]\s+(?P<path>[^\s`]+)"
 )
 
 
@@ -385,6 +392,15 @@ class RunningEntry:
     # 0 alongside `codex_state_total_tokens` on phase transitions so the
     # EMA samples turn-cost-within-stage, not cross-stage history.
     last_ema_state_total_tokens: int = 0
+    # The state the current turn STARTED in. Captured at worker_turn_started
+    # so the EMA samples the stage that actually consumed the tokens. Without
+    # this, `_update_token_ema` reads `entry.issue.state` at
+    # EVENT_TURN_COMPLETED time — but the agent may already have flipped
+    # `state:` in the ticket body before the turn ends, so the sample would
+    # land under the destination state, not the source. Live claude demo
+    # 2026-05-17 reproduced this: Explore turn cost recorded under "plan",
+    # Plan turn cost under "in progress", etc.
+    state_at_turn_start: str = ""
     codex_app_server_pid: int | None = None
     last_error: str | None = None
     # Set to `now` the first time stall detection cancels this worker. Used
@@ -1949,6 +1965,13 @@ class Orchestrator:
                         )
                         return
                     running.turn_count = turn_number
+                    # Capture the state THIS turn is starting in. C3 EMA
+                    # samples need the source state, not the destination
+                    # the agent flips to mid-turn — without this, every
+                    # stage's tokens get attributed to the next stage.
+                    running.state_at_turn_start = (
+                        running.issue.state or ""
+                    ).lower()
                     # Symmetry with worker_turn_completed — a single line per
                     # turn-start so multi-turn runs (especially slow ones
                     # like gemini -p where a single turn can take 60-90s)
@@ -2429,8 +2452,15 @@ class Orchestrator:
                 0,
             )
             if turn_sample > 0:
+                # Prefer the source state (captured at worker_turn_started)
+                # so a stage that flipped the ticket mid-turn still has its
+                # cost attributed correctly. Fall back to current state for
+                # event-injection unit tests that bypass turn_started.
+                target_state = (
+                    entry.state_at_turn_start or entry.issue.state
+                )
                 self._update_token_ema(
-                    entry.issue.state, turn_sample, cfg
+                    target_state, turn_sample, cfg
                 )
                 entry.last_ema_state_total_tokens = (
                     entry.codex_state_total_tokens

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -49,6 +49,7 @@ from .issue import Issue, normalize_state, sort_for_dispatch
 from .logging import get_logger
 from .prompt import build_continuation_prompt, build_first_turn_prompt
 from .tracker import build_tracker_client
+from . import wiki_sweep as _wiki_sweep_module
 from .workflow import (
     ServiceConfig,
     SUPPORTED_AGENT_KINDS,
@@ -123,8 +124,14 @@ _QA_FAILURE_HEADING_RE = re.compile(
 )
 _NEXT_HEADING_RE = re.compile(r"^##\s+\S", re.MULTILINE)
 # Bullet list rows: `- path/to/file.py` (optionally with surrounding backticks).
-_BULLET_PATH_RE = re.compile(
-    r"^\s*[-*]\s+`?(?P<path>[^\s`]+)`?\s*(?:[—\-].*)?$"
+# Two forms, tried in order:
+#   1. `- \`path with spaces/foo.py\` — note`  (backticks delimit; spaces OK)
+#   2. `- path/to/file.py — note`              (no backticks; first token only)
+_BULLET_PATH_BACKTICK_RE = re.compile(
+    r"^\s*[-*]\s+`(?P<path>[^`]+)`\s*(?:[—\-].*)?$"
+)
+_BULLET_PATH_PLAIN_RE = re.compile(
+    r"^\s*[-*]\s+(?P<path>[^\s`]+)\s*(?:[—\-].*)?$"
 )
 
 
@@ -161,7 +168,7 @@ def _parse_touched_files(text: str | None) -> set[str]:
         return set()
     out: set[str] = set()
     for line in body.splitlines():
-        m = _BULLET_PATH_RE.match(line)
+        m = _BULLET_PATH_BACKTICK_RE.match(line) or _BULLET_PATH_PLAIN_RE.match(line)
         if not m:
             continue
         path = m.group("path").strip()
@@ -512,6 +519,7 @@ class Orchestrator:
             hook_env=_branch_hook_env(cfg),
         )
         self._load_token_ema(cfg)
+        self._load_done_count(cfg)
         await self._startup_terminal_cleanup(cfg)
         self._tick_task = asyncio.create_task(self._tick_loop(), name="symphony-tick")
 
@@ -813,6 +821,45 @@ class Orchestrator:
             "paused": self.is_paused(entry.issue_id),
         }
 
+    def _done_count_path(self, cfg: ServiceConfig) -> Path:
+        """On-disk location for the persisted Done counter."""
+        return cfg.workflow_path.parent / ".symphony" / "done_count.json"
+
+    def _load_done_count(self, cfg: ServiceConfig) -> None:
+        """Restore the Done counter across orchestrator restarts.
+
+        Without persistence, every restart resets `_done_count` to 0 and
+        the C5 wiki-sweep cadence skips indefinitely on a frequently
+        restarted backend. Malformed payloads degrade to 0 rather than
+        crash startup.
+        """
+        path = self._done_count_path(cfg)
+        try:
+            if not path.exists():
+                return
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("done_count_load_failed", path=str(path), error=str(exc))
+            return
+        if isinstance(raw, dict):
+            value = raw.get("done_count")
+            if isinstance(value, int) and value >= 0:
+                self._done_count = value
+
+    def _persist_done_count(self, cfg: ServiceConfig) -> None:
+        """Best-effort flush; mirrors `_persist_token_ema`."""
+        path = self._done_count_path(cfg)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps({"done_count": self._done_count}, indent=2),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
+        except OSError as exc:
+            log.warning("done_count_persist_failed", path=str(path), error=str(exc))
+
     def _maybe_run_wiki_sweep(self, cfg: ServiceConfig, *, identifier: str) -> None:
         """C5 — bump the Done counter and run wiki-sweep every Nth time.
 
@@ -821,21 +868,21 @@ class Orchestrator:
         auto-sweep entirely. The sweep is intentionally synchronous and
         best-effort: it runs in-process for simplicity (the typical wiki
         is small), failures only log a warning, and never block the
-        Done transition.
+        Done transition. The counter is persisted after every Done so
+        sweep cadence survives orchestrator restarts.
         """
         every = cfg.wiki.sweep_every_n
         if every <= 0:
             return
         self._done_count += 1
+        self._persist_done_count(cfg)
         if self._done_count % every != 0:
             return
         root = cfg.wiki.root
         if root is None:
             return
         try:
-            from . import wiki_sweep as _wiki_sweep
-
-            report = _wiki_sweep.sweep(root, dry_run=False)
+            report = _wiki_sweep_module.sweep(root, dry_run=False)
         except Exception as exc:
             log.warning(
                 "wiki_sweep_failed",

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -13,6 +13,8 @@ Concurrency model:
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 import re
 import subprocess
 import time
@@ -99,6 +101,139 @@ def _is_rewind_transition(prev_state: str, current_state: str) -> bool:
     would otherwise have no signal beyond the markdown trail itself.
     """
     return (prev_state, current_state) in _REWIND_TRANSITIONS
+
+
+# Adaptive token-budget EMA — C3 (workflow-v0.5.2.md).
+# Alpha=0.3 weights recent turns ~70% by the third sample, fast enough to
+# track stage-cost drift without single-turn whiplash. Persisted to disk so
+# the soft budget survives orchestrator restarts.
+_TOKEN_EMA_ALPHA = 0.3
+
+# Section heading patterns parsed out of ticket markdown bodies.
+# These are intentionally permissive: leading/trailing whitespace, optional
+# trailing colon, and content up to the next `## ` heading or end-of-body.
+_TOUCHED_FILES_HEADING_RE = re.compile(
+    r"^##\s+Touched\s+Files\s*:?\s*$", re.IGNORECASE | re.MULTILINE
+)
+_REVIEW_FINDINGS_HEADING_RE = re.compile(
+    r"^##\s+Review\s+Findings\s*:?\s*$", re.IGNORECASE | re.MULTILINE
+)
+_QA_FAILURE_HEADING_RE = re.compile(
+    r"^##\s+QA\s+Failure\s*:?\s*$", re.IGNORECASE | re.MULTILINE
+)
+_NEXT_HEADING_RE = re.compile(r"^##\s+\S", re.MULTILINE)
+# Bullet list rows: `- path/to/file.py` (optionally with surrounding backticks).
+_BULLET_PATH_RE = re.compile(
+    r"^\s*[-*]\s+`?(?P<path>[^\s`]+)`?\s*(?:[—\-].*)?$"
+)
+
+
+def _section_body(text: str, heading_re: re.Pattern[str]) -> str | None:
+    """Return the body between `heading_re` and the next `## ` heading.
+
+    Returns None when the heading is absent. Returns "" when the heading is
+    present but the body is empty.
+    """
+    if not text:
+        return None
+    matches = list(heading_re.finditer(text))
+    if not matches:
+        return None
+    # Use the LAST occurrence so re-issued findings (e.g. Review→IP→Review)
+    # win over older sections in the same ticket body.
+    match = matches[-1]
+    after = text[match.end() :]
+    next_heading = _NEXT_HEADING_RE.search(after)
+    body = after if next_heading is None else after[: next_heading.start()]
+    return body.strip("\n")
+
+
+def _parse_touched_files(text: str | None) -> set[str]:
+    """Extract repo-relative paths from the `## Touched Files` bullet list.
+
+    Returns an empty set when the section is missing or contains no
+    bullet rows. Tolerant of trailing comments after the path (anything
+    after the first whitespace following a backticked path is ignored)."""
+    if not text:
+        return set()
+    body = _section_body(text, _TOUCHED_FILES_HEADING_RE)
+    if body is None:
+        return set()
+    out: set[str] = set()
+    for line in body.splitlines():
+        m = _BULLET_PATH_RE.match(line)
+        if not m:
+            continue
+        path = m.group("path").strip()
+        if path:
+            out.add(path)
+    return out
+
+
+def _parse_findings_rows(text: str | None) -> list[dict[str, Any]]:
+    """Best-effort parse of `## Review Findings` / `## QA Failure` bullets.
+
+    Returns a list of `{severity, file, line, fix}` dicts. Unrecognised
+    bullets are skipped silently — the env var is informational, not
+    contractual, so the agent prompt must already tolerate empty rows.
+
+    Heuristics (bullet variants we have seen in WORKFLOW prompts):
+      - ``- HIGH: src/foo.py:42 — refactor to use shared helper``
+      - ``- [CRITICAL] src/foo.py:42 fix XSS``
+      - ``- src/foo.py:42 fix XSS`` (severity defaults to empty string)
+    """
+    if not text:
+        return []
+    # Prefer Review Findings if both sections are present; QA Failure is a
+    # fallback because QA-stage tickets emit it instead.
+    body = _section_body(text, _REVIEW_FINDINGS_HEADING_RE)
+    if body is None:
+        body = _section_body(text, _QA_FAILURE_HEADING_RE)
+    if not body:
+        return []
+
+    severity_re = re.compile(
+        r"^\s*[-*]\s+"
+        r"(?:\[(?P<sev_b>[A-Za-z]+)\]\s*|"
+        r"(?P<sev_a>CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*[:\-—]?\s*)?"
+        r"(?P<rest>.+)$",
+        re.IGNORECASE,
+    )
+    path_line_re = re.compile(
+        r"`?(?P<file>[A-Za-z0-9_./\\-]+\.[A-Za-z0-9]+)`?"
+        r"(?::(?P<line>\d+))?"
+    )
+
+    rows: list[dict[str, Any]] = []
+    for raw in body.splitlines():
+        m = severity_re.match(raw)
+        if not m:
+            continue
+        rest = (m.group("rest") or "").strip()
+        if not rest:
+            continue
+        severity = (m.group("sev_a") or m.group("sev_b") or "").upper()
+        pm = path_line_re.search(rest)
+        file_path = pm.group("file") if pm else ""
+        try:
+            line_no = int(pm.group("line")) if pm and pm.group("line") else 0
+        except ValueError:
+            line_no = 0
+        # `fix` = the trailing free-text after the path (or the whole rest
+        # when no path was found). Strip common dash separators so the
+        # downstream prompt isn't fed `— foo`.
+        fix_text = rest
+        if pm:
+            fix_text = (rest[pm.end() :] or "").strip(" -—:\t")
+        rows.append(
+            {
+                "severity": severity,
+                "file": file_path,
+                "line": line_no,
+                "fix": fix_text,
+            }
+        )
+    return rows
 
 
 def _branch_hook_env(cfg: ServiceConfig) -> dict[str, str]:
@@ -208,6 +343,11 @@ class RunningEntry:
     workspace_path: Path
     attempt_kind: str = "initial"
     agent_kind: str = ""
+    # Live backend driver for this attempt. Populated by `_run_agent_attempt`
+    # immediately after `build_backend(...)` so `_on_codex_event` can route
+    # the stall-progress predicate through `backend.is_progress_event(...)`
+    # without re-implementing per-backend filters inside the orchestrator.
+    client: AgentBackend | None = None
     session_id: str | None = None
     thread_id: str | None = None
     turn_id: str | None = None
@@ -233,6 +373,11 @@ class RunningEntry:
     last_reported_cache_input_tokens: int = 0
     last_reported_output_tokens: int = 0
     last_reported_total_tokens: int = 0
+    # Cumulative state-local total tokens at the close of the previous
+    # turn — used by the EMA updater to derive per-turn deltas. Reset to
+    # 0 alongside `codex_state_total_tokens` on phase transitions so the
+    # EMA samples turn-cost-within-stage, not cross-stage history.
+    last_ema_state_total_tokens: int = 0
     codex_app_server_pid: int | None = None
     last_error: str | None = None
     # Set to `now` the first time stall detection cancels this worker. Used
@@ -303,6 +448,11 @@ class Orchestrator:
         self._claimed: set[str] = set()
         self._retry: dict[str, RetryEntry] = {}
         self._completed: set[str] = set()
+        # C5 — `Done`-transition counter for the periodic wiki sweep. Lives
+        # in-process; restart resets it (acceptable — the sweep is a
+        # housekeeping nudge, not a correctness gate). Wraparound at
+        # `sys.maxsize` is a non-issue at any realistic ticket throughput.
+        self._done_count: int = 0
         self._turn_budget_exhausted: set[str] = set()
         self._totals = _CodexTotals()
         self._latest_rate_limits: dict[str, Any] | None = None
@@ -327,6 +477,13 @@ class Orchestrator:
         #     pre-cleared event in `_dispatch`.
         self._paused_issue_ids: set[str] = set()
         self._pause_events: dict[str, asyncio.Event] = {}
+        # Rolling EMA of completion `total_tokens` per state. Keys are the
+        # lowercased state name (normalize_state). Persisted to
+        # `<workflow_dir>/.symphony/token_ema.json` so the soft budget the
+        # agent sees survives restarts. Updated on each EVENT_TURN_COMPLETED
+        # via `_update_token_ema_for_completed_turn`. C3 (workflow-v0.5.2).
+        self._token_ema: dict[str, float] = {}
+        self._token_ema_loaded: bool = False
 
     # ------------------------------------------------------------------
     # public lifecycle
@@ -354,6 +511,7 @@ class Orchestrator:
             reuse_policy=cfg.workspace_reuse_policy,
             hook_env=_branch_hook_env(cfg),
         )
+        self._load_token_ema(cfg)
         await self._startup_terminal_cleanup(cfg)
         self._tick_task = asyncio.create_task(self._tick_loop(), name="symphony-tick")
 
@@ -655,6 +813,51 @@ class Orchestrator:
             "paused": self.is_paused(entry.issue_id),
         }
 
+    def _maybe_run_wiki_sweep(self, cfg: ServiceConfig, *, identifier: str) -> None:
+        """C5 — bump the Done counter and run wiki-sweep every Nth time.
+
+        Called from the two Done-transition sites (`_on_worker_exit` and
+        the reconcile-driven path). `sweep_every_n: 0` disables the
+        auto-sweep entirely. The sweep is intentionally synchronous and
+        best-effort: it runs in-process for simplicity (the typical wiki
+        is small), failures only log a warning, and never block the
+        Done transition.
+        """
+        every = cfg.wiki.sweep_every_n
+        if every <= 0:
+            return
+        self._done_count += 1
+        if self._done_count % every != 0:
+            return
+        root = cfg.wiki.root
+        if root is None:
+            return
+        try:
+            from . import wiki_sweep as _wiki_sweep
+
+            report = _wiki_sweep.sweep(root, dry_run=False)
+        except Exception as exc:
+            log.warning(
+                "wiki_sweep_failed",
+                identifier=identifier,
+                root=str(root),
+                error=str(exc),
+            )
+            return
+        log.info(
+            "wiki_sweep_run",
+            identifier=identifier,
+            done_count=self._done_count,
+            sweep_every_n=every,
+            root=str(report.root) if report.root is not None else "",
+            duplicates=len(report.duplicates),
+            orphans=len(report.orphans),
+            missing_files=len(report.missing_files),
+            stale=len(report.stale_entries),
+            mutations=len(report.mutations),
+            clean=report.is_clean(),
+        )
+
     async def _after_done_then_remove_per_policy(
         self,
         cfg: "ServiceConfig",
@@ -845,8 +1048,21 @@ class Orchestrator:
                 continue
             if self._available_slots(cfg) <= 0:
                 break
-            if self._should_dispatch(issue, cfg):
-                self._dispatch(issue, cfg, attempt=None)
+            if not self._should_dispatch(issue, cfg):
+                continue
+            # C1 — system-level pre-check. An overlap with any in-flight
+            # ticket's `## Touched Files` would race two workers against
+            # the same paths. Move the candidate to Blocked instead of
+            # claiming the slot; the agent prompt no longer carries this
+            # check itself (workflow-v0.5.2 § C1).
+            conflict = self._conflict_blocker(issue)
+            if conflict is not None:
+                other_identifier, overlap = conflict
+                await self._block_ticket_for_conflict(
+                    cfg, issue, other_identifier, overlap
+                )
+                continue
+            self._dispatch(issue, cfg, attempt=None)
 
         await self._archive_sweep(cfg)
 
@@ -1021,6 +1237,266 @@ class Orchestrator:
         # still in Review" even though `max_concurrent_agents == 1`.
         in_flight = len(self._running) + len(self._retry)
         return max(cfg.agent.max_concurrent_agents - in_flight, 0)
+
+    # ------------------------------------------------------------------
+    # C1 — system-level conflict pre-check
+    # ------------------------------------------------------------------
+
+    def _touched_files_for(self, issue: Issue) -> set[str]:
+        """Return the `## Touched Files` paths declared on a ticket body.
+
+        Parses the issue's markdown description (set by every tracker
+        adapter on candidate fetch). Returns an empty set when the
+        section is missing or contains no bullet rows. Tolerant of
+        malformed bullets — anything we can't recognise is skipped.
+        """
+        return _parse_touched_files(issue.description)
+
+    def _conflict_blocker(
+        self, candidate: Issue
+    ) -> tuple[str, set[str]] | None:
+        """Return `(other_identifier, overlapping_paths)` when claiming
+        ``candidate`` would conflict with an in-flight ticket.
+
+        "In-flight" = currently in `_running` OR pending retry. Iterates
+        both, intersects each touched-file set against the candidate, and
+        returns the first overlap found (stable order: running before
+        retry, then insertion order within each).
+        """
+        candidate_files = self._touched_files_for(candidate)
+        if not candidate_files:
+            return None
+        for other_id, entry in self._running.items():
+            if other_id == candidate.id:
+                continue
+            other_files = self._touched_files_for(entry.issue)
+            overlap = candidate_files & other_files
+            if overlap:
+                return entry.issue.identifier, overlap
+        for other_id, retry_entry in self._retry.items():
+            if other_id == candidate.id:
+                continue
+            # Retry entries don't carry the full Issue. Look up the
+            # last-known body via running history when present; the
+            # common case (retry of an exited ticket) leaves no body to
+            # inspect, and the retry path re-evaluates on its own tick.
+            running_entry = self._running.get(other_id)
+            if running_entry is None:
+                continue
+            other_files = self._touched_files_for(running_entry.issue)
+            overlap = candidate_files & other_files
+            if overlap:
+                return retry_entry.identifier, overlap
+        return None
+
+    async def _block_ticket_for_conflict(
+        self,
+        cfg: ServiceConfig,
+        candidate: Issue,
+        other_identifier: str,
+        overlap: set[str],
+    ) -> None:
+        """Move ``candidate`` to ``Blocked`` and append a `## Conflict` note.
+
+        Lenient: tracker failures only log a warning. The in-memory
+        `_claimed` set still gets the candidate so the same dispatch loop
+        doesn't immediately retry it inside the same tick.
+        """
+        sorted_overlap = sorted(overlap)
+        note_body = (
+            f"Conflicts with `{other_identifier}` on overlapping "
+            f"`## Touched Files`:\n"
+            + "\n".join(f"- `{p}`" for p in sorted_overlap)
+        )
+        try:
+            await asyncio.to_thread(
+                self._tracker_call_append_note,
+                cfg,
+                candidate,
+                "Conflict",
+                note_body,
+            )
+        except Exception as exc:
+            log.warning(
+                "conflict_note_failed",
+                issue_id=candidate.id,
+                identifier=candidate.identifier,
+                error=str(exc),
+            )
+        try:
+            await asyncio.to_thread(
+                self._tracker_call_update_state,
+                cfg,
+                candidate,
+                "Blocked",
+            )
+        except Exception as exc:
+            log.warning(
+                "conflict_block_failed",
+                issue_id=candidate.id,
+                identifier=candidate.identifier,
+                error=str(exc),
+            )
+        # Keep the candidate out of this tick's dispatch loop even if the
+        # tracker mutation didn't land — the in-memory claim clears on
+        # the next reconcile if Blocked is terminal in the workflow.
+        self._claimed.add(candidate.id)
+        log.info(
+            "conflict_blocked",
+            issue_id=candidate.id,
+            identifier=candidate.identifier,
+            other=other_identifier,
+            overlap=sorted_overlap,
+        )
+
+    # ------------------------------------------------------------------
+    # C3 — adaptive token-budget EMA
+    # ------------------------------------------------------------------
+
+    def _token_ema_path(self, cfg: ServiceConfig) -> Path:
+        """Return the on-disk location for the persisted EMA snapshot."""
+        return cfg.workflow_path.parent / ".symphony" / "token_ema.json"
+
+    def _load_token_ema(self, cfg: ServiceConfig) -> None:
+        """Load `_token_ema` from disk on `start()`. Missing file = empty.
+
+        Idempotent: a second `start()` (e.g. reload) overwrites in-memory
+        EMA with the latest disk snapshot. Malformed payloads degrade to
+        empty rather than crash startup.
+        """
+        path = self._token_ema_path(cfg)
+        try:
+            if not path.exists():
+                self._token_ema = {}
+                self._token_ema_loaded = True
+                return
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning(
+                "token_ema_load_failed",
+                path=str(path),
+                error=str(exc),
+            )
+            self._token_ema = {}
+            self._token_ema_loaded = True
+            return
+        ema: dict[str, float] = {}
+        if isinstance(raw, dict):
+            for key, value in raw.items():
+                if not isinstance(key, str):
+                    continue
+                try:
+                    ema[key.lower()] = float(value)
+                except (TypeError, ValueError):
+                    continue
+        self._token_ema = ema
+        self._token_ema_loaded = True
+
+    def _persist_token_ema(self, cfg: ServiceConfig) -> None:
+        """Best-effort flush to disk via tmp+rename. Failures only log."""
+        path = self._token_ema_path(cfg)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(self._token_ema, sort_keys=True, indent=2),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
+        except OSError as exc:
+            log.warning(
+                "token_ema_persist_failed",
+                path=str(path),
+                error=str(exc),
+            )
+
+    def _update_token_ema(
+        self, state: str, total_tokens: int, cfg: ServiceConfig | None
+    ) -> None:
+        """Fold ``total_tokens`` into the rolling EMA for ``state``.
+
+        Standard EMA recurrence: ``ema_new = α·sample + (1-α)·ema_prev``.
+        Unseen states start at zero, so a first sample lands at α·sample.
+        Persists every update so the budget survives mid-turn crashes.
+        """
+        if total_tokens <= 0:
+            return
+        key = (state or "").lower()
+        if not key:
+            return
+        prev = self._token_ema.get(key, 0.0)
+        self._token_ema[key] = (
+            _TOKEN_EMA_ALPHA * float(total_tokens)
+            + (1.0 - _TOKEN_EMA_ALPHA) * prev
+        )
+        if cfg is not None:
+            self._persist_token_ema(cfg)
+
+    def _token_ema_for_state(self, state: str) -> int:
+        """Rounded EMA for a state. 0 when unseen."""
+        key = (state or "").lower()
+        return int(round(self._token_ema.get(key, 0.0)))
+
+    def _token_budget_for_state(
+        self, cfg: ServiceConfig, state: str
+    ) -> int:
+        """Hard cap from `agent.max_total_tokens_by_state` w/ fallback."""
+        key = (state or "").lower()
+        by_state = cfg.agent.max_total_tokens_by_state
+        cap = by_state.get(key)
+        if cap is None and key == "learn":
+            cap = by_state.get("learning")
+        if cap is None and key == "learning":
+            cap = by_state.get("learn")
+        return cap if cap is not None else cfg.agent.max_total_tokens
+
+    # ------------------------------------------------------------------
+    # A2-orch + C3 — backend subprocess env injection
+    # ------------------------------------------------------------------
+
+    def _apply_dispatch_env(
+        self,
+        *,
+        issue: Issue,
+        cfg: ServiceConfig,
+        is_rewind: bool,
+    ) -> None:
+        """Set per-dispatch env vars consumed by the backend subprocess.
+
+        Always sets:
+          * ``SYMPHONY_TOKEN_EMA`` — rolling EMA of total tokens for the
+            current state (rounded int), 0 when unseen.
+          * ``SYMPHONY_TOKEN_BUDGET`` — hard cap for the current state
+            (max_total_tokens_by_state with fallback to max_total_tokens).
+
+        On rewind dispatches also sets:
+          * ``SYMPHONY_REWIND_SCOPE`` — JSON list of finding rows parsed
+            from the ticket's most recent `## Review Findings` or
+            `## QA Failure` section. Empty list when parsing fails (the
+            env var is informational; an empty list signals "rewind, no
+            machine-readable scope" without unsetting).
+
+        On forward dispatches the rewind scope env var is UNSET so a
+        previous-turn value can't bleed across.
+
+        Backends inherit `os.environ`, so this mutates process-global
+        state. Concurrent dispatches in the same tick are serialised by
+        the orchestrator's single event loop, and each backend spawns
+        its subprocess before the next dispatch lands.
+        """
+        ema_value = self._token_ema_for_state(issue.state)
+        budget_value = self._token_budget_for_state(cfg, issue.state)
+        os.environ["SYMPHONY_TOKEN_EMA"] = str(ema_value)
+        os.environ["SYMPHONY_TOKEN_BUDGET"] = str(budget_value)
+        if is_rewind:
+            rows = _parse_findings_rows(issue.description)
+            try:
+                payload = json.dumps(rows, ensure_ascii=False)
+            except (TypeError, ValueError):
+                payload = "[]"
+            os.environ["SYMPHONY_REWIND_SCOPE"] = payload
+        else:
+            os.environ.pop("SYMPHONY_REWIND_SCOPE", None)
 
     # ------------------------------------------------------------------
     # dispatch (§16.4)
@@ -1214,7 +1690,14 @@ class Orchestrator:
                     client_tools=tools,
                 )
             )
+            # Expose the live backend to `_on_codex_event` so the stall-progress
+            # predicate routes through `client.is_progress_event(...)`.
+            running.client = client
             after_run_pending = False
+            # Initial dispatch is always forward (no rewind); the env
+            # mutation MUST land before `client.start()` because the
+            # backend subprocess inherits os.environ at fork time.
+            self._apply_dispatch_env(issue=issue, cfg=cfg, is_rewind=False)
             try:
                 await client.start()
                 await client.initialize()
@@ -1232,6 +1715,9 @@ class Orchestrator:
                     max_turns=cfg.agent.max_turns,
                     max_attempts=cfg.agent.max_attempts,
                     auto_merge_on_done=cfg.agent.auto_merge_on_done,
+                    token_ema=self._token_ema_for_state(issue.state),
+                    token_budget=self._token_budget_for_state(cfg, issue.state),
+                    rewind_scope=None,
                 )
                 await client.start_session(
                     initial_prompt=first_prompt,
@@ -1346,6 +1832,10 @@ class Orchestrator:
                             )
                             running_entry = self._running.get(running_issue_id)
                             if running_entry is not None:
+                                # New backend instance — refresh the
+                                # `_on_codex_event` reference so the stall
+                                # predicate keeps routing to the live driver.
+                                running_entry.client = client
                                 running_entry.thread_id = None
                                 running_entry.session_id = None
                                 running_entry.turn_id = None
@@ -1367,6 +1857,11 @@ class Orchestrator:
                                 running_entry.codex_state_cache_input_tokens = 0
                                 running_entry.codex_state_output_tokens = 0
                                 running_entry.codex_state_total_tokens = 0
+                                # Per-stage EMA window restarts with the
+                                # new state so first-turn cost in the new
+                                # stage isn't inflated by the prior
+                                # stage's cumulative total.
+                                running_entry.last_ema_state_total_tokens = 0
                                 running_entry.hit_token_budget = False
                                 running_entry.token_budget_cap = 0
                             log.info(
@@ -1590,6 +2085,10 @@ class Orchestrator:
                 client_tools=tools,
             )
         )
+        # Reset per-dispatch env BEFORE the new backend's subprocess spawns.
+        # Forward phase transitions unset SYMPHONY_REWIND_SCOPE; rewinds
+        # set it to the JSON of the latest finding rows.
+        self._apply_dispatch_env(issue=issue, cfg=cfg, is_rewind=is_rewind)
         await new_client.start()
         await new_client.initialize()
         first_prompt, _ = build_first_turn_prompt(
@@ -1601,6 +2100,11 @@ class Orchestrator:
             max_attempts=cfg.agent.max_attempts,
             is_rewind=is_rewind,
             auto_merge_on_done=cfg.agent.auto_merge_on_done,
+            token_ema=self._token_ema_for_state(issue.state),
+            token_budget=self._token_budget_for_state(cfg, issue.state),
+            rewind_scope=(
+                _parse_findings_rows(issue.description) if is_rewind else None
+            ),
         )
         await new_client.start_session(
             initial_prompt=first_prompt,
@@ -1807,7 +2311,21 @@ class Orchestrator:
         # model actually emits content, which is the signal we need.
         is_progress = ev_name != EVENT_OTHER_MESSAGE
         if not is_progress and isinstance(payload, dict):
-            is_progress = payload.get("type") == "assistant"
+            # Delegate the catch-all OTHER_MESSAGE filter to the backend so
+            # per-driver echo shapes (claude stream-json `user`/tool_result
+            # frames, codex preview items, future backends with their own
+            # keepalive types) live next to the code that knows their wire
+            # protocol. Claude and codex both narrow to `type=="assistant"`;
+            # pi/gemini inherit the conservative `BaseAgentBackend` default
+            # of always-True. When the backend reference isn't published
+            # yet (e.g. unit tests poking `_on_codex_event` directly without
+            # a build_backend call), apply the historical inline filter so
+            # existing invariants hold.
+            backend = entry.client
+            if backend is None:
+                is_progress = payload.get("type") == "assistant"
+            else:
+                is_progress = backend.is_progress_event(payload)
         if delta_out > 0:
             is_progress = True
         if is_progress:
@@ -1853,6 +2371,23 @@ class Orchestrator:
                 total_tokens=entry.codex_total_tokens,
                 last_message=(entry.last_codex_message or "")[:160],
             )
+            # C3 — adaptive token budget. Sample = per-turn state-local
+            # total tokens. `_update_token_ema` no-ops on non-positive
+            # samples, so a turn with zero token movement (e.g. an event
+            # that fires before any usage is reported) is skipped
+            # silently rather than dragging the EMA toward zero.
+            turn_sample = max(
+                entry.codex_state_total_tokens
+                - entry.last_ema_state_total_tokens,
+                0,
+            )
+            if turn_sample > 0:
+                self._update_token_ema(
+                    entry.issue.state, turn_sample, cfg
+                )
+                entry.last_ema_state_total_tokens = (
+                    entry.codex_state_total_tokens
+                )
         if ev_name == EVENT_TURN_FAILED:
             reason = payload.get("reason") if isinstance(payload, dict) else None
             stderr_tail = payload.get("stderr_tail") if isinstance(payload, dict) else None
@@ -2101,6 +2636,13 @@ class Orchestrator:
                         identifier=entry.issue.identifier,
                         title=entry.issue.title,
                         debug_target=debug,
+                    )
+                    # C5 — count this Done and run wiki-sweep if the cadence
+                    # configured by `wiki.sweep_every_n` is up. Failures are
+                    # absorbed inside the helper so we never block the
+                    # Done transition on a wiki housekeeping nudge.
+                    self._maybe_run_wiki_sweep(
+                        cfg, identifier=entry.issue.identifier
                     )
                 # Don't schedule a continuation — a Done ticket has nothing
                 # to continue. Skip straight to the worker_exit emit below.
@@ -2435,6 +2977,10 @@ class Orchestrator:
                                 identifier=entry.issue.identifier,
                                 title=entry.issue.title,
                                 debug_target=self._issue_debug.get(issue.id),
+                            )
+                            # C5 — see _on_worker_exit for the rationale.
+                            self._maybe_run_wiki_sweep(
+                                cfg, identifier=entry.issue.identifier
                             )
                     else:
                         # Non-Done terminal state (e.g. Cancelled, Blocked):

--- a/src/symphony/orchestrator.py
+++ b/src/symphony/orchestrator.py
@@ -49,7 +49,7 @@ from .issue import Issue, normalize_state, sort_for_dispatch
 from .logging import get_logger
 from .prompt import build_continuation_prompt, build_first_turn_prompt
 from .tracker import build_tracker_client
-from . import wiki_sweep as _wiki_sweep_module
+from .wiki_sweep import sweep as _wiki_sweep_run
 from .workflow import (
     ServiceConfig,
     SUPPORTED_AGENT_KINDS,
@@ -898,7 +898,7 @@ class Orchestrator:
         if root is None:
             return
         try:
-            report = _wiki_sweep_module.sweep(root, dry_run=False)
+            report = _wiki_sweep_run(root, dry_run=False)
         except Exception as exc:
             log.warning(
                 "wiki_sweep_failed",

--- a/src/symphony/prompt.py
+++ b/src/symphony/prompt.py
@@ -439,6 +439,9 @@ def build_prompt_env(
     is_rewind: bool = False,
     max_attempts: int = 3,
     auto_merge_on_done: bool = True,
+    token_ema: int = 0,
+    token_budget: int = 0,
+    rewind_scope: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """§12.1 — input variables for prompt rendering.
 
@@ -454,6 +457,19 @@ def build_prompt_env(
     inside a single worker run otherwise has no signal to give the agent.
     Always present in the env (default False) so strict templates that
     reference `{{ is_rewind }}` never fail to render.
+
+    `token_ema` / `token_budget` (C3, workflow-v0.5.2) are the rolling
+    EMA of completion tokens for this stage and the hard cap from
+    `agent.max_total_tokens_by_state`. Templates can render a soft
+    budget directive with `{{ token_ema }}` / `{{ token_budget }}`.
+    Default 0 keeps existing prompts that don't reference them safe;
+    base.md's directive can guard with `{% if token_ema %}`.
+
+    `rewind_scope` (A2-orch, workflow-v0.5.2) is the parsed list of
+    `{severity, file, line, fix}` finding rows for rewind turns. Empty
+    list when no rewind / parsing failed. Available to templates as
+    `{{ rewind_scope }}` (typically iterated with `{% for row in
+    rewind_scope %}…{% endfor %}`).
     """
     if hasattr(issue_obj, "to_template_dict"):
         issue_dict = issue_obj.to_template_dict()
@@ -470,6 +486,9 @@ def build_prompt_env(
             "max_attempts": max_attempts,
             "auto_merge_on_done": auto_merge_on_done,
         },
+        "token_ema": int(token_ema or 0),
+        "token_budget": int(token_budget or 0),
+        "rewind_scope": list(rewind_scope) if rewind_scope else [],
     }
 
 
@@ -483,6 +502,9 @@ def build_first_turn_prompt(
     max_attempts: int = 3,
     is_rewind: bool = False,
     auto_merge_on_done: bool = True,
+    token_ema: int = 0,
+    token_budget: int = 0,
+    rewind_scope: list[dict[str, Any]] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Construct the first-turn prompt sent to a worker.
 
@@ -495,6 +517,10 @@ def build_first_turn_prompt(
     authors can branch the retry-preamble block on rewind specifically
     (in-flight `Review→In Progress` / `QA→In Progress` handoffs that
     don't trip the dispatch-level retry counter).
+
+    `token_ema` / `token_budget` / `rewind_scope` plumb the C3 + A2
+    template-context fields through to `build_prompt_env`. Defaults keep
+    older callers (and tests) unchanged.
 
     Returns `(final_prompt, env)` so callers can keep `env` for later
     bookkeeping (e.g. logging, tests).
@@ -509,6 +535,9 @@ def build_first_turn_prompt(
         is_rewind=is_rewind,
         max_attempts=max_attempts,
         auto_merge_on_done=auto_merge_on_done,
+        token_ema=token_ema,
+        token_budget=token_budget,
+        rewind_scope=rewind_scope,
     )
     env["turn_number"] = 1
     env["max_turns"] = max_turns

--- a/src/symphony/wiki_sweep.py
+++ b/src/symphony/wiki_sweep.py
@@ -1,0 +1,378 @@
+"""C5 — wiki integrity sweep extracted from the Learn prompt.
+
+The sweep walks `docs/llm-wiki/` (or any caller-supplied root) and surfaces
+the same four classes of drift the Learn agent used to check by hand:
+
+1. Duplicate slugs (`# Title` heading collides across files).
+2. Orphan files (`docs/llm-wiki/*.md` with no matching `INDEX.md` row).
+3. Missing files (INDEX rows pointing at files that no longer exist).
+4. Stale entries (`**Last updated:** YYYY-MM-DD` more than 90 days old).
+
+The first three are reported only — auto-merging duplicates is the kind of
+edit that needs a human in the loop. Stale entries trigger an idempotent
+append of ` (stale?)` to the matching INDEX summary cell so the human-
+facing INDEX makes the rot visible.
+
+Pure logic — file IO is concentrated in `_load_entries` and `_apply_*` so
+unit tests can drive `sweep` against a temp tree without monkeypatching.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+INDEX_FILENAME = "INDEX.md"
+STALE_AFTER_DAYS = 90
+STALE_MARKER = " (stale?)"
+
+_TITLE_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+_LAST_UPDATED_RE = re.compile(
+    r"\*\*Last updated:\*\*\s*(\d{4}-\d{2}-\d{2})", re.IGNORECASE
+)
+# Match `| slug | summary | last touched |` rows; require at least one
+# dash-only separator row to anchor onto the table. We accept the slug
+# column verbatim — the wiki convention is `<topic-slug>` matching the
+# file stem under docs/llm-wiki/.
+_INDEX_ROW_RE = re.compile(
+    r"^\|\s*([^|]+?)\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|\s*$"
+)
+_INDEX_SEPARATOR_RE = re.compile(r"^\|\s*-+\s*\|")
+
+
+@dataclass(frozen=True)
+class WikiEntry:
+    """File-on-disk view of a wiki page."""
+
+    path: Path
+    slug: str  # filename stem
+    title: str | None  # `# Title` heading text, None if missing
+    last_updated: date | None  # parsed `**Last updated:** YYYY-MM-DD`
+
+
+@dataclass(frozen=True)
+class IndexRow:
+    """One parsed row of `INDEX.md`."""
+
+    line_no: int  # 1-based line index in INDEX.md (for stable mutations)
+    slug: str
+    summary: str
+    last_touched: str
+    raw_line: str
+
+
+@dataclass(frozen=True)
+class DuplicateSlug:
+    title: str
+    paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class StaleEntry:
+    slug: str
+    last_updated: date
+    age_days: int
+
+
+@dataclass(frozen=True)
+class SweepReport:
+    """Aggregated sweep findings.
+
+    `mutations` records what the sweep wrote (only stale markers in this
+    revision); empty in dry-run mode. Counts give CLI / log lines a quick
+    summary without recomputing list lengths.
+    """
+
+    duplicates: tuple[DuplicateSlug, ...] = ()
+    orphans: tuple[Path, ...] = ()
+    missing_files: tuple[str, ...] = ()
+    stale_entries: tuple[StaleEntry, ...] = ()
+    mutations: tuple[tuple[Path, str], ...] = ()
+    # Root scanned — useful in CLI output / structured logs.
+    root: Path | None = None
+    # Whether `INDEX.md` was present. False when the wiki root exists but
+    # has no index yet (treated as no rows + every file is an orphan).
+    index_present: bool = True
+
+    def is_clean(self) -> bool:
+        """True when no errors fired. Stale entries alone don't count."""
+        return not (self.duplicates or self.orphans or self.missing_files)
+
+    def summary_lines(self) -> list[str]:
+        """Human-readable lines for CLI / log output."""
+        out: list[str] = []
+        root = str(self.root) if self.root is not None else "<unknown>"
+        out.append(f"wiki-sweep: root={root}")
+        if not self.index_present:
+            out.append("  INDEX.md: missing")
+        out.append(
+            "  duplicates={d} orphans={o} missing_files={m} stale={s}".format(
+                d=len(self.duplicates),
+                o=len(self.orphans),
+                m=len(self.missing_files),
+                s=len(self.stale_entries),
+            )
+        )
+        for dup in self.duplicates:
+            joined = ", ".join(str(p) for p in dup.paths)
+            out.append(f"  duplicate slug '{dup.title}': {joined}")
+        for orphan in self.orphans:
+            out.append(f"  orphan file (no INDEX row): {orphan}")
+        for missing in self.missing_files:
+            out.append(f"  missing file (INDEX row points nowhere): {missing}")
+        for stale in self.stale_entries:
+            out.append(
+                f"  stale entry: {stale.slug} last updated "
+                f"{stale.last_updated.isoformat()} ({stale.age_days} days)"
+            )
+        for path, action in self.mutations:
+            out.append(f"  mutation: {action} -> {path}")
+        return out
+
+
+def sweep(
+    root: Path,
+    *,
+    dry_run: bool = False,
+    today: date | None = None,
+) -> SweepReport:
+    """Run all four checks against `root`. Pure orchestration.
+
+    `today` is injectable to keep tests deterministic; defaults to
+    `datetime.now(UTC).date()`.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    if not root.exists() or not root.is_dir():
+        # Empty / missing root is a clean report — Symphony's auto-sweep
+        # call site treats this as "nothing to do" without escalating.
+        return SweepReport(root=root, index_present=False)
+
+    entries = _load_entries(root)
+    index_path = root / INDEX_FILENAME
+    index_present = index_path.is_file()
+    index_rows = _load_index_rows(index_path) if index_present else ()
+
+    duplicates = _detect_duplicate_slugs(entries)
+    orphans = _detect_orphans(entries, index_rows)
+    missing_files = _detect_missing_files(root, index_rows)
+    stale_entries = _detect_stale(entries, today=today)
+
+    mutations: list[tuple[Path, str]] = []
+    if not dry_run and stale_entries and index_present:
+        mutated = _apply_stale_markers(index_path, index_rows, stale_entries)
+        if mutated:
+            mutations.append((index_path, f"marked {mutated} stale row(s)"))
+
+    return SweepReport(
+        duplicates=tuple(duplicates),
+        orphans=tuple(orphans),
+        missing_files=tuple(missing_files),
+        stale_entries=tuple(stale_entries),
+        mutations=tuple(mutations),
+        root=root,
+        index_present=index_present,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loading — file IO concentrated here so the checks below stay pure.
+# ---------------------------------------------------------------------------
+
+
+def _load_entries(root: Path) -> list[WikiEntry]:
+    """Read every `*.md` under root (top-level only, excluding INDEX)."""
+    out: list[WikiEntry] = []
+    for path in sorted(root.glob("*.md")):
+        if path.name == INDEX_FILENAME:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        out.append(
+            WikiEntry(
+                path=path,
+                slug=path.stem,
+                title=_parse_title(text),
+                last_updated=_parse_last_updated(text),
+            )
+        )
+    return out
+
+
+def _load_index_rows(index_path: Path) -> tuple[IndexRow, ...]:
+    """Parse INDEX.md table rows; tolerates leading prose / headers."""
+    try:
+        text = index_path.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    rows: list[IndexRow] = []
+    seen_separator = False
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        if _INDEX_SEPARATOR_RE.match(raw_line):
+            seen_separator = True
+            continue
+        if not seen_separator:
+            continue
+        match = _INDEX_ROW_RE.match(raw_line)
+        if not match:
+            continue
+        slug = match.group(1).strip()
+        # Skip header rows ("topic-slug" or other column labels). Real
+        # slugs in this codebase use lowercase + hyphen; column headers
+        # like "topic-slug" still match that pattern, so we instead key
+        # off the file existing on disk in the orphan/missing checks.
+        rows.append(
+            IndexRow(
+                line_no=line_no,
+                slug=slug,
+                summary=match.group(2).strip(),
+                last_touched=match.group(3).strip(),
+                raw_line=raw_line,
+            )
+        )
+    return tuple(rows)
+
+
+def _parse_title(text: str) -> str | None:
+    match = _TITLE_RE.search(text)
+    return match.group(1).strip() if match else None
+
+
+def _parse_last_updated(text: str) -> date | None:
+    match = _LAST_UPDATED_RE.search(text)
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Checks — pure functions over the loaded model.
+# ---------------------------------------------------------------------------
+
+
+def _detect_duplicate_slugs(entries: list[WikiEntry]) -> list[DuplicateSlug]:
+    """Same `# Title` text across two or more files → merge candidate."""
+    by_title: dict[str, list[Path]] = {}
+    for entry in entries:
+        if not entry.title:
+            continue
+        # Normalise whitespace so trivial formatting differences don't
+        # mask a real duplicate, but keep case (titles are human prose).
+        key = " ".join(entry.title.split())
+        by_title.setdefault(key, []).append(entry.path)
+    out: list[DuplicateSlug] = []
+    for title, paths in by_title.items():
+        if len(paths) >= 2:
+            out.append(DuplicateSlug(title=title, paths=tuple(sorted(paths))))
+    out.sort(key=lambda d: d.title)
+    return out
+
+
+def _detect_orphans(
+    entries: list[WikiEntry], index_rows: tuple[IndexRow, ...]
+) -> list[Path]:
+    """Files on disk that no INDEX row references."""
+    indexed_slugs = {row.slug for row in index_rows}
+    orphans = [entry.path for entry in entries if entry.slug not in indexed_slugs]
+    orphans.sort()
+    return orphans
+
+
+def _detect_missing_files(
+    root: Path, index_rows: tuple[IndexRow, ...]
+) -> list[str]:
+    """INDEX rows whose slug has no matching file on disk."""
+    on_disk = {p.stem for p in root.glob("*.md") if p.name != INDEX_FILENAME}
+    missing = [row.slug for row in index_rows if row.slug not in on_disk]
+    # Stable, dedupe.
+    seen: set[str] = set()
+    out: list[str] = []
+    for slug in missing:
+        if slug not in seen:
+            seen.add(slug)
+            out.append(slug)
+    return out
+
+
+def _detect_stale(
+    entries: list[WikiEntry], *, today: date
+) -> list[StaleEntry]:
+    out: list[StaleEntry] = []
+    for entry in entries:
+        if entry.last_updated is None:
+            continue
+        age = (today - entry.last_updated).days
+        if age > STALE_AFTER_DAYS:
+            out.append(
+                StaleEntry(slug=entry.slug, last_updated=entry.last_updated, age_days=age)
+            )
+    out.sort(key=lambda s: (s.slug,))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Mutations — append ` (stale?)` to INDEX rows idempotently.
+# ---------------------------------------------------------------------------
+
+
+def _apply_stale_markers(
+    index_path: Path,
+    index_rows: tuple[IndexRow, ...],
+    stale_entries: list[StaleEntry],
+) -> int:
+    """Append ` (stale?)` to the summary cell of matching INDEX rows.
+
+    Idempotent — only writes when at least one row needs the marker and
+    doesn't already carry it. Returns the number of rows mutated.
+    """
+    stale_slugs = {s.slug for s in stale_entries}
+    rows_by_line = {row.line_no: row for row in index_rows if row.slug in stale_slugs}
+    if not rows_by_line:
+        return 0
+    try:
+        original = index_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    lines = original.splitlines(keepends=True)
+    mutated_count = 0
+    for line_no, row in rows_by_line.items():
+        if STALE_MARKER in row.summary:
+            continue
+        # `line_no` is 1-based; lines list is 0-based.
+        idx = line_no - 1
+        if idx < 0 or idx >= len(lines):
+            continue
+        old_line = lines[idx]
+        new_summary = f"{row.summary}{STALE_MARKER}"
+        # Rebuild the row preserving trailing newline. We use the parsed
+        # cells rather than regex-replacing inside the raw line so a
+        # summary that happens to contain the slug doesn't get garbled.
+        new_line = (
+            f"| {row.slug} | {new_summary} | {row.last_touched} |"
+        )
+        if old_line.endswith("\n"):
+            new_line += "\n"
+        lines[idx] = new_line
+        mutated_count += 1
+    if mutated_count == 0:
+        return 0
+    index_path.write_text("".join(lines), encoding="utf-8")
+    return mutated_count
+
+
+__all__ = [
+    "DuplicateSlug",
+    "IndexRow",
+    "STALE_AFTER_DAYS",
+    "STALE_MARKER",
+    "StaleEntry",
+    "SweepReport",
+    "WikiEntry",
+    "sweep",
+]

--- a/src/symphony/workflow.py
+++ b/src/symphony/workflow.py
@@ -398,6 +398,21 @@ class SystemConfig:
 
 
 @dataclass(frozen=True)
+class WikiConfig:
+    """Wiki integrity sweep config (C5).
+
+    `sweep_every_n` controls how often the orchestrator runs `symphony
+    wiki-sweep` automatically after a `Done` transition. 0 disables the
+    auto-sweep entirely; the manual CLI subcommand still works. `root`
+    is the wiki directory the sweep walks (defaults to `docs/llm-wiki`
+    relative to the workflow file).
+    """
+
+    sweep_every_n: int = 10
+    root: Path | None = None
+
+
+@dataclass(frozen=True)
 class PromptConfig:
     """External prompt files configured from WORKFLOW.md.
 
@@ -431,6 +446,7 @@ class ServiceConfig:
     progress: ProgressConfig = field(default_factory=ProgressConfig)
     system: SystemConfig = field(default_factory=SystemConfig)
     prompts: PromptConfig = field(default_factory=PromptConfig)
+    wiki: WikiConfig = field(default_factory=WikiConfig)
     raw: dict[str, Any] = field(default_factory=dict)
     prompt_template: str = ""
     workspace_reuse_policy: str = DEFAULT_WORKSPACE_REUSE_POLICY
@@ -962,6 +978,31 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
     prompt_template = workflow.prompt_template or DEFAULT_PROMPT
     prompts = _build_prompt_config(cfg.get("prompts"), base_dir)
 
+    wiki_raw = cfg.get("wiki") or {}
+    if not isinstance(wiki_raw, dict):
+        wiki_raw = {}
+    sweep_every_n = _validated_nonnegative_or_default(
+        wiki_raw.get("sweep_every_n"), 10, name="wiki.sweep_every_n"
+    )
+    raw_wiki_root = wiki_raw.get("root")
+    if isinstance(raw_wiki_root, str) and raw_wiki_root.strip():
+        resolved_wiki = (
+            resolve_var_indirection(raw_wiki_root)
+            if raw_wiki_root.startswith("$")
+            else raw_wiki_root
+        )
+        if isinstance(resolved_wiki, str) and resolved_wiki:
+            wiki_path = Path(expand_path_value(resolved_wiki))
+            if not wiki_path.is_absolute():
+                wiki_path = (base_dir / wiki_path).resolve()
+            else:
+                wiki_path = wiki_path.resolve()
+        else:
+            wiki_path = (base_dir / "docs" / "llm-wiki").resolve()
+    else:
+        wiki_path = (base_dir / "docs" / "llm-wiki").resolve()
+    wiki = WikiConfig(sweep_every_n=sweep_every_n, root=wiki_path)
+
     return ServiceConfig(
         workflow_path=workflow.source_path,
         poll_interval_ms=poll_interval_ms,
@@ -978,6 +1019,7 @@ def build_service_config(workflow: WorkflowDefinition) -> ServiceConfig:
         progress=progress,
         system=system,
         prompts=prompts,
+        wiki=wiki,
         raw=dict(cfg),
         prompt_template=prompt_template,
         workspace_reuse_policy=workspace_reuse_policy,

--- a/tests/test_after_run_classifier.py
+++ b/tests/test_after_run_classifier.py
@@ -1,0 +1,148 @@
+"""B1: live-coverage for the WORKFLOW.md `after_run` marker classifier.
+
+The hook is a bash heredoc, so we exercise it through `bash -c` against a
+temp git repo. Without this, the only verification was indirect (a real
+claude/codex turn happens to omit a test file). The live 2026-05-17 demo
+showed claude doing strict TDD — adding src + test together — which
+means the marker never naturally fires and the prompt half (review.md
+scans wip subjects for `[no-test]`) could regress without anyone
+noticing.
+
+The classifier under test is the section inside WORKFLOW.md's `after_run`
+that picks a wip commit subject prefix. We extract it into a self-contained
+shell snippet so the test is hermetic.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+# A trimmed copy of the WORKFLOW.md classifier — same logic, no I/O on the
+# staged diff (we feed STAGED_FILES directly). If you change the classifier
+# in WORKFLOW.md, mirror that change here.
+_CLASSIFIER = textwrap.dedent(
+    r"""
+    set -uo pipefail
+    PROD_CHANGED=0
+    TESTS_CHANGED=0
+    SCOPE_EXPAND=0
+    SCOPE_FILES=""
+    if [ -n "${SYMPHONY_REWIND_SCOPE:-}" ]; then
+      SCOPE_FILES="$(printf '%s' "$SYMPHONY_REWIND_SCOPE" \
+        | tr ',' '\n' \
+        | sed -n 's/.*"file"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+    fi
+    NL=$(printf '\nx'); NL=${NL%x}
+    OLDIFS="$IFS"
+    IFS="$NL"
+    for f in $STAGED_FILES; do
+      [ -n "$f" ] || continue
+      case "$f" in
+        tests/*|*_test.py|*.test.ts|*.test.tsx|*_test.go) TESTS_CHANGED=1 ;;
+      esac
+      case "$f" in
+        tests/*|docs/*|kanban*|.symphony/*|*.md|LICENSE|LICENSE.*|NOTICE|CHANGELOG*|README*|AGENTS.md|GEMINI.md) : ;;
+        *) PROD_CHANGED=1 ;;
+      esac
+      if [ -n "$SCOPE_FILES" ] && [ "$SCOPE_EXPAND" = 0 ]; then
+        in_scope=0
+        for s in $SCOPE_FILES; do
+          [ "$f" = "$s" ] && in_scope=1 && break
+        done
+        [ "$in_scope" = 0 ] && SCOPE_EXPAND=1
+      fi
+    done
+    IFS="$OLDIFS"
+    PREFIX=""
+    [ "$PROD_CHANGED" = 1 ] && [ "$TESTS_CHANGED" = 0 ] && PREFIX="${PREFIX}[no-test]"
+    [ -n "${SYMPHONY_REWIND_SCOPE:-}" ] && [ "$SCOPE_EXPAND" = 1 ] && PREFIX="${PREFIX}[scope-expand]"
+    printf '%s' "$PREFIX"
+    """
+)
+
+
+def _classify(staged: str, *, rewind_scope: str | None = None) -> str:
+    env = {**os.environ, "STAGED_FILES": staged}
+    if rewind_scope is not None:
+        env["SYMPHONY_REWIND_SCOPE"] = rewind_scope
+    out = subprocess.run(
+        ["bash", "-c", _CLASSIFIER],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout
+
+
+def test_prod_only_change_gets_no_test_marker():
+    """A production-code change without a paired test → `[no-test]`."""
+    assert _classify("src/foo.py") == "[no-test]"
+
+
+def test_paired_test_clears_marker():
+    """Adding src + matching test in the same diff → no marker (TDD)."""
+    assert _classify("src/foo.py\ntests/test_foo.py") == ""
+
+
+def test_test_in_root_pattern_clears_marker():
+    """`*_test.go` / `*.test.ts` / `*_test.py` also count as tests."""
+    for staged in (
+        "internal/foo.go\ninternal/foo_test.go",
+        "src/foo.ts\nsrc/foo.test.ts",
+        "lib/foo.py\nlib/foo_test.py",
+    ):
+        assert _classify(staged) == "", f"failed for: {staged!r}"
+
+
+def test_docs_only_carve_out_clears_marker():
+    """README / CHANGELOG / *.md / LICENSE never count as production."""
+    for staged in (
+        "README.md",
+        "CHANGELOG.md",
+        "docs/feature.md",
+        "LICENSE",
+        "LICENSE.MIT",
+        "NOTICE",
+        "AGENTS.md",
+        "docs/symphony-prompts/file/stages/plan.md",
+    ):
+        assert _classify(staged) == "", f"failed for: {staged!r}"
+
+
+def test_scope_expand_marker_fires_on_out_of_scope_edit():
+    """Rewind dispatch + diff touches a file outside scope → `[scope-expand]`."""
+    scope = '[{"file": "src/auth.py", "line": 10, "fix": "validate", "severity": "HIGH"}]'
+    assert _classify(
+        "src/auth.py\ntests/test_auth.py\nsrc/leaked.py",
+        rewind_scope=scope,
+    ) == "[scope-expand]"
+
+
+def test_markers_stack():
+    """Prod-only + rewind-out-of-scope can stack both prefixes."""
+    scope = '[{"file": "src/only.py", "line": 1, "fix": "x", "severity": "HIGH"}]'
+    out = _classify("src/elsewhere.py", rewind_scope=scope)
+    assert "[no-test]" in out and "[scope-expand]" in out
+
+
+def test_no_staged_files_yields_empty_prefix():
+    assert _classify("") == ""
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "scripts/symphony-setup-worktree.sh",
+        "pyproject.toml",
+        "src/symphony/cli.py",
+    ],
+)
+def test_production_code_without_test_pairs(path):
+    """Various production paths trigger the marker absent a paired test."""
+    assert _classify(path) == "[no-test]"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -23,6 +23,7 @@ from symphony.backends import (
     EVENT_TURN_COMPLETED,
     EVENT_TURN_FAILED,
     BackendInit,
+    BaseAgentBackend,
     build_backend,
 )
 from symphony.backends.claude_code import ClaudeCodeBackend, _extract_text, _is_error_result
@@ -1142,7 +1143,7 @@ def test_pi_consume_stream_surfaces_compaction_events(tmp_path: Path) -> None:
             self.returncode = 0
 
     asyncio.run(
-        backend._consume_stream(_FakeProc())
+        backend._consume_stream(_FakeProc())  # type: ignore[arg-type]
     )
     kinds = [c["event"] for c in captured]
     # We expect: session_started, compaction(start), compaction(end),
@@ -1287,3 +1288,80 @@ async def test_codex_legacy_totals_path_still_works(tmp_path: Path) -> None:
         "output_tokens": 10,
         "total_tokens": 60,
     }
+
+
+# ---- Stall-progress predicate (C2) -------------------------------------
+# Backends share a `is_progress_event(event) -> bool` hook so the
+# orchestrator's stall-progress timer routes per-driver echo filtering
+# through the backend that knows its wire protocol. Default is conservative
+# (everything counts); only the Claude Code backend currently narrows.
+# Regression guard for the OLV-002 fix (commit 499e787).
+
+
+def test_base_backend_is_progress_event_is_true_by_default() -> None:
+    """Bare base class instance returns True for any event shape — the
+    conservative default that future backends inherit unless they override."""
+    backend = BaseAgentBackend()
+    assert backend.is_progress_event({"type": "assistant"}) is True
+    assert backend.is_progress_event({"type": "tool_result"}) is True
+    assert backend.is_progress_event({"type": "user"}) is True
+    assert backend.is_progress_event({}) is True
+
+
+def test_claude_backend_is_progress_event_filters_to_assistant(tmp_path: Path) -> None:
+    """ClaudeCodeBackend narrows the catch-all OTHER_MESSAGE bucket to
+    `type=="assistant"` only. `user`/`tool_result` echoes must NOT count
+    as progress, otherwise the 5-min stall timer never trips while the
+    model is silently spinning between tool calls (OLV-002 regression)."""
+    cfg = _make_cfg("claude", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = ClaudeCodeBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    assert backend.is_progress_event({"type": "assistant"}) is True
+    assert backend.is_progress_event({"type": "user"}) is False
+    assert backend.is_progress_event({"type": "tool_result"}) is False
+    assert backend.is_progress_event({}) is False
+
+
+def test_pi_backend_is_progress_event_defaults_to_true(tmp_path: Path) -> None:
+    cfg = _make_cfg("pi", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = PiBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    assert backend.is_progress_event({"type": "assistant"}) is True
+    assert backend.is_progress_event({"type": "tool_result"}) is True
+    assert backend.is_progress_event({}) is True
+
+
+def test_gemini_backend_is_progress_event_defaults_to_true(tmp_path: Path) -> None:
+    cfg = _make_cfg("gemini", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = GeminiBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    assert backend.is_progress_event({"type": "assistant"}) is True
+    assert backend.is_progress_event({"type": "tool_result"}) is True
+    assert backend.is_progress_event({}) is True
+
+
+def test_codex_backend_is_progress_event_filters_to_assistant(tmp_path: Path) -> None:
+    """CodexAppServerBackend mirrors the claude filter: catch-all
+    OTHER_MESSAGE payloads count only when `type=="assistant"`. Codex
+    item / toolCall previews lack `type` and so must NOT advance the
+    stall clock by themselves — the orchestrator separately uses output
+    token deltas as the codex progress signal (IB-006 fix)."""
+    cfg = _make_cfg("codex", workspace_root=tmp_path)
+    cwd = tmp_path / "ws"
+    cwd.mkdir()
+    backend = CodexAppServerBackend(
+        BackendInit(cfg=cfg, cwd=cwd, workspace_root=tmp_path, on_event=_noop_event)
+    )
+    assert backend.is_progress_event({"type": "assistant"}) is True
+    assert backend.is_progress_event({"type": "toolCall"}) is False
+    assert backend.is_progress_event({"item": {"type": "agentMessage"}}) is False
+    assert backend.is_progress_event({}) is False

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -2621,6 +2621,39 @@ def test_touched_files_for_missing_section_returns_empty_set():
     assert orch._touched_files_for(issue_none) == set()
 
 
+def test_touched_files_for_accepts_real_agent_bullet_annotations():
+    """Real agent output uses ` (new)` / ` (deleted)` / ` (M)` annotations.
+
+    A live claude demo (2026-05-17) emitted::
+
+        - `src/demo_math.py` (new)
+        - `tests/test_demo_math.py` (new)
+
+    A previous strict-`$` regex silently dropped both rows from the
+    conflict pre-check. Lock in the lenient trailing-content match so
+    that regression cannot return.
+    """
+    orch = _orch()
+    issue = _issue(
+        "MT-1",
+        description=(
+            "## Touched Files\n"
+            "- `src/demo_math.py` (new)\n"
+            "- `tests/test_demo_math.py` (new)\n"
+            "- `src/legacy/old.py` (deleted)\n"
+            "- src/plain.py (M)\n"
+            "- `src/has spaces/file.py` (modified)\n"
+        ),
+    )
+    assert orch._touched_files_for(issue) == {
+        "src/demo_math.py",
+        "tests/test_demo_math.py",
+        "src/legacy/old.py",
+        "src/plain.py",
+        "src/has spaces/file.py",
+    }
+
+
 def test_conflict_pre_check_blocks_overlapping_candidate(monkeypatch):
     """Two tickets, one running with `src/foo.py`; candidate also touches it.
 

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -520,6 +520,7 @@ def test_dispatch_task_cancelled_before_start_releases_running_slot():
         orch._loop = asyncio.get_running_loop()
         orch._dispatch(issue, cfg, attempt=None)
         task = orch._running[issue.id].worker_task
+        assert task is not None
         task.cancel()
         await asyncio.sleep(0)
         await asyncio.sleep(0)
@@ -2584,3 +2585,319 @@ def test_find_running_issue_id_resolves_human_identifier():
 
     assert orch.find_running_issue_id("OLV-002") == issue.id
     assert orch.find_running_issue_id("NOT-A-TICKET") is None
+
+
+# ---------------------------------------------------------------------------
+# C1 — system-level conflict pre-check (workflow-v0.5.2 § C1).
+# ---------------------------------------------------------------------------
+
+
+def test_touched_files_for_parses_bullet_list():
+    """`## Touched Files` section yields a set of repo-relative paths."""
+    orch = _orch()
+    issue = _issue(
+        "MT-1",
+        description=(
+            "## Brief\nHello\n\n"
+            "## Touched Files\n"
+            "- src/foo.py\n"
+            "- `src/bar.py`\n"
+            "- docs/notes.md — incidental\n\n"
+            "## Next\nbody"
+        ),
+    )
+    assert orch._touched_files_for(issue) == {
+        "src/foo.py",
+        "src/bar.py",
+        "docs/notes.md",
+    }
+
+
+def test_touched_files_for_missing_section_returns_empty_set():
+    orch = _orch()
+    issue = _issue("MT-1", description="## Brief only, no list")
+    assert orch._touched_files_for(issue) == set()
+    issue_none = _issue("MT-2", description=None)
+    assert orch._touched_files_for(issue_none) == set()
+
+
+def test_conflict_pre_check_blocks_overlapping_candidate(monkeypatch):
+    """Two tickets, one running with `src/foo.py`; candidate also touches it.
+
+    Outcome: candidate is moved to `Blocked` and `## Conflict` is appended,
+    no worker is dispatched. Mirrors workflow-v0.5.2 § C1 contract.
+    """
+    cfg = _make_config(
+        tracker_kind="file",
+        active_states=("Todo", "In Progress"),
+    )
+    held = _issue(
+        "MT-1",
+        state="In Progress",
+        description=(
+            "## Brief\nfoo\n\n"
+            "## Touched Files\n- src/foo.py\n- src/util.py\n"
+        ),
+    )
+    candidate = _issue(
+        "MT-2",
+        state="Todo",
+        description=(
+            "## Brief\nbar\n\n"
+            "## Touched Files\n- src/foo.py\n- src/other.py\n"
+        ),
+    )
+
+    orch = _orch()
+    monkeypatch.setattr(orch._workflow_state, "reload", lambda: (cfg, None))
+
+    # Install MT-1 as a live running entry — its description carries the
+    # `## Touched Files` body the conflict checker reads.
+    orch._running[held.id] = RunningEntry(
+        issue=held,
+        started_at=datetime.now(timezone.utc),
+        retry_attempt=None,
+        worker_task=None,  # type: ignore[arg-type]
+        workspace_path=Path("/tmp"),
+    )
+    orch._claimed.add(held.id)
+
+    dispatched: list[str] = []
+    appended: list[tuple[str, str, str]] = []
+    moved: list[tuple[str, str]] = []
+
+    async def _fetch(_cfg):
+        return [candidate]
+
+    async def _archive(_cfg):
+        return None
+
+    def _dispatch(_issue, _cfg, *, attempt, attempt_kind=None):
+        dispatched.append(_issue.identifier)
+
+    def _append(_cfg, _issue, heading, body):
+        appended.append((_issue.identifier, heading, body))
+
+    def _move(_cfg, _issue, target):
+        moved.append((_issue.identifier, target))
+
+    monkeypatch.setattr(orch, "_fetch_candidates", _fetch)
+    monkeypatch.setattr(orch, "_archive_sweep", _archive)
+    monkeypatch.setattr(orch, "_dispatch", _dispatch)
+    monkeypatch.setattr(
+        Orchestrator, "_tracker_call_append_note", staticmethod(_append)
+    )
+    monkeypatch.setattr(
+        Orchestrator, "_tracker_call_update_state", staticmethod(_move)
+    )
+
+    asyncio.run(orch._on_tick())
+
+    assert dispatched == [], "conflict must skip dispatch entirely"
+    assert moved == [("MT-2", "Blocked")], (
+        "candidate must be moved to Blocked on overlap"
+    )
+    assert appended == [
+        ("MT-2", "Conflict", appended[0][2])
+    ], "exactly one Conflict note must be appended"
+    note_body = appended[0][2]
+    assert "MT-1" in note_body, "Conflict note must name the other ticket"
+    assert "src/foo.py" in note_body, "Conflict note must list overlap path"
+    assert "src/other.py" not in note_body, (
+        "Non-overlapping paths must not appear in the Conflict note"
+    )
+
+
+def test_conflict_pre_check_no_overlap_dispatches_normally(monkeypatch):
+    """Non-overlapping `## Touched Files` lets dispatch proceed."""
+    cfg = _make_config(
+        tracker_kind="file",
+        active_states=("Todo", "In Progress"),
+    )
+    held = _issue(
+        "MT-1",
+        state="In Progress",
+        description="## Touched Files\n- src/foo.py\n",
+    )
+    candidate = _issue(
+        "MT-2",
+        state="Todo",
+        description="## Touched Files\n- src/bar.py\n",
+    )
+
+    orch = _orch()
+    monkeypatch.setattr(orch._workflow_state, "reload", lambda: (cfg, None))
+    orch._running[held.id] = RunningEntry(
+        issue=held,
+        started_at=datetime.now(timezone.utc),
+        retry_attempt=None,
+        worker_task=None,  # type: ignore[arg-type]
+        workspace_path=Path("/tmp"),
+    )
+    orch._claimed.add(held.id)
+
+    dispatched: list[str] = []
+
+    async def _fetch(_cfg):
+        return [candidate]
+
+    async def _archive(_cfg):
+        return None
+
+    def _dispatch(_issue, _cfg, *, attempt, attempt_kind=None):
+        dispatched.append(_issue.identifier)
+
+    monkeypatch.setattr(orch, "_fetch_candidates", _fetch)
+    monkeypatch.setattr(orch, "_archive_sweep", _archive)
+    monkeypatch.setattr(orch, "_dispatch", _dispatch)
+
+    asyncio.run(orch._on_tick())
+
+    assert dispatched == ["MT-2"], (
+        "non-overlapping touched files must not block dispatch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C3 — adaptive token-budget EMA (workflow-v0.5.2 § C3).
+# ---------------------------------------------------------------------------
+
+
+def test_token_ema_first_then_second_sample_matches_formula(tmp_path):
+    """α=0.3 EMA over two samples produces the expected rounded value.
+
+    First sample 100k against ema=0 → 0.3·100k = 30k.
+    Second sample 200k → 0.3·200k + 0.7·30k = 60k + 21k = 81k.
+    """
+    cfg = _make_config()
+    # Redirect the EMA file to a temp dir so the test never writes into
+    # the real `.symphony/` next to the repo's WORKFLOW.md.
+    cfg_temp = replace(cfg, workflow_path=tmp_path / "WORKFLOW.md")
+    orch = _orch()
+
+    orch._update_token_ema("In Progress", 100_000, cfg_temp)
+    assert orch._token_ema_for_state("In Progress") == 30_000
+
+    orch._update_token_ema("In Progress", 200_000, cfg_temp)
+    assert orch._token_ema_for_state("In Progress") == 81_000
+
+
+def test_token_ema_persists_and_reloads(tmp_path):
+    """EMA round-trips through `.symphony/token_ema.json` on restart."""
+    cfg = _make_config()
+    cfg_temp = replace(cfg, workflow_path=tmp_path / "WORKFLOW.md")
+    orch = _orch()
+
+    orch._update_token_ema("In Progress", 100_000, cfg_temp)
+    orch._update_token_ema("In Progress", 200_000, cfg_temp)
+
+    # New orchestrator with the same workflow path: load reads the file.
+    fresh = _orch()
+    fresh._load_token_ema(cfg_temp)
+    assert fresh._token_ema_for_state("In Progress") == 81_000
+    # Unseen state still reports 0.
+    assert fresh._token_ema_for_state("Review") == 0
+
+
+def test_token_budget_for_state_falls_back_to_default():
+    """`max_total_tokens_by_state` overrides; absent state uses the
+    global `max_total_tokens` cap.
+    """
+    base = _make_config()
+    cfg_with_caps = _replace_agent_field(
+        base,
+        max_total_tokens=500_000,
+        max_total_tokens_by_state={"in progress": 750_000},
+    )
+    orch = _orch()
+    assert orch._token_budget_for_state(cfg_with_caps, "In Progress") == 750_000
+    assert orch._token_budget_for_state(cfg_with_caps, "Review") == 500_000
+
+
+# ---------------------------------------------------------------------------
+# A2-orch — SYMPHONY_REWIND_SCOPE env var on rewind dispatch.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_dispatch_env_sets_rewind_scope_on_rewind(monkeypatch):
+    """Rewind dispatch must export SYMPHONY_REWIND_SCOPE as JSON."""
+    monkeypatch.delenv("SYMPHONY_REWIND_SCOPE", raising=False)
+    cfg = _make_config()
+    orch = _orch()
+    issue = _issue(
+        "MT-REWIND",
+        state="In Progress",
+        description=(
+            "## Plan\nimplement\n\n"
+            "## Review Findings\n"
+            "- HIGH: src/foo.py:42 — switch to shared helper\n"
+            "- MEDIUM src/bar.py:7 add input validation\n"
+        ),
+    )
+
+    orch._apply_dispatch_env(issue=issue, cfg=cfg, is_rewind=True)
+
+    import os
+    import json as _json
+
+    raw = os.environ.get("SYMPHONY_REWIND_SCOPE")
+    assert raw is not None, "SYMPHONY_REWIND_SCOPE must be set on rewind"
+    rows = _json.loads(raw)
+    assert isinstance(rows, list) and rows, "rewind scope must parse to list"
+    severities = {row["severity"] for row in rows}
+    assert "HIGH" in severities
+    files = {row["file"] for row in rows}
+    assert "src/foo.py" in files
+    # Env vars for budget always present, regardless of rewind.
+    assert os.environ.get("SYMPHONY_TOKEN_BUDGET") is not None
+    assert os.environ.get("SYMPHONY_TOKEN_EMA") is not None
+
+    # Clean up so the env var doesn't leak to other tests.
+    monkeypatch.delenv("SYMPHONY_REWIND_SCOPE", raising=False)
+
+
+def test_apply_dispatch_env_unsets_rewind_scope_on_forward(monkeypatch):
+    """Forward dispatch must NOT carry a stale SYMPHONY_REWIND_SCOPE."""
+    import os
+
+    cfg = _make_config()
+    orch = _orch()
+    issue = _issue(
+        "MT-FWD",
+        state="Plan",
+        description="## Brief\nnothing rewinding",
+    )
+
+    # Simulate a prior rewind dispatch leaving the env var set.
+    monkeypatch.setenv("SYMPHONY_REWIND_SCOPE", '[{"severity": "HIGH"}]')
+    orch._apply_dispatch_env(issue=issue, cfg=cfg, is_rewind=False)
+
+    assert os.environ.get("SYMPHONY_REWIND_SCOPE") is None, (
+        "forward dispatch must unset SYMPHONY_REWIND_SCOPE so a prior "
+        "rewind value cannot bleed across turns"
+    )
+
+
+def test_apply_dispatch_env_empty_list_when_findings_missing(monkeypatch):
+    """Rewind without parseable findings still sets the env (as `[]`)."""
+    import json as _json
+    import os
+
+    monkeypatch.delenv("SYMPHONY_REWIND_SCOPE", raising=False)
+    cfg = _make_config()
+    orch = _orch()
+    issue = _issue(
+        "MT-EMPTY",
+        state="In Progress",
+        description="## Plan only, no review findings here",
+    )
+
+    orch._apply_dispatch_env(issue=issue, cfg=cfg, is_rewind=True)
+
+    raw = os.environ.get("SYMPHONY_REWIND_SCOPE")
+    assert raw is not None
+    assert _json.loads(raw) == [], (
+        "missing Review Findings / QA Failure must produce an empty list, "
+        "not omit the env var entirely"
+    )
+    monkeypatch.delenv("SYMPHONY_REWIND_SCOPE", raising=False)

--- a/tests/test_orchestrator_dispatch.py
+++ b/tests/test_orchestrator_dispatch.py
@@ -1250,9 +1250,13 @@ def test_max_total_tokens_cap_cancels_worker(monkeypatch):
             assert entry.cancelled_at is not None, (
                 "breaching max_total_tokens must record cancelled_at"
             )
-            assert worker_task.cancelled() or worker_task.cancelling() > 0, (
-                "worker_task.cancel() must have been called"
+            # Task.cancelling() is 3.11+; fall back to .cancelled() so the
+            # assertion compiles on the 3.10 floor declared in pyproject.toml.
+            _cancelling = getattr(worker_task, "cancelling", None)
+            cancel_observed = worker_task.cancelled() or (
+                _cancelling is not None and _cancelling() > 0
             )
+            assert cancel_observed, "worker_task.cancel() must have been called"
             debug = orch._issue_debug.get(issue.id)
             assert debug is not None
             assert "token budget exceeded" in (debug.last_error or "")

--- a/tests/test_wiki_sweep.py
+++ b/tests/test_wiki_sweep.py
@@ -1,0 +1,291 @@
+"""C5 — unit tests for `symphony.wiki_sweep`."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from symphony import wiki_sweep
+from symphony.wiki_sweep import (
+    STALE_AFTER_DAYS,
+    STALE_MARKER,
+    DuplicateSlug,
+    StaleEntry,
+    sweep,
+)
+
+
+# ---------------------------------------------------------------------------
+# fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_entry(
+    root: Path,
+    slug: str,
+    *,
+    title: str,
+    last_updated: str | None = None,
+    body: str = "",
+) -> Path:
+    """Write a wiki entry shaped like the real `docs/llm-wiki/*.md` files."""
+    parts = [f"# {title}", "", body]
+    if last_updated is not None:
+        parts.extend(["", f"**Last updated:** {last_updated} by TEST."])
+    path = root / f"{slug}.md"
+    path.write_text("\n".join(parts).rstrip() + "\n", encoding="utf-8")
+    return path
+
+
+def _write_index(root: Path, rows: list[tuple[str, str, str]]) -> Path:
+    """Write `INDEX.md` with a header + a separator + the given rows."""
+    lines = [
+        "# docs/llm-wiki index",
+        "",
+        "| topic-slug | summary | last touched |",
+        "|------------|---------|--------------|",
+    ]
+    for slug, summary, last in rows:
+        lines.append(f"| {slug} | {summary} | {last} |")
+    path = root / "INDEX.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Missing / empty roots are no-ops, not errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_root_returns_clean_empty_report(tmp_path: Path) -> None:
+    """`sweep` on a path that doesn't exist must not raise."""
+    report = sweep(tmp_path / "does-not-exist")
+    assert report.is_clean()
+    assert report.index_present is False
+    assert report.duplicates == ()
+    assert report.orphans == ()
+
+
+def test_empty_root_with_no_index(tmp_path: Path) -> None:
+    """Empty root: clean, INDEX absent flag set."""
+    report = sweep(tmp_path)
+    assert report.is_clean()
+    assert report.index_present is False
+
+
+# ---------------------------------------------------------------------------
+# Duplicate slug (collision on `# Title`)
+# ---------------------------------------------------------------------------
+
+
+def test_detects_duplicate_titles(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Same Topic")
+    _write_entry(tmp_path, "beta", title="Same Topic")
+    _write_index(tmp_path, [("alpha", "a", "2026-05-17"), ("beta", "b", "2026-05-17")])
+
+    report = sweep(tmp_path, dry_run=True)
+    assert len(report.duplicates) == 1
+    dup = report.duplicates[0]
+    assert isinstance(dup, DuplicateSlug)
+    assert dup.title == "Same Topic"
+    assert {p.stem for p in dup.paths} == {"alpha", "beta"}
+    assert not report.is_clean()
+
+
+def test_single_title_is_not_a_duplicate(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha")
+    _write_entry(tmp_path, "beta", title="Beta")
+    _write_index(tmp_path, [("alpha", "a", "2026-05-17"), ("beta", "b", "2026-05-17")])
+
+    report = sweep(tmp_path, dry_run=True)
+    assert report.duplicates == ()
+
+
+# ---------------------------------------------------------------------------
+# Orphan files (no INDEX row)
+# ---------------------------------------------------------------------------
+
+
+def test_detects_orphan_file_without_index_row(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha")
+    _write_entry(tmp_path, "orphan-topic", title="Orphan")
+    _write_index(tmp_path, [("alpha", "a", "2026-05-17")])
+
+    report = sweep(tmp_path, dry_run=True)
+    assert [p.stem for p in report.orphans] == ["orphan-topic"]
+    assert not report.is_clean()
+
+
+def test_no_index_means_every_file_is_orphan(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha")
+    _write_entry(tmp_path, "beta", title="Beta")
+
+    report = sweep(tmp_path, dry_run=True)
+    assert report.index_present is False
+    assert {p.stem for p in report.orphans} == {"alpha", "beta"}
+
+
+# ---------------------------------------------------------------------------
+# Missing files (INDEX row, no file)
+# ---------------------------------------------------------------------------
+
+
+def test_detects_missing_files(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha")
+    _write_index(
+        tmp_path,
+        [("alpha", "a", "2026-05-17"), ("ghost", "missing", "2026-05-17")],
+    )
+
+    report = sweep(tmp_path, dry_run=True)
+    assert report.missing_files == ("ghost",)
+    assert not report.is_clean()
+
+
+# ---------------------------------------------------------------------------
+# Stale entries — idempotent ` (stale?)` append
+# ---------------------------------------------------------------------------
+
+
+def test_stale_appends_marker_idempotently(tmp_path: Path) -> None:
+    today = date(2026, 5, 17)
+    very_old = (today - timedelta(days=STALE_AFTER_DAYS + 10)).isoformat()
+    fresh = today.isoformat()
+    _write_entry(tmp_path, "old-topic", title="Old", last_updated=very_old)
+    _write_entry(tmp_path, "new-topic", title="New", last_updated=fresh)
+    _write_index(
+        tmp_path,
+        [("old-topic", "old summary", "2026-01-01"), ("new-topic", "fresh summary", "2026-05-17")],
+    )
+
+    report = sweep(tmp_path, dry_run=False, today=today)
+    assert len(report.stale_entries) == 1
+    stale = report.stale_entries[0]
+    assert isinstance(stale, StaleEntry)
+    assert stale.slug == "old-topic"
+    assert stale.age_days > STALE_AFTER_DAYS
+    # stale alone is not an error
+    assert report.is_clean()
+    # marker was written
+    text = (tmp_path / "INDEX.md").read_text(encoding="utf-8")
+    assert f"| old-topic | old summary{STALE_MARKER} |" in text
+    assert "| new-topic | fresh summary |" in text
+
+    # Second run: idempotent — no further mutation, but stale_entries still reported.
+    report2 = sweep(tmp_path, dry_run=False, today=today)
+    text2 = (tmp_path / "INDEX.md").read_text(encoding="utf-8")
+    assert text == text2
+    assert len(report2.stale_entries) == 1
+    assert report2.mutations == ()
+
+
+def test_dry_run_does_not_write_stale_marker(tmp_path: Path) -> None:
+    today = date(2026, 5, 17)
+    very_old = (today - timedelta(days=STALE_AFTER_DAYS + 5)).isoformat()
+    _write_entry(tmp_path, "old-topic", title="Old", last_updated=very_old)
+    _write_index(tmp_path, [("old-topic", "summary", "2024-01-01")])
+    original = (tmp_path / "INDEX.md").read_text(encoding="utf-8")
+
+    report = sweep(tmp_path, dry_run=True, today=today)
+    assert len(report.stale_entries) == 1
+    assert report.mutations == ()
+    assert (tmp_path / "INDEX.md").read_text(encoding="utf-8") == original
+
+
+def test_no_last_updated_is_not_stale(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha")  # no Last updated line
+    _write_index(tmp_path, [("alpha", "a", "2026-05-17")])
+    report = sweep(tmp_path, dry_run=True, today=date(2030, 1, 1))
+    assert report.stale_entries == ()
+
+
+# ---------------------------------------------------------------------------
+# Aggregate behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_summary_lines_includes_root_and_counts(tmp_path: Path) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha")
+    _write_index(tmp_path, [("alpha", "a", "2026-05-17"), ("ghost", "g", "2026-05-17")])
+    report = sweep(tmp_path, dry_run=True)
+    lines = report.summary_lines()
+    assert any(str(tmp_path) in line for line in lines)
+    assert any("missing_files=1" in line for line in lines)
+
+
+def test_is_clean_distinguishes_stale_from_errors(tmp_path: Path) -> None:
+    today = date(2026, 5, 17)
+    _write_entry(
+        tmp_path,
+        "old",
+        title="Old",
+        last_updated=(today - timedelta(days=STALE_AFTER_DAYS + 1)).isoformat(),
+    )
+    _write_index(tmp_path, [("old", "summary", "2024-01-01")])
+    report = sweep(tmp_path, dry_run=True, today=today)
+    assert report.stale_entries  # stale found
+    assert report.is_clean()  # but no errors
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_sweep_does_not_mutate_index_when_clean(tmp_path: Path, dry_run: bool) -> None:
+    _write_entry(tmp_path, "alpha", title="Alpha", last_updated="2026-05-17")
+    _write_index(tmp_path, [("alpha", "summary", "2026-05-17")])
+    original = (tmp_path / "INDEX.md").read_text(encoding="utf-8")
+    report = sweep(tmp_path, dry_run=dry_run, today=date(2026, 5, 17))
+    assert report.is_clean()
+    assert (tmp_path / "INDEX.md").read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes — make sure errors propagate, stale-only does not.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_wiki_sweep_exit_code_for_error(tmp_path: Path) -> None:
+    """Run the CLI directly. Error condition (orphan) → exit 1."""
+    from symphony import cli
+
+    _write_entry(tmp_path, "orphan", title="Orphan")  # no INDEX
+
+    rc = cli.main(["wiki-sweep", "--root", str(tmp_path), "--dry-run"])
+    assert rc == 1
+
+
+def test_cli_wiki_sweep_exit_code_clean(tmp_path: Path) -> None:
+    from symphony import cli
+
+    _write_entry(tmp_path, "alpha", title="Alpha", last_updated="2026-05-17")
+    _write_index(tmp_path, [("alpha", "summary", "2026-05-17")])
+    rc = cli.main(["wiki-sweep", "--root", str(tmp_path), "--dry-run"])
+    assert rc == 0
+
+
+def test_cli_wiki_sweep_handles_missing_root(tmp_path: Path) -> None:
+    from symphony import cli
+
+    rc = cli.main(["wiki-sweep", "--root", str(tmp_path / "does-not-exist")])
+    # Empty root is clean per sweep contract.
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Module exports
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports() -> None:
+    """Guard against accidental API removals."""
+    for name in (
+        "sweep",
+        "SweepReport",
+        "DuplicateSlug",
+        "StaleEntry",
+        "WikiEntry",
+        "IndexRow",
+        "STALE_AFTER_DAYS",
+        "STALE_MARKER",
+    ):
+        assert hasattr(wiki_sweep, name), f"missing public name: {name}"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -226,6 +226,17 @@ async def test_file_workflow_after_create_hides_host_symlink_roots_from_git(tmp_
     (host / "docs").mkdir()
     (host / "kanban" / "DEMO-1.md").write_text("---\nstate: Review\n---\n")
     (host / "docs" / "seed.md").write_text("seed\n")
+    # C4 — the after_create hook now delegates to scripts/symphony-setup-worktree.sh
+    # under SYMPHONY_WORKFLOW_DIR. Copy the canonical script into the synthetic
+    # host so the hook can find it (real users have it next to WORKFLOW.md).
+    import shutil as _shutil
+    repo_root = Path(__file__).parents[1]
+    (host / "scripts").mkdir()
+    _shutil.copy2(
+        repo_root / "scripts" / "symphony-setup-worktree.sh",
+        host / "scripts" / "symphony-setup-worktree.sh",
+    )
+    (host / "scripts" / "symphony-setup-worktree.sh").chmod(0o755)
     _git(host, "add", "-A")
     _git(host, "commit", "-q", "-m", "seed")
 


### PR DESCRIPTION
## Summary

v0.5.1 -> v0.6.0. Eleven coordinated changes across agent prompts and the orchestrator so Symphony ticket outcomes are predictable and the system is observable. Plan + post-fix verification log: [`docs/improvements/workflow-v0.5.2.md`](docs/improvements/workflow-v0.5.2.md).

### Prompt contracts (agent-visible)
- **A1** Plan emits `## Acceptance Tests` + `## Done Signals`; QA scores them via `## AC Scorecard`.
- **A2** Rewinds receive `SYMPHONY_REWIND_SCOPE` JSON env and scope edits to flagged files (`## Scope Expansion` for justified spillover).
- **A3** Explore emits a scored `reuse-inventory.md`; Plan candidate set is now an explicit Markdown table with `reuse_from` + `observability` columns (revised after live demo showed claude falling back to bullets under the original prose-only spec).
- **B2** Review emits a 7-row `## Security Audit` (secrets / input-validation / sql-injection / xss / csrf / authz / rate-limit); any `fail` auto-promotes to CRITICAL.
- **B3** Wiki entries record `**Observability hooks:**` (log / metric / trace) under `## Technical Reference` (KO + EN). Plan candidate table gains `observability` column.

### Harness (orchestrator + hooks)
- **C1** Orchestrator parses `## Touched Files` at dispatch and auto-Blocks overlapping candidates with a `## Conflict` section. Agent-side pre-check removed. Regex hardened to accept real-world annotations like `` `path` (new) `` and `` `path with spaces` (deleted) `` (live demo found this gap).
- **C2** `BaseAgentBackend.is_progress_event` lifts the meta-event stall filter into one place. Claude + Codex override; Pi + Gemini inherit the conservative default.
- **C3** Per-state EMA of completion tokens persists to `.symphony/token_ema.json`; dispatch injects `SYMPHONY_TOKEN_EMA` + `SYMPHONY_TOKEN_BUDGET`. The EMA captures the source state at `worker_turn_started` so token costs attribute to the stage that actually consumed them (live demo found pre-fix EMA was recording under the destination state).
- **B1** `after_run` prefixes the wip commit with `[no-test]` when prod-code diff lacks a paired test. Review scans the marker and promotes each to HIGH. Carve-out includes `*.md`, `LICENSE*`, `NOTICE`, `CHANGELOG*`, `README*`, `AGENTS.md`, `GEMINI.md`. 10 hermetic shell tests pin the classifier.
- **C4** 200-line `after_create` heredoc extracted to `scripts/symphony-setup-worktree.sh`; hook is a one-liner.
- **C5** New `symphony wiki-sweep` CLI scans `docs/llm-wiki/` for dup / orphan / stale rows. Orchestrator runs it every Nth `Done` (default `wiki.sweep_every_n: 10`). Done counter persists to `.symphony/done_count.json` so cadence survives orchestrator restarts.

### Bug fixes
- `after_run` YAML literal block fixed (replaced `IFS='\n'` with POSIX `printf` trick).
- C1 path-with-spaces regex hardened (backtick + plain forms, lenient trailing content).
- C5 done counter persistence.

### Release hygiene
- `pyproject.toml` + `src/symphony/__init__.py` bumped to `0.6.0` in lockstep, separate `chore(release)` commit.
- CHANGELOG `[0.6.0]` entry with PM-readable per-item summaries.

## Live demo verification

Two backends (claude + codex) ran the same demo ticket twice — once with the original v0.6.0 bundle, once after addressing the gaps surfaced by run 1.

| Fix | Run 1 (pre-fix) | Run 2 (post-fix) |
|---|---|---|
| C1 regex `(new)` annotation | parser returned `set()` | parses both paths |
| C3 EMA keys | `plan, in progress, review` (destination state) | `explore, plan` (source state) on both backends |
| A3 Plan candidate table | claude=bullets; columns missing | both backends emit full 3-row table |
| B2 Security Audit | claude emitted exact 7-row table; codex sandbox blocked file write | not re-tested (out of mini-run scope) |

Also live-verified: `## Acceptance Tests`, `## Done Signals`, `## Implementation`, `reuse-inventory.md`, `work/feature.md`, `implementation-plan.md`, conflict pre-check parser, no spurious stalls under 5+ minute codex turns, EMA persistence across restarts.

## Test plan

- [x] `pytest -q` -> 519 passed, 6 skipped.
- [x] YAML parse check on all three `WORKFLOW*.md` files.
- [x] `python -m symphony wiki-sweep --root docs/llm-wiki --dry-run` exits 0 on clean / missing root.
- [x] `scripts/symphony-setup-worktree.sh` has `+x` mode bit (100755).
- [x] code-reviewer pass: HIGH x 2 + MEDIUM x 1 addressed in fix commit; 3 MEDIUMs filed as follow-ups.
- [x] Live demo, claude + codex, run 1 (full Todo->Done arc, max_turns=4) + run 2 (Explore->Plan, max_turns=2).
- [ ] Manual: run a live ticket on the host repo's main board through one full cycle before tagging the release.

## Commits

- `ba9273c` -- docs: plan 11-item workflow accuracy + harness upgrade
- `61f5a2d` -- feat(workflow): accuracy + harness upgrade (v0.6.0)
- `86ca62b` -- chore(release): v0.6.0
- `8be3d26` -- fix(workflow): address code-review HIGH + MEDIUM items
- `1e82d70` -- fix(workflow): close gaps surfaced by live demo
- `aa31f3b` -- chore: clarify wiki_sweep imports
- `123800c` -- docs: record post-fix live re-verification + out-of-scope findings

## Follow-ups (filed in plan doc, NOT in this PR)

- C1 retry-overlap completeness (best-effort today; needs tracker re-read at dispatch).
- C3 per-subprocess `env=` for true isolation under `max_concurrent_agents > 1`.
- C3 Windows rename atomicity on concurrent reader hold.
- Codex sandbox blocks symlinked board writes (pre-existing; surfaced during demo).
- EMA last-writer-wins under multiple co-located orchestrators sharing `.symphony/` (test-harness curiosity).
