### PR TITLE
docs(readme): lead with value props and target audience to drive adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,60 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python: 3.10+](https://img.shields.io/badge/Python-3.10%2B-3776AB.svg)](https://www.python.org/)
 [![Tests](https://github.com/cskwork/symphony-multi-agent/actions/workflows/tests.yml/badge.svg)](https://github.com/cskwork/symphony-multi-agent/actions/workflows/tests.yml)
+[![GitHub stars](https://img.shields.io/github/stars/cskwork/symphony-multi-agent?style=social)](https://github.com/cskwork/symphony-multi-agent/stargazers)
 
-> Drive any coding-agent CLI — Codex, Claude Code, Gemini, or Pi — from one
-> orchestrator, with a Jira-style Kanban board rendered straight in your
-> terminal.
+> One terminal. One Kanban board. Four AI coding agents
+> (**Codex**, **Claude Code**, **Gemini**, **Pi**) — pick per ticket, run in
+> parallel, watch live.
+
+**Stop juggling AI coding CLIs.** Symphony hands each Kanban ticket to the
+agent you want, runs them concurrently in isolated `git worktree` workspaces,
+and shows live progress — turn counts, token usage, rate-limit headroom — in
+a Jira-style TUI you never have to leave your terminal for.
+
+[**Try it in 60 seconds, no AI CLI required →**](#try-it-in-60-seconds-no-agent-cli-required)
+
+## Why Symphony?
+
+- **No vendor lock-in.** Swap Codex ↔ Claude Code ↔ Gemini ↔ Pi with one
+  YAML line, or mix backends per ticket. New agents (Ollama, local models,
+  anything with a CLI) drop in behind a thin `AgentBackend` Protocol — four
+  steps, no orchestrator changes.
+- **See what your agents are actually doing.** Live Kanban shows turn count,
+  last event, accumulated tokens, and rate-limit headroom for every running
+  card. No more "is it stuck or just thinking?" — and no SaaS dashboard to
+  log into.
+- **Run dozens of tickets in parallel, unattended.** Concurrency is built in:
+  every ticket gets its own `git worktree` workspace, so agents can't step on
+  each other. Headless mode mirrors progress to a Markdown file you can
+  `tail -F` in any editor; macOS keep-awake stops the lock screen from
+  killing overnight pipelines.
+- **No SaaS, no API key, no signup to try.** File-based Markdown Kanban
+  means tickets live in `git` next to your code. Linear is supported as a
+  drop-in tracker; you don't need it.
+- **Battle-tested core.** Forked from
+  [OpenAI's official Symphony reference implementation](https://github.com/openai/symphony).
+  The orchestrator, scheduler, retry policy, workspace lifecycle, and prompt
+  renderer are all upstream — this fork is a thin layer that adds the four
+  backends and the TUI.
+- **Operator-grade tooling out of the box.** `symphony doctor` catches the
+  five most common first-run failures (port collisions, missing CLIs,
+  placeholder URLs, unwritable workspaces) in one pass. `symphony service
+  start/stop/restart/logs` runs the orchestrator as a managed background
+  service. A web viewer adds **Pause / Resume** for running cards and a real
+  branch-picker for feature / merge branches.
+
+## Who is this for?
+
+- **Solo devs** running unattended overnight refactors across dozens of
+  tickets while they sleep.
+- **Teams** parallelizing bug fixes, doc updates, or migration tickets across
+  multiple coding agents simultaneously.
+- **Researchers and reviewers** comparing how Codex, Claude Code, Gemini, and
+  Pi tackle the same task side by side, with identical prompts and
+  workspaces.
+- **Anyone** who hit the "one chat window per agent" ceiling and wants a
+  real orchestrator with a Kanban they can read at a glance.
 
 ## What it looks like
 


### PR DESCRIPTION
## Summary

Restructure the README intro to convert first-time visitors. The current top jumps straight into screenshots and the upstream-fork explanation — strong material, but it asks visitors to already understand *why* they want a multi-agent orchestrator. This change leads with the value proposition, then earns the technical depth.

## What changed

Above-the-fold additions before `## What it looks like`:

- **Punchier tagline** — "One terminal. One Kanban board. Four AI coding agents — pick per ticket, run in parallel, watch live."
- **"Stop juggling AI coding CLIs"** value-prop paragraph naming the concrete pain (concurrent tickets, isolated `git worktree`, live progress).
- **Direct CTA** to the existing 60-second mock demo so the next click is "try it" not "scroll more."
- **"Why Symphony?"** with six concrete benefits, each tying a feature to an outcome: no vendor lock-in, live agent visibility, parallel unattended runs, no SaaS, battle-tested upstream core, operator-grade tooling (`doctor` / `service` / Pause-Resume viewer).
- **"Who is this for?"** with four personas (solo dev / team / researcher / power user) so visitors self-identify within seconds.
- **GitHub stars badge** alongside the existing CI / license / Python badges for social proof.

No structural or content changes below the fold — install, quickstart, design notes, and gap list are untouched.

## Test plan

- [ ] Render the README on GitHub and confirm the section anchors resolve (`#try-it-in-60-seconds-no-agent-cli-required`).
- [ ] Confirm the badge row still wraps cleanly on narrow viewports.
- [ ] Spot-check that no factual claim was added that isn't already supported elsewhere in the README (every bullet maps to an existing section).