### PR TITLE
fix(codex): add git-worktree gitdir to sandbox writable_roots

### DIFF
--- a/src/symphony/backends/codex.py
+++ b/src/symphony/backends/codex.py
@@ -146,21 +146,35 @@ def _sandbox_uses_workspace_write(*values: Any) -> bool:
 
 
 def _scan_workspace_symlinks(*roots: Path) -> list[str]:
-    """Return realpath targets of top-level symlinks in workspace roots.
+    """Return realpath targets of top-level symlinks AND git-worktree gitdirs.
 
-    Codex with ``sandbox_mode=workspace-write`` resolves symlinks via realpath
+    Codex with ``sandbox_mode=workspace-write`` resolves paths via realpath
     and refuses to write through paths whose target falls outside the
-    workspace root. When ``after_create`` symlinks host repo directories
-    (kanban/, prompt/, ...) into the workspace, stage-transition
-    commits silently fail and the worker burns turns repeating "쓰기 불가".
+    workspace root. Two failure modes are auto-fixed here:
 
-    This scan returns the resolved targets so the backend can pass them to
-    codex as ``sandbox_workspace_write.writable_roots`` — keeping the safer
-    workspace-write default while letting writes succeed through symlinks.
+    1. ``after_create`` symlinks host repo directories (kanban/, prompt/,
+       ...) into the workspace — without this, stage-transition commits
+       silently fail and the worker burns turns repeating "쓰기 불가".
 
-    Top-level only by design — after_create hooks symlink leaf dirs at the
-    workspace root, and recursing would slow start() materially on large
-    repos.
+    2. ``after_create`` attaches the workspace as a git worktree of the host
+       repo (the default Symphony hook), which stores the worktree's
+       admin state in ``<host_repo>/.git/worktrees/<ID>/``. The worktree's
+       ``.git`` file is a one-liner pointer (``gitdir: <abspath>``), not a
+       directory. Every ``git`` invocation inside the worktree writes
+       ``index.lock``, ``HEAD.lock``, etc. under that admin dir, and the
+       merge-gate's ``git merge-tree`` writes objects to it too. Without
+       the gitdir in ``writable_roots`` the merge gate dies with
+       ``unable to create temporary file: Operation not permitted`` and
+       Symphony surfaces the worker as ``Blocked``.
+
+    The scan returns resolved targets that the backend passes to codex as
+    ``sandbox_workspace_write.writable_roots``, preserving the safer
+    workspace-write default while letting writes succeed through symlinks
+    and worktree-attached git admin dirs.
+
+    Top-level only for the symlink scan — after_create hooks symlink leaf
+    dirs at the workspace root, and recursing would slow start() materially
+    on large repos.
     """
     seen: set[str] = set()
     for root in roots:
@@ -176,6 +190,22 @@ def _scan_workspace_symlinks(*roots: Path) -> list[str]:
             except OSError:
                 continue
             seen.add(str(target))
+        # Git-worktree pointer file. Resolving the gitdir target by reading
+        # `.git` is safe: the file is plain text owned by the same user that
+        # ran `git worktree add`, and the worst case is a missing/garbled
+        # pointer (treated as "no extra writable root").
+        git_file = root / ".git"
+        try:
+            if git_file.is_file():
+                content = git_file.read_text(encoding="utf-8", errors="replace")
+                for line in content.splitlines():
+                    if line.startswith("gitdir:"):
+                        target = line[len("gitdir:"):].strip()
+                        if target:
+                            seen.add(target)
+                        break
+        except OSError:
+            pass
     return sorted(seen)
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -532,6 +532,40 @@ def test_scan_workspace_symlinks_tolerates_missing_root(tmp_path: Path) -> None:
     assert _scan_workspace_symlinks(missing) == []
 
 
+def test_scan_workspace_symlinks_includes_worktree_gitdir(tmp_path: Path) -> None:
+    """A git-worktree's `.git` pointer file must contribute its gitdir target
+    to writable_roots so codex's sandbox does not block index.lock writes
+    or merge-tree temp files (SMA-25 root cause)."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    gitdir = tmp_path / "host_repo" / ".git" / "worktrees" / "SMA-25"
+    gitdir.mkdir(parents=True)
+    (workspace / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+
+    roots = _scan_workspace_symlinks(workspace)
+
+    assert str(gitdir) in roots
+
+
+def test_scan_workspace_symlinks_tolerates_garbled_git_pointer(tmp_path: Path) -> None:
+    """A `.git` file without a `gitdir:` line must not raise — fall back to
+    treating the workspace as if no extra writable root were needed."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / ".git").write_text("garbage without gitdir line\n", encoding="utf-8")
+
+    assert _scan_workspace_symlinks(workspace) == []
+
+
+def test_scan_workspace_symlinks_skips_directory_dot_git(tmp_path: Path) -> None:
+    """A normal (non-worktree) repo has `.git` as a directory — must be
+    ignored by the worktree-pointer branch."""
+    workspace = tmp_path / "ws"
+    (workspace / ".git").mkdir(parents=True)
+
+    assert _scan_workspace_symlinks(workspace) == []
+
+
 def test_inject_writable_roots_modifies_direct_codex_command() -> None:
     out = _inject_writable_roots("codex app-server", ["/a", "/b"])
     assert out == (


### PR DESCRIPTION
## Summary
Codex `workspace-write` sandbox was blocking Learn→Done merge gate writes when the workspace is attached as a git worktree (the default Symphony hook). Auto-injects the worktree's gitdir path into `sandbox_workspace_write.writable_roots`.

## Symptom
Live observation on SMA-25 (codex worker): worker reached Learn after 5 normal phase transitions, then merge gate died with:

```
fatal: unable to write .git/worktrees/SMA-25/index.lock
error: unable to create temporary file: Operation not permitted
fatal: failure to merge
```

Worker honestly self-reported "Ticket is now blocked with the exact gate failure captured" → `state: Blocked`. No fake success.

## Root cause
`_scan_workspace_symlinks` only collected resolved targets of top-level symlinks (kanban/, etc.). It missed the workspace's `.git` *pointer file* (`gitdir: <abspath>`), so the host repo's `.git/worktrees/<ID>/` admin dir was never added to writable_roots even though every `git` invocation inside the worktree writes there.

## Fix
`_scan_workspace_symlinks` now also parses `.git` pointer files and unions their gitdir targets into the result. Same helper signature, every call site unchanged.

Defensive cases:
- `.git` is a directory (normal repo, not a worktree) → skipped
- `.git` file present but no `gitdir:` line → silently no-op (no raise)
- Multiple workspaces share a host repo → set-union dedupes

## Verified
- `pytest tests/test_backends.py -q` → 72 passed (3 new regression tests + 69 existing).
- Manual: with the fix, codex's `git merge-tree --write-tree main symphony/<ID>` no longer raises `Operation not permitted` against `.git/worktrees/<ID>/objects/`.

## Test plan
- [ ] CI green
- [ ] Live re-run of a codex-routed ticket reaches Done (or Blocked for a legitimate reason, not sandbox)