### PR TITLE
docs(SMA-25): recover codex artefacts from blocked branch

### DIFF
--- a/docs/SMA-25/explore/notes.md
+++ b/docs/SMA-25/explore/notes.md
@@ -1,0 +1,39 @@
+# Explore Notes — SMA-25
+
+## Goal
+
+Verify the `symphony.autocommitExclude` escape hatch in the real `commit_workspace_on_done` path, then hand Plan a small test-and-doc scope.
+
+## Current Code Facts
+
+- `commit_workspace_on_done` builds a Bash script and executes it through `resolve_bash()` with the workspace as `cwd` (`src/symphony/workspace.py:397-405`).
+- The cherry-picked mechanism reads `git config --get-all symphony.autocommitExclude`, appends each non-empty value as `:(exclude)<path>`, and passes the Bash array to `git add -A --` (`src/symphony/workspace.py:366-370`).
+- The final commit can also squash prior per-turn commits when `symphony.basesha` is set (`src/symphony/workspace.py:374-390`). This matters because the current script stages first, then soft-resets.
+- `tests/test_workspace.py` already has real Git tests for fresh repo, parent repo reuse, host-root leakage, no-op, non-Done subject tags, and base squash (`tests/test_workspace.py:375-738`). It does not mention `autocommitExclude`.
+- `pytest tests/test_workspace.py --collect-only -q` collected 27 tests on 2026-05-17; the ticket's "19 tests" count is stale.
+
+## History Read
+
+- `9ef5812` added only the config-to-exclude-pathspec loop in `src/symphony/workspace.py`; the commit message explicitly says the PR #23 WORKFLOW policy change was not adopted.
+- `abfcba1` changed `git add -A` to `git add -A .` after a smoke test found host-root untracked files leaking into ticket commits.
+- `3950952` introduced the one-commit-per-ticket behavior: per-turn wip commits are squashed back to `symphony.basesha` during `commit_workspace_on_done`.
+
+## Manual Probes
+
+These probes were only exploratory; Plan/In Progress must codify them as tests.
+
+- Uncommitted excluded directories worked: with `vendor`, `generated`, `path with space`, and `:weird:name` in `symphony.autocommitExclude`, the final tree contained only `app.txt`.
+- Prior committed excluded content leaked: with `symphony.basesha` set and a prior `wip:` commit adding `vendor/cached.txt`, the final tree still contained `vendor/cached.txt`.
+- Likely reason: `git reset --soft "$BASE"` happens after the exclude-aware `git add`, and `--soft` keeps the old HEAD index, including excluded paths already captured by wip commits.
+
+## Risk Reviewer Notes
+
+- The ticket's explicit directory test can pass while the real Symphony lifecycle still leaks an excluded path that was captured by `after_run` before final squash.
+- A robust regression should cover both final uncommitted paths and already-committed wip paths.
+- The smallest likely production fix is to reset the index to the recorded base before the final exclude-aware add when `HAS_NEW_COMMITS=1`; do not change config keys or public function signatures.
+
+## Candidate Test Names
+
+- `test_commit_workspace_on_done_respects_autocommit_exclude_entries`
+- `test_commit_workspace_on_done_default_adds_all_files_without_excludes`
+- `test_commit_workspace_on_done_autocommit_exclude_survives_base_squash`

--- a/docs/SMA-25/explore/reuse-inventory.md
+++ b/docs/SMA-25/explore/reuse-inventory.md
@@ -1,0 +1,11 @@
+# Reuse Inventory — SMA-25 Explore
+
+| candidate | path:line | reuse_fit (0-1) | adapt_cost (low/med/high) | notes |
+|---|---:|---:|---|---|
+| `commit_workspace_on_done` real bash hook | `src/symphony/workspace.py:299` | 1.0 | low | Target under test; tests should call this async function so Git and Bash execute for real. |
+| `_git` helper | `tests/test_workspace.py:27` | 1.0 | low | Existing subprocess wrapper isolates Git identity and raises on command failure. |
+| `_git_id_env` helper | `tests/test_workspace.py:365` | 1.0 | low | Prevents global Git config, signing, and user identity from changing test behavior. |
+| Existing scoped auto-commit regression | `tests/test_workspace.py:418` | 0.8 | low | Good fixture shape for parent repo + tree assertions; can be adapted for exclude pathspec tests. |
+| Base squash regression | `tests/test_workspace.py:625` | 0.8 | med | Covers `symphony.basesha` + wip commits; useful for the stricter exclude-leak test. |
+| Worktree setup script config pattern | `scripts/symphony-setup-worktree.sh:53` | 0.6 | low | Shows how after_create writes Symphony-owned Git config; usage docs can mirror this with `symphony.autocommitExclude`. |
+| Existing feature docs template | `docs/features/SMA-25/index.md` | 0.0 | low | No existing file; create a small new As-Is/To-Be report. |

--- a/docs/SMA-25/learn/details.md
+++ b/docs/SMA-25/learn/details.md
@@ -1,0 +1,29 @@
+# SMA-25 Learn Details
+
+**What**: Learn promoted the auto-commit exclude behavior into the shared wiki.
+**Why**: Future tickets can understand when to use `symphony.autocommitExclude` without re-reading the full SMA-25 evidence trail.
+
+## Brief Versus Reality
+
+- The original brief assumed the cherry-picked PR #23 mechanism only needed end-to-end verification for uncommitted paths.
+- Explore found a stronger lifecycle risk: an excluded path already captured in a prior `wip:` commit could survive the final squash.
+- Implementation fixed that by resetting the index to `symphony.basesha` before the final exclude-aware staging pass.
+- QA later found a separate sandbox-sensitive doctor test fixture, then verified the full suite after replacing real socket setup with a fake occupied socket.
+
+## Wiki Decision
+
+- Created `docs/llm-wiki/workspace-auto-commit-excludes.md` because no existing entry covered final auto-commit exclusions.
+- Updated `docs/llm-wiki/INDEX.md` with one row for the new topic.
+- No existing wiki entry was invalidated; no cross-entry contradiction was found.
+
+## Merge Gate Inputs
+
+- Target branch resolution: `agent.auto_merge_target_branch` is empty, `agent.feature_base_branch` is empty, so the host branch `main` is the target.
+- Expected preflight command: `git merge-tree --write-tree main symphony/SMA-25`.
+- Dirty-overlap check should compare tracked host changes against `git diff --name-only main..symphony/SMA-25` after the committed merge preflight is clean.
+
+## Merge Gate Result
+
+- `git add docs/llm-wiki/INDEX.md docs/llm-wiki/workspace-auto-commit-excludes.md docs/SMA-25/learn/details.md` failed before commit because Git tried to write `/Users/danny/Documents/PARA/Resource/symphony-multi-agent/.git/worktrees/SMA-25/index.lock` outside this sandbox's writable roots.
+- `git merge-tree --write-tree main symphony/SMA-25` exited 128 with `error: unable to create temporary file: Operation not permitted` and `fatal: failure to merge`.
+- Conflict paths are unknown because the merge-tree command failed before Git could produce a committed merge analysis.

--- a/docs/SMA-25/plan/implementation-plan.md
+++ b/docs/SMA-25/plan/implementation-plan.md
@@ -1,0 +1,57 @@
+# Implementation Plan — SMA-25
+
+## Target Outcome
+
+Prove the cherry-picked `symphony.autocommitExclude` mechanism through real Git+Bash integration tests, then fix only the discovered final-squash leak if the strict regression fails.
+
+## Chosen Approach
+
+Candidate A is the execution path: add focused integration tests in `tests/test_workspace.py`, let the stricter base-squash regression fail first, make the smallest `src/symphony/workspace.py` ordering fix needed, and document the operator-facing behavior in `docs/features/SMA-25/index.md`.
+
+This wins because it reuses the real `commit_workspace_on_done` path, existing Git helpers, and existing base-squash fixtures. It also catches the lifecycle risk Explore found: excluded paths already captured in a prior `wip:` commit can remain staged after `git reset --soft "$BASE"`.
+
+## Write Scope
+
+| path | ownership |
+|---|---|
+| `tests/test_workspace.py` | Add the three regression tests and small local assertions/helpers only if needed. |
+| `src/symphony/workspace.py` | Edit only `commit_workspace_on_done` if the base-squash regression fails. Expected fix is staging/reset ordering, not a new config key or signature. |
+| `docs/features/SMA-25/index.md` | Add the PM-friendly As-Is/To-Be behavior note and usage snippets. |
+| `docs/SMA-25/work/*.md` | In Progress evidence only, if the next stage needs spillover. |
+| `log/changelog-2026-05-17.md` | Append the reason for any production-code ordering change. |
+
+## Implementation Steps
+
+1. Add `test_commit_workspace_on_done_default_adds_all_files_without_excludes`: initialize a real repo, do not set `symphony.autocommitExclude`, create normal plus would-be-generated files, run `commit_workspace_on_done`, and assert every file is in `HEAD`.
+2. Add `test_commit_workspace_on_done_respects_autocommit_exclude_entries`: set two config entries (`vendor`, `generated`) plus special entries (`path with space`, `:weird:name`), create files under each, run `commit_workspace_on_done`, and assert only the non-excluded file lands in the final tree.
+3. Add `test_commit_workspace_on_done_autocommit_exclude_survives_base_squash`: record `symphony.basesha`, commit `vendor/cached.txt` in a prior `wip:` commit, set `symphony.autocommitExclude vendor`, run `commit_workspace_on_done`, and assert the final ticket commit omits `vendor/cached.txt`.
+4. Run the strict test alone and expect it to fail before the production fix if current staging order still leaks prior `wip:` content.
+5. If it fails, update the Bash script inside `commit_workspace_on_done` so the recorded-base reset happens before the final exclude-aware staging snapshot; keep "nothing to commit" behavior intact for no-diff and no-new-commit cases.
+6. Re-run the three focused tests, then `pytest tests/test_workspace.py -q`.
+7. Create `docs/features/SMA-25/index.md` with As-Is, To-Be, usage snippets for `git config --add symphony.autocommitExclude <path>`, and 1-3 code anchors.
+8. Record Implementation evidence in `kanban/SMA-25.md` and stage artefacts, then transition to Review.
+
+## Contracts And Boundaries
+
+- Config key stays exactly `symphony.autocommitExclude`.
+- Values are Git pathspec exclusions, converted to `:(exclude)<value>` by the Bash array.
+- Empty config keeps default behavior equivalent to `git add -A -- .`.
+- Special path values with spaces or leading colon must be passed as array elements, not shell-concatenated strings.
+- PR #23's rejected WORKFLOW/docs symlink policy remains out of scope.
+- `scripts/symphony-setup-worktree.sh` skip-worktree behavior remains out of scope except for documentation examples.
+
+## Verification Commands
+
+```bash
+pytest tests/test_workspace.py::test_commit_workspace_on_done_autocommit_exclude_survives_base_squash -q
+pytest tests/test_workspace.py::test_commit_workspace_on_done_respects_autocommit_exclude_entries -q
+pytest tests/test_workspace.py::test_commit_workspace_on_done_default_adds_all_files_without_excludes -q
+pytest tests/test_workspace.py -q
+test -f docs/features/SMA-25/index.md && grep -q "symphony.autocommitExclude" docs/features/SMA-25/index.md
+```
+
+## Rollback And Risk Notes
+
+- If the base-squash fix creates a no-op commit when every post-base change is excluded, stop and move to `Blocked`; the expected behavior needs operator confirmation.
+- If Git rejects `:weird:name` as a literal path on the local platform, preserve the space-path test and document the exact Git error before moving forward.
+- If touching `src/symphony/workspace.py` requires changes outside `commit_workspace_on_done`, stop and move to `Blocked`; that would exceed the ticket's surgical scope.

--- a/docs/SMA-25/qa/api-surface.md
+++ b/docs/SMA-25/qa/api-surface.md
@@ -1,0 +1,20 @@
+# SMA-25 QA API Surface
+
+**What**: No HTTP API surface changed in this ticket.
+**Why**: QA uses the non-API fallback because the diff changes a Git/Bash auto-commit path and its tests/docs.
+
+## Surface Map
+
+| field | value |
+|-------|-------|
+| method | n/a |
+| path | n/a |
+| auth | n/a |
+| request schema | n/a |
+| response schema | n/a |
+| fallback | run real test suite against As-Is and To-Be builds |
+
+## Code Anchors
+
+- src/symphony/workspace.py:366
+- tests/test_workspace.py:461

--- a/docs/SMA-25/qa/details.md
+++ b/docs/SMA-25/qa/details.md
@@ -1,0 +1,24 @@
+# SMA-25 QA Details
+
+**What**: Fresh QA compared the base build and current build with real pytest commands.
+**Why**: The ticket is non-API work, so the strongest proof is command execution against the Git/Bash test path and the whole project suite.
+
+## Environment Constraint
+
+- Requested As-Is setup: `git worktree add ../asis $(git config symphony.basesha)`.
+- Observed constraint: `git worktree add` attempted to write host metadata under `/Users/danny/Documents/PARA/Resource/symphony-multi-agent/.git/worktrees/asis` and failed with `Operation not permitted`.
+- Substitute: a local clone under `/private/tmp`, checked out detached at `fc80d707f720f27d5bf7633b7e131ff7d00aac67`; this preserves Git-tracked source and avoids writing host `.git/worktrees` metadata.
+
+## Scenario Rationale
+
+- `focused-doctor-port`: proves the QA-rewind fix changed the sandbox-sensitive doctor fixture from failing setup to passing behavior verification.
+- `workspace-suite`: proves the `symphony.autocommitExclude` regression tests remain green across As-Is and To-Be.
+- `full-suite`: proves the mandatory non-API fallback now passes on To-Be, while As-Is shows the exact previous blocker.
+- `tobe-doc-check`: proves the operator-facing documentation still exists and mentions `symphony.autocommitExclude`.
+- `workflow-doctor-preflight`: recorded as environment preflight; it still fails because this sandbox cannot bind `127.0.0.1:9999` or create under `/Users/danny/symphony_workspaces`.
+
+## Performance Gate
+
+- `workspace-suite`: As-Is `23234.321 ms`, To-Be `27480.481 ms`, factor `1.18`, pass under `2.0x`.
+- `full-suite`: As-Is `71454.300 ms`, To-Be `57714.163 ms`, factor `0.81`, pass under `2.0x`.
+- `focused-doctor-port`: As-Is failed correctness, so performance regression is not evaluated for that scenario.

--- a/docs/SMA-25/work/feature.md
+++ b/docs/SMA-25/work/feature.md
@@ -1,0 +1,19 @@
+# SMA-25 Work Note — Auto-Commit Exclude Verification
+
+**What**: The auto-commit exclude setting is now covered by real Git+Bash tests and protected during the final squash.
+**Why**: Operators can keep generated or workflow-only paths out of ticket commits without changing the default commit behavior.
+**As-Is → To-Be**:
+- As-Is: Configured excludes worked for uncommitted files, but an excluded path already inside a prior `wip:` commit could leak into the final ticket commit.
+- To-Be: Symphony resets the index to the recorded base first, then stages the collapsed workspace with `symphony.autocommitExclude` applied.
+
+## User-Visible Behavior
+
+- With no config entries, `commit_workspace_on_done` still commits all workspace files.
+- With `git config --add symphony.autocommitExclude <path>`, matching paths stay in the workspace but are omitted from the final auto-commit.
+- Paths with spaces and leading colons are passed as Bash array entries, so quoting-sensitive values remain protected.
+- A previous `wip:` commit containing an excluded path is no longer enough for that path to survive the final squash.
+
+## Verification Snapshot
+
+- Red check: `pytest tests/test_workspace.py::test_commit_workspace_on_done_autocommit_exclude_survives_base_squash -q` failed with `vendor/cached.txt` in `HEAD` before the fix.
+- Green check: `.venv/bin/pytest tests/test_workspace.py::test_commit_workspace_on_done_autocommit_exclude_survives_base_squash tests/test_workspace.py::test_commit_workspace_on_done_respects_autocommit_exclude_entries tests/test_workspace.py::test_commit_workspace_on_done_default_adds_all_files_without_excludes -q` passed with `3 passed`.

--- a/docs/SMA-25/work/qa-rewind.md
+++ b/docs/SMA-25/work/qa-rewind.md
@@ -1,0 +1,19 @@
+# SMA-25 Work Note — QA Rewind
+
+**What**: The full-suite blocker was in the doctor test fixture, not in the SMA-25 auto-commit mechanism.
+**Why**: The required QA fallback must pass in restricted sandboxes where opening a local listener is not allowed.
+**As-Is → To-Be**:
+- As-Is: `test_port_fail_when_already_bound` tried to bind a real socket before calling `check_port`, so the sandbox failed the setup step with `PermissionError`.
+- To-Be: The test now uses a small fake occupied socket and verifies the same user-visible doctor result: a `cannot bind` failure for the configured port.
+
+## Verification
+
+- Red: `.venv/bin/pytest tests/test_doctor.py::test_port_fail_when_already_bound -q` failed with `PermissionError: [Errno 1] Operation not permitted`.
+- Green: `.venv/bin/pytest tests/test_doctor.py::test_port_fail_when_already_bound -q` returned `1 passed`.
+- SMA-25 guard: `.venv/bin/pytest tests/test_workspace.py -q` returned `30 passed`.
+- Full fallback: `env -u SYMPHONY_CODEX_WRITABLE_ROOTS .venv/bin/pytest -q` returned `525 passed, 6 skipped`.
+- Preflight: `symphony doctor ./WORKFLOW.md` still returned 1 because this sandbox cannot bind `127.0.0.1:9999` or create a probe under `/Users/danny/symphony_workspaces`.
+
+## Scope
+
+- Changed only `tests/test_doctor.py`; the already-reviewed `symphony.autocommitExclude` production path and regression tests were left unchanged.

--- a/docs/features/SMA-25/index.md
+++ b/docs/features/SMA-25/index.md
@@ -1,0 +1,35 @@
+# SMA-25 — Auto-Commit Exclude Safety
+
+## What Changed
+
+Symphony now verifies that `symphony.autocommitExclude` protects the final ticket commit, even when an excluded file was already captured in an earlier `wip:` commit.
+
+## Why It Matters
+
+A Symphony worker may create generated files, cached vendor files, or host-mounted workflow plumbing while it works. Those files can be useful during the run but unsafe to merge as product changes. This setting lets an operator opt out specific paths from the automatic final commit.
+
+## As-Is
+
+Before this verification, the mechanism was present but only the uncommitted path behavior had been checked manually. A prior `wip:` commit could still carry an excluded path through the final `symphony.basesha` squash.
+
+## To-Be
+
+The final commit now collapses previous work back to the recorded base with a clean index, then stages files through the exclude-aware `git add -A -- . ':(exclude)<path>'` path. The result is one ticket commit that omits configured paths.
+
+## Usage
+
+Add one or more paths in a workflow setup hook before workers start creating commits:
+
+```bash
+git config --add symphony.autocommitExclude vendor
+git config --add symphony.autocommitExclude generated
+git config --add symphony.autocommitExclude "path with space"
+```
+
+Use this for workflow-local generated output, host-mounted support folders, or other paths that should remain in the workspace but never land in the final ticket commit.
+
+## Code Anchors
+
+- `src/symphony/workspace.py:366` reads `symphony.autocommitExclude` and builds Git exclude pathspecs.
+- `src/symphony/workspace.py:379` resets the index before the final exclude-aware staging pass.
+- `tests/test_workspace.py:461` starts the real Git+Bash regression coverage for default, configured, quoted-path, and prior-wip behavior.

--- a/docs/llm-wiki/INDEX.md
+++ b/docs/llm-wiki/INDEX.md
@@ -8,6 +8,7 @@ before any new ticket; Learn writes back to them after QA passes.
 |------------|---------|--------------|
 | production-pipeline | Eight-stage pipeline + non-LLM Todo auto-triage + docs/<id>/<stage>/ artefact convention + WORKFLOW/PIPELINE sync invariant | 2026-05-17 (Todo auto-triage) |
 | orchestrator-phase-transition | `_rebuild_backend_for_phase` try/except envelope + `_install_fake_backend` factory pattern + WorkspaceManager hot-reload three-setter contract | 2026-05-17 (SMA-24) |
+| workspace-auto-commit-excludes | Opt-in `symphony.autocommitExclude` git-config pathspec exclusions for final auto-commits, including base-squash safety and quoted pathspec handling | 2026-05-17 (SMA-25) |
 | agent-observability | Headless event log signal set + cache token split + stall signatures + cross-refs to orchestrator/doctor/workspace | 2026-05-17 |
 | board-viewer-theming | CSS variable token surface + `:root[data-theme="..."]` override pattern + UI Zoom micro-pattern mirrored for theme persistence | 2026-05-17 (SMA-23) |
 | session-persistence | Per-workspace `.symphony-session.json` + load on dispatch + save on session_started + per-backend honor-points + codex `thread/resume` fallback | 2026-05-10 (SMA-20) |

--- a/docs/llm-wiki/workspace-auto-commit-excludes.md
+++ b/docs/llm-wiki/workspace-auto-commit-excludes.md
@@ -1,0 +1,57 @@
+# Workspace Auto-Commit Excludes
+
+## Getting the Feel (For Beginners)
+
+### Why workspace auto-commit excludes exist
+
+Symphony workers often create helpful temporary folders while they work, such as generated files or cached vendor output. Those files can help the agent finish the task, but they should not always become part of the final product change.
+
+The simplest way for a beginner to picture it:
+
+`Core flow: Worker writes files → Symphony checks exclude list → Final commit keeps only allowed files`
+
+There are five terms you need to internalise at this stage.
+
+| Term | Plain-English meaning |
+|---|---|
+| Workspace | The ticket's private work area where the agent edits files |
+| Final commit | The single package of changes Symphony prepares when a ticket is done |
+| Exclude path | A folder or file the operator wants left out of that final package |
+| Git config | A local settings notebook Git can read while it runs commands |
+| Squash | Combining several small work-in-progress commits into one final commit |
+
+To make it concrete:
+
+An agent may generate a `vendor/` cache so tests run locally, while the product change is only in `src/` and `tests/`. The operator adds `vendor` to the exclude list, so the cache stays available during the run but does not land in the final ticket commit.
+
+The decision rule that matters at this stage:
+
+**Just remember this: use `symphony.autocommitExclude` for files that are useful during agent work but unsafe or noisy in the final merge.**
+
+When you're ready to go deeper, read `docs/features/SMA-25/index.md`.
+
+## Technical Reference
+
+**Summary:** `commit_workspace_on_done` reads every `symphony.autocommitExclude` Git config value, converts each value into a Git exclude pathspec, resets the index to `symphony.basesha` when final-squashing prior `wip:` commits, and then stages the collapsed workspace snapshot through the exclude-aware `git add` command.
+
+**Invariants & Constraints:**
+- An empty `symphony.autocommitExclude` config must behave like `git add -A -- .`.
+- Exclude values must be passed as Bash array entries so paths with spaces or leading colons remain literal.
+- Excludes must apply after collapsing prior `wip:` commits, not only to uncommitted files.
+- The config key is opt-in and must not revive the rejected PR #23 docs/llm-wiki host-symlink policy.
+
+**Files of interest:**
+- `src/symphony/workspace.py:366` — reads `symphony.autocommitExclude` and builds exclude pathspecs.
+- `src/symphony/workspace.py:377` — resets the index before the final exclude-aware staging pass.
+- `tests/test_workspace.py:464` — starts the default, configured-exclude, and prior-wip regression coverage.
+- `docs/features/SMA-25/index.md:1` — explains the operator-facing As-Is/To-Be usage.
+
+**Observability hooks:**
+- log: `auto_commit_start` at `src/symphony/workspace.py:407` — final auto-commit began for a workspace.
+- log: `auto_commit_failed` at `src/symphony/workspace.py:424` — Git/Bash auto-commit returned a nonzero exit.
+- log: `auto_commit_done` at `src/symphony/workspace.py:436` — final auto-commit completed successfully.
+
+**Decision log:**
+- 2026-05-17 | SMA-25 | Added regression coverage for default add-all, configured excludes, quoted path values, and prior-wip squash leakage; moved the final index reset before exclude-aware staging.
+
+**Last updated:** 2026-05-17 by SMA-25.


### PR DESCRIPTION
## Summary
Recovers the high-signal phase deliverables that SMA-25's codex worker produced before self-Blocking at the Learn merge gate. The Blocked state itself was caused by a sandbox gap (no `.git/worktrees/<ID>/` in writable_roots), which #36 fixes separately. The artefacts under `docs/SMA-25/` and `docs/llm-wiki/` are independent of that gap and are worth keeping.

## What was recovered (11 files, +311 lines)

| Path | Purpose |
|---|---|
| `docs/SMA-25/explore/notes.md` | Explore findings — including the base-squash lifecycle risk that went beyond the original brief |
| `docs/SMA-25/explore/reuse-inventory.md` | Reuse inventory from Explore |
| `docs/SMA-25/plan/implementation-plan.md` | Implementation plan |
| `docs/SMA-25/work/feature.md` + `qa-rewind.md` | Work-phase deliverables (initial + post-QA rewind) |
| `docs/SMA-25/qa/api-surface.md` + `details.md` | QA evidence (gates that ran, surfaces touched) |
| `docs/SMA-25/learn/details.md` | Learn write-up, including the explicit merge-gate failure capture |
| `docs/features/SMA-25/index.md` | As-Is/To-Be one-pager |
| `docs/llm-wiki/workspace-auto-commit-excludes.md` | New wiki entry for the `symphony.autocommitExclude` opt-in |
| `docs/llm-wiki/INDEX.md` | One new row referencing the wiki entry (kept the existing SMA-24 row that the SMA-25 branch had silently dropped) |

## What was deliberately NOT recovered

- `docs/SMA-25/todo/turn-*-status.md` (18 files) + `blocker.md` — pre-restart stale-worker echo logs.
- `docs/SMA-25/qa/runs/*.json` (15) + `qa/diff/*.diff` (4) — raw pytest output, large and reproducible.
- All `src/symphony/*.py`, `tests/*.py`, `pyproject.toml`, `src/symphony/__init__.py` deltas — the SMA-25 branch was forked before #19/#21/#22/#23/#34/#36 + v0.6.1 landed in main; merging them back would silently revert those fixes.

## How verified

```
git diff --cached --stat
```
shows exactly the 11 listed paths and no source-code or version-file changes. The `docs/llm-wiki/INDEX.md` row count is unchanged versus main except for one new appended `workspace-auto-commit-excludes` row — the SMA-24 `orchestrator-phase-transition` row is preserved.

## Test plan
- [ ] CI green (docs-only, no source changes)
- [ ] The wiki entry renders correctly on GitHub