### PR TITLE
chore(prompts): trim verbose stage prompts (-3.6%)

### DIFF
--- a/docs/symphony-prompts/file/base.md
+++ b/docs/symphony-prompts/file/base.md
@@ -41,9 +41,8 @@ entry per topic plus an `INDEX.md`. Explore reads it before new work;
 Learn writes back after QA passes. Treat it as living memory future
 tickets depend on. The first Learn stage creates the directory if missing.
 Plan turns Explore's candidates into a single executable `## Plan`; In
-Progress must read that plan before editing code.
-After Learn writes back, merge the ticket's `symphony/{{ issue.identifier }}`
-feature branch into the target branch before marking the ticket `Done`.
+Progress must read that plan before editing code. Learn's Merge Gate
+handles feature-branch integration before `Done`.
 
 `docs/{{ issue.identifier }}/` is this ticket's evidence root — see Hard rules below for the artefact policy. Learn writes to `${LLM_WIKI_PATH:-./docs/llm-wiki}/<topic>.md`, a sibling under the same `docs/` root.
 

--- a/docs/symphony-prompts/file/stages/in-progress.md
+++ b/docs/symphony-prompts/file/stages/in-progress.md
@@ -9,17 +9,13 @@ You are the implementer. Ship the smallest change that satisfies the brief.
    missing a required detail. If `## Plan` is missing, set state to `Plan`,
    append `## Plan Missing`, and stop. Fresh context means earlier
    conversation is gone; the markdown is the contract.
-2. **Rewind scope.** If `$SYMPHONY_REWIND_SCOPE` is set (Symphony injects
-   it on Review→In Progress / QA→In Progress rewinds), it is a JSON array
-   of `{severity, file, line, fix}` rows from the most recent
-   `## Review Findings` or `## QA Failure`. Implement only fixes for those
-   files. If you genuinely need to touch a file not listed, append
-   `## Scope Expansion` with a one-line rationale per extra file and
-   proceed — this does not block, but Symphony marks the wip commit
-   `[scope-expand]`. When the env var is unset, follow `## Plan` normally;
-   if the most recent ticket section is `## QA Failure` or
-   `## Review Findings` and the env var is missing, fall back to scoping
-   the turn to those flagged items.
+2. **Rewind scope.** `$SYMPHONY_REWIND_SCOPE` is a JSON
+   `{severity, file, line, fix}[]` Symphony sets on Review→In Progress /
+   QA→In Progress rewinds. Scope this turn to those files. Touching any
+   other file needs a one-line `## Scope Expansion` rationale (commit
+   gets a `[scope-expand]` marker — non-blocking). Unset → follow
+   `## Plan`; unset AND the latest section is `## QA Failure` /
+   `## Review Findings` → scope to those rows anyway.
 3. Implement the chosen option from `## Plan` (or, on rewind, only the
    flagged failure items above). Do not reopen the plan unless the brief
    got a fact wrong — then append a one-line `## Plan Adjustment` and

--- a/docs/symphony-prompts/file/stages/learn.md
+++ b/docs/symphony-prompts/file/stages/learn.md
@@ -64,17 +64,12 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    **Last updated:** YYYY-MM-DD by <issue.identifier>.
    ```
 
-   `## 감 잡기` 작성 규칙 (강제):
-   - 전문용어를 앞쪽에 쏟지 말 것. 꼭 써야 하면 같은 줄에 짧은 괄호 설명을 붙인다.
-   - 사전식 정의 금지. "X는 ~을 의미한다" 대신 "X는 마치 ~처럼 동작한다" 또는 "X를 쓰면 ~이 된다".
-   - 비유는 쓰되 유치하지 않게. 독자가 이미 아는 비즈니스 도메인 비유가 우선.
-   - 핵심 흐름 화살표는 3-5단계. 7개면 감이 아니라 스펙이 된다.
-   - 용어 표는 정확히 5개. 더 적으면 부족, 더 많으면 초보자 단계가 아님.
-   - 엣지 케이스·내부 구현·성능 트레이드오프는 빼고 마지막 줄 "나중에 배울 내용"으로 미룬다.
-   - 문장은 짧고 명확하게. 한 문장에 한 가지만.
-   - "이것만 기억하면 된다"는 정확히 한 문장. 두 문장이면 핵심이 둘 → 쪼개라.
+   `## 감 잡기` 작성 규칙:
+   - 사전식 정의 금지. "X는 마치 ~처럼 동작한다" 또는 "X를 쓰면 ~이 된다"로 풀어쓴다.
+   - 화살표 3-5단계, 용어 표 정확히 5개, takeaway 정확히 한 문장 — 위 template이 이미 강제.
+   - 비즈니스 도메인 비유 우선. 엣지 케이스·내부 구현은 "나중에 배울 내용"으로 미룬다.
 
-   기존 엔트리에 `## 감 잡기`가 없으면 이번 Learn에서 추가한다. 이미 있다면, 이번 티켓이 비유나 핵심 흐름을 무너뜨렸을 때만 손본다 (사소한 wording 변경 금지 — Decision log row로 충분).
+   기존 엔트리에 `## 감 잡기`가 없으면 이번 Learn에서 추가. 있다면 이번 티켓이 비유나 핵심 흐름을 무너뜨렸을 때만 손본다 (사소한 wording 변경은 Decision log row로 충분).
 {% else %}
    ```
    # <Topic Title>
@@ -132,16 +127,11 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    ```
 
    Hard rules for the `## Getting the Feel` block:
-   - Do not front-load jargon. If a domain term is unavoidable, attach a short parenthetical on the same line.
    - No dictionary definitions. Write "X behaves like ..." or "you use X when ...", never "X is defined as ...".
-   - Analogies welcome but not childish. Prefer business-domain analogies the reader already lives in.
-   - Arrow flow stays at 3-5 steps. Seven steps stop being a "feel" — they're a spec.
-   - Exactly five terms in the table. Fewer = under-explained; more = no longer beginner level.
-   - Defer edge cases, internal implementation, performance trade-offs — push them under "ready to go deeper".
-   - Short, clear sentences. One idea per sentence.
-   - "Just remember this" must be exactly one sentence. Two sentences = two takeaways → split the topic.
+   - Arrow flow 3-5 steps, table exactly 5 terms, "Just remember this" exactly one sentence — the template above already enforces shape.
+   - Prefer business-domain analogies the reader lives in. Defer edge cases / internals to "ready to go deeper".
 
-   If the entry has no `## Getting the Feel` section, add one this turn. If it already exists, touch it only when this ticket invalidated the analogy or core flow — small wording tweaks are out of scope (a Decision log row is enough).
+   Add the block if absent. If present, touch it only when this ticket invalidated the analogy or core flow — small wording tweaks belong in the Decision log.
 {% endif %}
 
 4. Wiki integrity (lightweight at the ticket level):

--- a/docs/symphony-prompts/file/stages/plan.md
+++ b/docs/symphony-prompts/file/stages/plan.md
@@ -35,9 +35,8 @@ execute by reading only `## Plan`. Do not write production code in this stage.
    - `reuse_from`: a `path:line` from `reuse-inventory.md`, or `none`.
    - `observability`: `add`, `change`, or `none` — declares whether this
      candidate adds, modifies, or skips logs/metrics/traces.
-   - Live agent demo (2026-05-17) showed bullets silently dropping
-     both columns; the explicit header above is non-optional so Plan
-     Rationale and Learn can rely on the columns existing.
+   - The table header (not a bullet list) is mandatory — Plan Rationale
+     and Learn depend on those two columns existing.
 5. Append `## Acceptance Tests` — one bullet per AC, each a runnable test
    signature (e.g. `tests/test_foo.py::test_bar` or
    `pytest -k "expr"` / `npm test -- --grep "..."`). Empty list is invalid:

--- a/docs/symphony-prompts/file/stages/review.md
+++ b/docs/symphony-prompts/file/stages/review.md
@@ -16,14 +16,12 @@ You are the reviewer. Find issues; do not fix them.
 3. Apply the checklist: clarity, naming, error handling, security,
    performance, simplicity, no dead code, no debug prints, no secrets.
    Then scan `git log --format=%s $(git config symphony.basesha)..HEAD`
-   for `[no-test]` commit-subject markers (Symphony's `after_run` hook
-   prefixes wip commits that changed production code without a paired
-   test). Each `[no-test]` marker becomes a HIGH severity row in
-   `## Review Findings` (file: the unpaired production path; fix: "add a
-   test exercising this change") UNLESS the In Progress turn was
-   documentation-only (only `docs/`, `kanban/`, `.symphony/` paths
-   changed in that commit). Note the exemption in `## Review` if you
-   apply it.
+   for `[no-test]` markers (Symphony's `after_run` hook prefixes wip
+   commits that changed prod code without a paired test). Each marker
+   = HIGH row in `## Review Findings` (file = unpaired prod path; fix =
+   "add a test exercising this change"). Exempt: commit changed only
+   `docs/` / `kanban/` / `.symphony/` paths — note the exemption in
+   `## Review` if applied.
 4. Use live HTTP proof only when this ticket changed runtime API behavior
    or its acceptance criteria explicitly require endpoint execution. For
    docs-only API mapping / scenario-definition tickets, verify against

--- a/docs/symphony-prompts/linear/base.md
+++ b/docs/symphony-prompts/linear/base.md
@@ -42,9 +42,8 @@ entry per topic plus an `INDEX.md`. Explore reads it before new work;
 Learn writes back after QA passes. Treat it as living memory future
 tickets depend on. The first Learn stage creates the directory if missing.
 Plan turns Explore's candidates into a single executable `## Plan`; In
-Progress must read that plan before editing code.
-After Learn writes back, merge the ticket's `symphony/{{ issue.identifier }}`
-feature branch into the target branch before marking the issue `Done`.
+Progress must read that plan before editing code. Learn's Merge Gate
+handles feature-branch integration before `Done`.
 
 `docs/{{ issue.identifier }}/` is this ticket's evidence root — see Hard rules below for the artefact policy. Learn writes to `${LLM_WIKI_PATH:-./docs/llm-wiki}/<topic>.md`, a sibling under the same `docs/` root.
 

--- a/docs/symphony-prompts/linear/stages/learn.md
+++ b/docs/symphony-prompts/linear/stages/learn.md
@@ -58,17 +58,12 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    **Last updated:** YYYY-MM-DD by <issue.identifier>.
    ```
 
-   `## 감 잡기` 작성 규칙 (강제):
-   - 전문용어를 앞쪽에 쏟지 말 것. 꼭 써야 하면 같은 줄에 짧은 괄호 설명을 붙인다.
-   - 사전식 정의 금지. "X는 ~을 의미한다" 대신 "X는 마치 ~처럼 동작한다" 또는 "X를 쓰면 ~이 된다".
-   - 비유는 쓰되 유치하지 않게. 독자가 이미 아는 비즈니스 도메인 비유가 우선.
-   - 핵심 흐름 화살표는 3-5단계. 7개면 감이 아니라 스펙이 된다.
-   - 용어 표는 정확히 5개. 더 적으면 부족, 더 많으면 초보자 단계가 아님.
-   - 엣지 케이스·내부 구현·성능 트레이드오프는 빼고 마지막 줄 "나중에 배울 내용"으로 미룬다.
-   - 문장은 짧고 명확하게. 한 문장에 한 가지만.
-   - "이것만 기억하면 된다"는 정확히 한 문장. 두 문장이면 핵심이 둘 → 쪼개라.
+   `## 감 잡기` 작성 규칙:
+   - 사전식 정의 금지. "X는 마치 ~처럼 동작한다" 또는 "X를 쓰면 ~이 된다"로 풀어쓴다.
+   - 화살표 3-5단계, 용어 표 정확히 5개, takeaway 정확히 한 문장 — 위 template이 이미 강제.
+   - 비즈니스 도메인 비유 우선. 엣지 케이스·내부 구현은 "나중에 배울 내용"으로 미룬다.
 
-   기존 엔트리에 `## 감 잡기`가 없으면 이번 Learn에서 추가한다. 이미 있다면, 이번 티켓이 비유나 핵심 흐름을 무너뜨렸을 때만 손본다 (사소한 wording 변경 금지 — Decision log row로 충분).
+   기존 엔트리에 `## 감 잡기`가 없으면 이번 Learn에서 추가. 있다면 이번 티켓이 비유나 핵심 흐름을 무너뜨렸을 때만 손본다 (사소한 wording 변경은 Decision log row로 충분).
 {% else %}
    ```
    # <Topic Title>
@@ -120,16 +115,11 @@ Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wik
    ```
 
    Hard rules for the `## Getting the Feel` block:
-   - Do not front-load jargon. If a domain term is unavoidable, attach a short parenthetical on the same line.
    - No dictionary definitions. Write "X behaves like ..." or "you use X when ...", never "X is defined as ...".
-   - Analogies welcome but not childish. Prefer business-domain analogies the reader already lives in.
-   - Arrow flow stays at 3-5 steps. Seven steps stop being a "feel" — they're a spec.
-   - Exactly five terms in the table. Fewer = under-explained; more = no longer beginner level.
-   - Defer edge cases, internal implementation, performance trade-offs — push them under "ready to go deeper".
-   - Short, clear sentences. One idea per sentence.
-   - "Just remember this" must be exactly one sentence. Two sentences = two takeaways → split the topic.
+   - Arrow flow 3-5 steps, table exactly 5 terms, "Just remember this" exactly one sentence — the template above already enforces shape.
+   - Prefer business-domain analogies the reader lives in. Defer edge cases / internals to "ready to go deeper".
 
-   If the entry has no `## Getting the Feel` section, add one this turn. If it already exists, touch it only when this ticket invalidated the analogy or core flow — small wording tweaks are out of scope (a Decision log row is enough).
+   Add the block if absent. If present, touch it only when this ticket invalidated the analogy or core flow — small wording tweaks belong in the Decision log.
 {% endif %}
 
 4. Wiki integrity sweep before transitioning:


### PR DESCRIPTION
## Summary

LLM-targeted prompts had layered explanations of constraints that the templates above them already enforce structurally. Cut the restated rules and one dev-history comment; kept every load-bearing path/state/table-header rule.

- **learn.md** (file + linear): "감 잡기" / "Getting the Feel" rules block duplicated template-enforced shape (5 terms, 3-5 arrows, one-sentence takeaway). 9→5 lines (KR) and 12→5 lines (EN) per locale.
- **plan.md** (file): drop 2026-05-17 war-story comment about bullets dropping table columns — the table-header requirement directly above stands on its own.
- **in-progress.md** (file): rewind-scope step compressed 11→7 lines; keeps `SYMPHONY_REWIND_SCOPE` contract, `[scope-expand]` marker, unset-fallback semantics.
- **review.md** (file): `[no-test]` marker exemption logic compressed 11→9 lines.
- **base.md** (file + linear): drop redundant "merge feature branch before Done" line — Learn stage Merge Gate already owns this transition.

Total: 10997 → 10598 words (-399, -3.6%). 7 files changed, 39 insertions, 68 deletions.

## Why this is safe to land

- **Linear mirrors only touched where they already had the same content.** linear/plan.md, linear/in-progress.md, linear/review.md never had the cut blocks — left alone (linear doesn't use `SYMPHONY_REWIND_SCOPE` at all).
- **Length caps, transition rules, artefact paths, table headers, hard rules — all preserved verbatim.** Those are deterministic-output guards; trimming them would surface as artefact drift on real ticket runs.
- **Style rules now sit under templates that physically enforce shape.** The 5-term table, A→B→C arrow flow, and "one sentence takeaway" are visible in the template itself; the rules block now only carries the non-shape rules (no dictionary definitions, business-domain analogies, defer edge cases).

## Test plan

- [x] `pytest -q` — 519 passed, 6 skipped (unchanged from baseline)
- [x] `pytest tests/test_workflow_pipeline_prompt.py tests/test_workflow.py tests/test_after_run_classifier.py` — 98 passed (prompt loading + after_run classifier reads `docs/symphony-prompts/file/stages/plan.md` path)
- [ ] Operator smoke: dispatch one ticket per backend (claude, codex) through Plan → Learn and confirm: (a) Plan Candidates table still renders with `reuse_from` + `observability` columns, (b) Learn entry still includes a `## 감 잡기` / `## Getting the Feel` block with the right shape, (c) In Progress rewind dispatch honors `SYMPHONY_REWIND_SCOPE`.

## Rollback

`git revert <merge-sha>` — pure-text change, no schema or contract migration.