### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "symphony-multi-agent"
-version = "0.6.1"
+version = "0.6.2"
 description = "Multi-agent fork of OpenAI Symphony — supports Codex CLI, Claude Code CLI, Gemini CLI, and Pi CLI behind a single orchestrator with a Jira-style CLI Kanban TUI."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/symphony/__init__.py
+++ b/src/symphony/__init__.py
@@ -1,3 +1,3 @@
 """Symphony — coding agent orchestration service (SPEC v1)."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"


### PR DESCRIPTION
## Summary
Patch release rolling up the two post-0.6.1 fixes that complete codex agent reliability.

## Included
| PR | Area |
|---|---|
| #36 | codex: auto-inject `.git/worktrees/<ID>/` into `sandbox_workspace_write.writable_roots` so Learn-stage merge-gate writes pass the sandbox. Surfaced live on SMA-25 where the agent honestly self-Blocked rather than overclaiming Done. |
| #37 | docs: recover SMA-25 codex artefacts (Explore→Learn deliverables + `workspace-auto-commit-excludes` wiki entry). |

## Why patch (not minor)
Bug fix restoring intended behavior — no new public API, signature, or required config. The wiki entry is reference material, not a feature toggle (the `symphony.autocommitExclude` mechanism itself shipped in 0.6.1).

## Verified
- pyproject.toml + `src/symphony/__init__.py` lockstep-bumped to `0.6.2`.
- #36 has 3 regression tests in `tests/test_backends.py` covering the worktree-gitdir branch (positive + garbled `.git` + non-worktree directory `.git`).

## Test plan
- [ ] CI green
- [ ] `pip install -e '.[dev]'` on a fresh clone reports `symphony --version` → `0.6.2`