### PR TITLE
docs(readme): move TUI screenshot above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 > (**Codex**, **Claude Code**, **Gemini**, **Pi**) — pick per ticket, run in
 > parallel, watch live.
 
+![symphony tui screenshot](docs/tui-screenshot.svg)
+
+<sub>`symphony tui ./WORKFLOW.md` — columns are your tracker's states; cards show the active agent, turn count, last event, and accumulated tokens. Live indicators: ● running, ↻ retry queued, ✓ done.</sub>
+
 **Stop juggling AI coding CLIs.** Symphony hands each Kanban ticket to the
 agent you want, runs them concurrently in isolated `git worktree` workspaces,
 and shows live progress — turn counts, token usage, rate-limit headroom — in
@@ -58,16 +62,10 @@ a Jira-style TUI you never have to leave your terminal for.
 - **Anyone** who hit the "one chat window per agent" ceiling and wants a
   real orchestrator with a Kanban they can read at a glance.
 
-## What it looks like
-
-`symphony tui ./WORKFLOW.md` opens a full-terminal Kanban board. Columns are
-your tracker's states; cards show the active agent, turn count, last event,
-and accumulated tokens. Live indicators: ● running, ↻ retry queued, ✓ done.
-
-![symphony tui screenshot](docs/tui-screenshot.svg)
+## How it works
 
 <details>
-<summary>Plain-text version (for terminals viewing raw README)</summary>
+<summary>Plain-text version of the TUI (for terminals viewing raw README)</summary>
 
 ```text
   agent=codex  tracker=linear  workflow=WORKFLOW.md  lang=en   running=2  retrying=1   │  tokens in=84,200 out=27,640 total=111,840


### PR DESCRIPTION
## Summary

Follow-up to #40. The TUI screenshot was the strongest single piece of evidence for what Symphony is, but it sat below the value-prop bullets — visitors had to scroll past ~50 lines of text to see it.

This change moves the screenshot directly under the tagline blockquote, adds a one-line caption explaining what the cards and indicators mean, and drops the now-redundant description from the old 'What it looks like' section. That section is renamed to 'How it works' since its remaining content (plain-text TUI fallback + fork architecture explanation) is no longer about visual appearance.

## Test plan

- [ ] Render on GitHub and confirm the screenshot loads above the fold on a standard laptop viewport.
- [ ] Confirm the `<sub>` caption renders as small text and remains readable.
- [ ] Confirm the plain-text fallback `<details>` block still expands.