### PR TITLE
fix(prompts): learn chore short-circuit honors auto_merge_on_done both ways

### DIFF
--- a/docs/symphony-prompts/file/stages/learn.md
+++ b/docs/symphony-prompts/file/stages/learn.md
@@ -4,8 +4,8 @@
 1. Append a one-line `## Learnings` ("chore — metadata-only change, no new invariants captured").
 2. Append a one-line `## Wiki Updates` ("none — chore short-circuit").
 3. Skip the wiki Decision-log row, the beginner / Technical Reference block, the `INDEX.md` refresh, and the integrity sweep.
-4. Then **run the Merge Gate clause below exactly as written** (the merge-tree probe + the conflict-vs-clean branch under step 7 if `agent.auto_merge_on_done`). The Merge Gate is non-negotiable even for chores — it is the last gate that catches a bad merge before Done.
-5. Set state to `Done` after the Merge Gate succeeds (or `Blocked` if it reports a conflict, exactly as the standard flow specifies).
+4. Then **run whichever Merge Gate clause step 7 below renders**, exactly as written — the chore short-circuit cannot bypass it. Under `agent.auto_merge_on_done=true` step 7 is the merge-tree probe + conflict-vs-clean branch; under `agent.auto_merge_on_done=false` step 7 is the disabled-gate clause that appends `## Merge Status` and leaves integration to the operator. Honor whichever the prompt renders.
+5. Set state to `Done` per step 8 (or `Blocked` if step 7's merge-tree probe reported a committed conflict, exactly as the standard flow specifies).
 {% endif %}{% endfor %}
 Make the next ticket cheaper. Distill what this ticket taught into `docs/llm-wiki/` so **both developers and non-developers** can learn from it.
 


### PR DESCRIPTION
## Summary

PR #46 post-merge code review caught a **[HIGH]** follow-up I'm shipping here.

In `docs/symphony-prompts/file/stages/learn.md`, the chore short-circuit's step 4 read:

> Then **run the Merge Gate clause below exactly as written** ... The Merge Gate is non-negotiable even for chores

But step 7 of the same prompt is wrapped in `{% if agent.auto_merge_on_done %}{% else %}{% endif %}`. Under `auto_merge_on_done=false` step 7 renders as the *disabled-gate* clause ("leaves branch integration to the operator"), so the chore block contradicted what the agent actually sees, and an agent could either refuse to transition or invent a merge command.

The fix rewrites step 4 to point at whichever clause step 7 renders, naming both branches explicitly — no nested Liquid, no risk of further drift.

## Verification

Rendered the chore-mode learn prompt under both flag values:

```
auto_merge_on_done=True:  chore_step4=True enabled_gate=True  disabled_gate=False
auto_merge_on_done=False: chore_step4=True enabled_gate=False disabled_gate=True
```

Both render consistently — chore step 4 now lines up with the step-7 clause that actually rendered.

## Out of scope

- Adding an automated render-test in `tests/` that exercises every stage prompt against `symphony.prompt.render` for the `chore` + `bug` + non-labelled paths. Would catch this class of bug in CI; worth a separate ticket.
- Touching `explore.md`, `plan.md`, `review.md` — none reference conditional stage steps the way `learn.md` does, so the same bug class doesn't recur.