### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "symphony-multi-agent"
-version = "0.6.0"
+version = "0.6.1"
 description = "Multi-agent fork of OpenAI Symphony — supports Codex CLI, Claude Code CLI, Gemini CLI, and Pi CLI behind a single orchestrator with a Jira-style CLI Kanban TUI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/symphony/__init__.py
+++ b/src/symphony/__init__.py
@@ -1,3 +1,3 @@
 """Symphony — coding agent orchestration service (SPEC v1)."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
## Summary
Patch release rolling up post-0.6.0 reliability fixes. All changes are bug fixes restoring intended behavior — no user-facing feature additions or signature changes.

## Included fixes
| PR / commit | Area |
|---|---|
| #19 (cherry-picked into chore/pr-backlog-cleanup) | orchestrator: refresh workflow dir on hook reload |
| #21 (cherry-picked) | orchestrator: stop failed phase-transition backend on cleanup-on-failure |
| #22 | tracker: isolate corrupt file tickets during scan |
| #23 mechanism (cherry-picked) | workspace: honor `symphony.autocommitExclude` git config (opt-in escape hatch; default unchanged) |
| #34 | codex: force valid model on app-server spawn to avoid silent hang on invalid `~/.codex/config.toml` model |
| #34 | workspace: pin hook stdin to `/dev/null` for background-launched backends (fixes `init_sys_streams` Fatal Python error in hook subprocess) |

## Why patch (not minor)
All changes restore previously-suppressed correct behavior or surface clearer failure modes. No new public APIs, no signature changes, no new config keys that the operator must touch (autocommitExclude is opt-in and a no-op when unset).

## Verified live
- claude agent: SMA-24 (Verify orchestrator fixes from PR #19 + PR #21) completed end-to-end Explore → Done with auto_merge to main.
- codex agent: SMA-25 (Verify autocommitExclude mechanism from PR #23) currently in Review after `525 passed, 6 skipped` pytest gate. Spawn + 5 phase transitions + QA rewind all without `port_exit` or hook fd-inherit failures (both #34 fixes exercised).

## Test plan
- [x] `pytest tests/test_orchestrator_dispatch.py tests/test_orchestrator_phase_transition.py tests/test_workspace.py -q` → 116 passed, 1 skipped (local).
- [x] `pyproject.toml` and `src/symphony/__init__.py` bumped in lockstep.
- [ ] `pip install -e '.[dev]'` on a fresh clone reports `symphony --version` shape as `0.6.1`.
- [ ] CI green.