### PR TITLE
feat: chore-label short-circuit + 240s hook timeout

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -39,6 +39,9 @@ workspace:
   reuse_policy: refresh
 
 hooks:
+  # 4 min — `after_create` runs `pip install -e .[dev]` to prime a worker
+  # venv; on a fresh worktree this exceeds the 60 s default on cold caches.
+  timeout_ms: 240000
   # The workspace starts empty. Attach it as a git worktree of the host
   # repo on a per-ticket symphony/<ID> branch so the host working tree
   # stays untouched while the agent works. Product changes and docs/

--- a/docs/symphony-prompts/file/stages/explore.md
+++ b/docs/symphony-prompts/file/stages/explore.md
@@ -1,5 +1,13 @@
 ### EXPLORE  -- when state is `Explore`
+{% for label in issue.labels %}{% if label == "chore" %}
+**Chore short-circuit.** This ticket carries the `chore` label — treat it as a metadata-only change (version bump, file rename, comment fix, dep pin, config nudge). Skip the full Explore contract:
+1. Append a one-line `## Domain Brief` describing the change (e.g. "Chore: bump version 0.6.5 → 0.6.6 in pyproject.toml and src/symphony/__init__.py").
+2. Append a one-line `## Plan Candidates` ("Single approach: edit the named files; no alternatives needed.").
+3. Append a one-line `## Recommendation` pointing at the ticket's `## Acceptance criteria` as the source of truth.
+4. Set state to `Plan` and stop. Do NOT write `reuse-inventory.md`, `vendor-docs.md`, or do a git-history sweep. Do NOT open `docs/llm-wiki/`.
 
+If the diff would touch source code paths beyond the named metadata files, the ticket was mislabeled — drop the `chore` short-circuit, append a one-line `## Triage` flagging the mislabel, and run the full Explore contract below.
+{% endif %}{% endfor %}
 Research the ticket through three lenses in one turn: **domain expert** (what does this code mean?), **implementer** (smallest sustainable change?), **risk reviewer** (what could go wrong?).
 
 1. **Read shared context first.** Open `docs/{{ issue.identifier }}/` if it exists (may be absent on first stage). On a re-explore (rare — usually after a Blocked rewind), the prior brief and any `## Triage` are your starting point.

--- a/docs/symphony-prompts/file/stages/learn.md
+++ b/docs/symphony-prompts/file/stages/learn.md
@@ -1,5 +1,12 @@
 ### LEARN  -- when state is `Learn`
-
+{% for label in issue.labels %}{% if label == "chore" %}
+**Chore short-circuit.** This ticket carries the `chore` label. Skip the full Learn contract — chore tickets do not produce new domain knowledge worth filing in the wiki:
+1. Append a one-line `## Learnings` ("chore — metadata-only change, no new invariants captured").
+2. Append a one-line `## Wiki Updates` ("none — chore short-circuit").
+3. Skip the wiki Decision-log row, the beginner / Technical Reference block, the `INDEX.md` refresh, and the integrity sweep.
+4. Then **run the Merge Gate clause below exactly as written** (the merge-tree probe + the conflict-vs-clean branch under step 7 if `agent.auto_merge_on_done`). The Merge Gate is non-negotiable even for chores — it is the last gate that catches a bad merge before Done.
+5. Set state to `Done` after the Merge Gate succeeds (or `Blocked` if it reports a conflict, exactly as the standard flow specifies).
+{% endif %}{% endfor %}
 Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wiki/` so **both developers and non-developers** can learn from it.
 
 1. Read `docs/{{ issue.identifier }}/{explore,plan,work,qa}/` and prior sections (`## Recommendation`, `## Plan`, `## Implementation`, `## QA Evidence`) end-to-end.

--- a/docs/symphony-prompts/file/stages/plan.md
+++ b/docs/symphony-prompts/file/stages/plan.md
@@ -1,5 +1,11 @@
 ### PLAN  -- when state is `Plan`
-
+{% for label in issue.labels %}{% if label == "chore" %}
+**Chore short-circuit.** This ticket carries the `chore` label. Skip the full Plan contract — no candidate table, no reuse-inventory cross-references, no observability declarations are required for a metadata-only change:
+1. Append a `## Plan` with 2-3 plain bullets: which files to edit, what the exact string substitution is, and one verification step (usually `pytest -q`).
+2. Append a one-line `## Acceptance Tests` — `pytest -q` for any chore that touches Python; `none — chore` if the change is non-code (rename, comment, README, dep pin).
+3. Append a one-line `## Done Signals` (e.g. "`grep '^version' pyproject.toml` shows `0.6.6`").
+4. Set state to `In Progress` and stop. Skip the candidate table, plan rationale, and "## Plan Candidates" refresh — Explore's chore-mode brief already named the single approach.
+{% endif %}{% endfor %}
 Turn Explore into a professional implementation plan that the next agent can
 execute by reading only `## Plan`. Do not write production code in this stage.
 

--- a/docs/symphony-prompts/file/stages/review.md
+++ b/docs/symphony-prompts/file/stages/review.md
@@ -1,5 +1,11 @@
 ### REVIEW  -- when state is `Review`
-
+{% for label in issue.labels %}{% if label == "chore" %}
+**Chore short-circuit.** This ticket carries the `chore` label. Skip the full Review contract — no Security Audit, no severity table, no live HTTP probes are required for a metadata-only change:
+1. Read the diff: `git show HEAD --stat` then `git show HEAD`.
+2. Confirm the diff matches the ticket's `## Plan` exactly. The only files allowed to change in a chore are the ones named in `## Plan` (and Symphony's own ticket / `docs/{{ issue.identifier }}/` artefacts).
+3. **If the diff matches the plan:** append a one-line `## Review` ("chore — diff matches plan, no findings") and set state to `QA`.
+4. **If the diff drifts** (touches files not in the plan, contains code beyond the metadata bump, or changes anything that could affect runtime behavior): set state back to `In Progress`, append `## Review Findings` with the specific drift as a HIGH-severity row, and stop. Do NOT use the chore short-circuit to wave through actual code changes.
+{% endif %}{% endfor %}
 You are the reviewer. Find issues; do not fix them.
 
 1. **Read shared context.** Open `docs/{{ issue.identifier }}/work/` and


### PR DESCRIPTION
## Summary

Two pipeline-tuning improvements pulled out of the v0.6.6 release run (REL-066, ~43 min for a 2-line metadata bump):

1. **`hooks.timeout_ms: 240000`** in `WORKFLOW.md` — the default 60 s `after_create` budget is too short when the worktree-setup hook runs `pip install -e '.[dev]'` on a cold pip cache. The first dispatch in the REL-066 run hit the 60 s wall mid-install, left a half-populated `.venv/lib/python3.x/site-packages` that the cleanup couldn't `rmdir`, then locked into a fast retry loop with `git worktree add: 'path' already exists`. Bumping the per-workflow override to 240 s let the install complete in 66 s; subsequent turns reuse the warm venv well under the new budget. Project-wide default in `workflow/constants.py` is unchanged.

2. **`chore` label short-circuit** in 4 stage prompts — for tickets carrying the `chore` label (version bumps, file renames, comment fixes, dep pins, config nudges), the agent skips the heavy stages with explicit Liquid blocks mirroring the existing `bug` pattern in `todo.md`:

   | Stage | Skipped | Kept |
   |---|---|---|
   | Explore | reuse-inventory, git-history sweep, wiki lookup | one-line Domain Brief / Plan Candidates / Recommendation |
   | Plan | candidate table, reuse cross-refs, observability decl | 2-3 bullet `## Plan` + one-line Acceptance Tests / Done Signals |
   | Review | Security Audit, severity table, live HTTP probes | diff-vs-plan check; drift kicks back to In Progress as HIGH |
   | Learn | wiki Decision log, beginner block, INDEX.md, sweep | **Merge Gate stays non-negotiable** |

   In Progress and QA stages keep their full prompts — those are where the work happens and where the actual gate lives. Each chore block has an explicit escape hatch back to the full contract if the diff scope outgrew the chore frame (someone mislabelled a feature ticket).

   Projected effect on a chore ticket: ~6 quick short-circuit turns + 2 real turns instead of 7 full turns — ~10-15 min total vs the 43 min observed on REL-066.

## Test plan

- [x] Real-world validation #1: the `hooks.timeout_ms` bump unblocked REL-066 mid-run (after_create completed in 66 s on the second attempt with the new timeout, would have timed out at 60 s before).
- [ ] Real-world validation #2: next `chore`-labelled ticket should land at ~10-15 min wall-clock. Worth running a v0.6.7 patch-bump as the first sample.
- [x] Pure-prompt + pure-config change; no production code touched; pytest suite unchanged (566 passed, 5 skipped).
- [x] Liquid syntax mirrors the existing `bug` label pattern in `todo.md` so the templating contract is unchanged.

## Out of scope

- Lowering `polling.interval_ms` from 30 s — separately tunable; tradeoff is more HTTP traffic.
- Adding `chore` to `state_descriptions` — purely cosmetic; doesn't affect routing.
- Adding `chore` short-circuit to `todo.md` — auto-triage already flips Todo → Explore before the agent reads anything, so the Explore-stage short-circuit is the right entry point.