### PR TITLE
test: file-tracker contract regression + xfail for v0.6.7 hotfix gap

### DIFF
--- a/src/symphony/orchestrator/core.py
+++ b/src/symphony/orchestrator/core.py
@@ -1513,6 +1513,25 @@ class Orchestrator:
                             # a forced rewind so the rebuild + budget
                             # bookkeeping below still apply.
                             if not is_rewind:
+                                if prev_phase_state in {
+                                    "plan",
+                                    "review",
+                                    "qa",
+                                    "done",
+                                }:
+                                    refreshed_for_contract = (
+                                        await self._refresh_issue_state(
+                                            cfg, running_issue_id
+                                        )
+                                    )
+                                    if refreshed_for_contract is not None:
+                                        issue = refreshed_for_contract
+                                        running_entry = self._running.get(
+                                            running_issue_id
+                                        )
+                                        if running_entry is not None:
+                                            running_entry.issue = issue
+                                        current_state = normalize_state(issue.state)
                                 contract = evaluate_contract(
                                     producing_state=prev_phase_state,
                                     ticket_body=issue.description or "",
@@ -1547,11 +1566,18 @@ class Orchestrator:
                                     )
                                     if refreshed is not None:
                                         issue = refreshed
-                                        running_entry = self._running.get(
-                                            running_issue_id
-                                        )
-                                        if running_entry is not None:
-                                            running_entry.issue = issue
+                                    issue = replace(
+                                        issue,
+                                        state=(
+                                            prev_phase_state_raw
+                                            or prev_phase_state
+                                        ),
+                                    )
+                                    running_entry = self._running.get(
+                                        running_issue_id
+                                    )
+                                    if running_entry is not None:
+                                        running_entry.issue = issue
                                     current_state = normalize_state(issue.state)
                                     is_rewind = True
                             if is_rewind:

--- a/tests/test_orchestrator_contract_integration.py
+++ b/tests/test_orchestrator_contract_integration.py
@@ -1,0 +1,456 @@
+"""End-to-end contract-validation regression tests against a real tracker.
+
+Background — what these tests guard against
+-------------------------------------------
+
+The v0.6.7 release (cfb6de4) added a stage-contract validator that reads
+``issue.description`` at every forward phase transition and rewinds the
+ticket if the producing stage's required sections are absent.
+
+CI was green (587 passed) — but production runs against the file tracker
+surfaced false ``## Contract Failure`` rewinds. Two follow-up patches
+landed:
+
+* ``e68c4d7`` (PR #48) — first attempt; insufficient.
+* ``365e67b`` (PR #49) — refreshed ``issue`` from the tracker before
+  evaluating the contract, plus replaced ``issue.state`` with the
+  producing stage's raw casing on rewind.
+
+Both patches were verified against tests that monkeypatched
+``Orchestrator._refresh_issue_state`` to return a fully-hydrated body.
+That is NOT how the production refresh helper behaves: for *all three*
+trackers (file / Linear / Jira), ``fetch_issue_states_by_ids`` returns a
+*minimal* Issue with ``description=None``. The pre-release CI scaffold
+silently papered over the realistic case.
+
+These tests run the contract path against a real ``FileBoardTracker``
+(no monkeypatching of refresh / append / update / build_tracker_client),
+so any regression that re-introduces the stale-body class of bug — or
+that depends on a phantom hydrated description from
+``_refresh_issue_state`` — fails here before merge.
+
+Test taxonomy
+-------------
+
+``test_contract_passes_when_disk_has_required_sections``
+    Happy path: ticket file already contains Plan / Acceptance Tests /
+    Done Signals before the agent transitions Plan → Review. Contract
+    must pass; no ``## Contract Failure`` note may be appended.
+
+``test_contract_fails_when_disk_missing_sections``
+    Sad path: ticket file is missing ``## Done Signals``. Contract must
+    fail and the orchestrator must rewind the ticket back to ``Plan``.
+
+The fake backend used here mutates the ticket file on disk inside
+``run_turn`` — the same shape the real agents have (Write tool → file)
+— so the orchestrator's subsequent ``_refresh_issue_state`` reads from
+the same source the validator depends on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from symphony import orchestrator as orch_mod
+from symphony.issue import Issue
+from symphony.orchestrator import Orchestrator, RunningEntry
+from symphony.trackers.file import (
+    parse_ticket_file,
+    write_ticket_atomic,
+)
+from symphony.workflow import (
+    AgentConfig,
+    ClaudeConfig,
+    CodexConfig,
+    GeminiConfig,
+    HooksConfig,
+    PiConfig,
+    PromptConfig,
+    ServerConfig,
+    ServiceConfig,
+    TrackerConfig,
+    TuiConfig,
+    WorkflowState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Plan-stage body fixtures
+# ---------------------------------------------------------------------------
+
+
+_PLAN_BODY_COMPLETE = """## Plan
+
+Step 1 — wire the new validator into the forward-transition path.
+Step 2 — surface a `## Contract Failure` note when the producing stage
+under-produces.
+
+## Acceptance Tests
+
+- existing phase-transition tests stay green
+- contract eval honours latest tracker body
+
+## Done Signals
+
+- pytest -q green
+- one release-bumping commit landed on `main`
+"""
+
+
+_PLAN_BODY_MISSING_DONE_SIGNALS = """## Plan
+
+Step 1 — wire the new validator into the forward-transition path.
+
+## Acceptance Tests
+
+- existing phase-transition tests stay green
+"""
+
+
+# ---------------------------------------------------------------------------
+# Test doubles — fake backend that drives the ticket file during run_turn
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TicketMutatingBackend:
+    """Fake backend whose ``run_turn`` mutates the ticket file on disk.
+
+    Simulates the real-agent contract:
+
+    * the agent owns the ticket markdown body (via Write tool)
+    * the agent owns the state transition (via tracker tool)
+    * the orchestrator sees both changes only through the file tracker
+
+    A scripted ``transitions`` list drives the per-turn behaviour. Each
+    entry is ``(new_state, body_after_turn)``. After the script is
+    exhausted, ``run_turn`` is a no-op so the orchestrator can drain its
+    bookkeeping loop and exit via ``max_turns``.
+    """
+
+    ticket_path: Path
+    transitions: list[tuple[str, str]] = field(default_factory=list)
+    init_id: int = 0
+    calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+
+    async def start(self) -> None:
+        self.calls.append(("start", {}))
+
+    async def initialize(self) -> None:
+        self.calls.append(("initialize", {}))
+
+    async def start_session(
+        self, *, initial_prompt: str, issue_title: str
+    ) -> None:
+        self.session_id = f"fake-session-{self.init_id}"
+        self.calls.append(
+            (
+                "start_session",
+                {"initial_prompt": initial_prompt, "issue_title": issue_title},
+            )
+        )
+
+    async def run_turn(self, *, prompt: str, is_continuation: bool) -> None:
+        self.calls.append(
+            ("run_turn", {"prompt": prompt, "is_continuation": is_continuation})
+        )
+        # Pop the next scripted transition and apply it to the ticket file
+        # before the orchestrator's post-turn _refresh_issue_state runs.
+        if not self.transitions:
+            return
+        new_state, body = self.transitions.pop(0)
+        front, _ = parse_ticket_file(self.ticket_path)
+        front["state"] = new_state
+        front["updated_at"] = datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        write_ticket_atomic(self.ticket_path, front, body)
+
+    async def stop(self) -> None:
+        self.calls.append(("stop", {}))
+
+
+class _FakeWorkspace:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.workspace_key = "fake"
+        self.created_now = True
+
+
+class _FakeWorkspaceManager:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.after_run_paths: list[Path] = []
+
+    def path_for(self, identifier: str) -> Path:
+        del identifier
+        return self._path
+
+    async def create_or_reuse(self, identifier: str) -> _FakeWorkspace:
+        del identifier
+        return _FakeWorkspace(self._path)
+
+    async def before_run(self, path: Path) -> None:
+        del path
+
+    async def after_run_best_effort(self, path: Path) -> None:
+        self.after_run_paths.append(path)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — real file tracker + matching ServiceConfig
+# ---------------------------------------------------------------------------
+
+
+def _write_initial_ticket(board_root: Path, *, state: str, body: str) -> Path:
+    """Seed ``MT-1.md`` on disk in the layout FileBoardTracker expects."""
+    board_root.mkdir(parents=True, exist_ok=True)
+    front = {
+        "id": "MT-1",
+        "identifier": "MT-1",
+        "title": "phase transition fixture",
+        "state": state,
+        "priority": 2,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    path = board_root / "MT-1.md"
+    write_ticket_atomic(path, front, body)
+    return path
+
+
+def _make_file_tracker_config(
+    *,
+    board_root: Path,
+    active_states: tuple[str, ...],
+    max_turns: int = 3,
+    max_attempts: int = 3,
+) -> ServiceConfig:
+    template = (
+        "issue={{ issue.identifier }} state={{ issue.state }} "
+        "rewind={{ is_rewind }}"
+    )
+    return ServiceConfig(
+        workflow_path=Path("/tmp/WORKFLOW.md"),
+        poll_interval_ms=30_000,
+        workspace_root=board_root.parent / "ws",
+        tracker=TrackerConfig(
+            kind="file",
+            endpoint="",
+            api_key="",
+            project_slug="",
+            active_states=active_states,
+            terminal_states=("Done", "Cancelled", "Blocked"),
+            board_root=board_root,
+        ),
+        hooks=HooksConfig(None, None, None, None, 60_000),
+        agent=AgentConfig(
+            kind="codex",
+            max_concurrent_agents=1,
+            max_turns=max_turns,
+            max_retry_backoff_ms=300_000,
+            max_concurrent_agents_by_state={},
+            max_attempts=max_attempts,
+        ),
+        codex=CodexConfig(
+            command="codex app-server",
+            approval_policy=None,
+            thread_sandbox=None,
+            turn_sandbox_policy=None,
+            turn_timeout_ms=3_600_000,
+            read_timeout_ms=5_000,
+            stall_timeout_ms=300_000,
+        ),
+        claude=ClaudeConfig(
+            command="claude -p",
+            turn_timeout_ms=3_600_000,
+            read_timeout_ms=5_000,
+            stall_timeout_ms=300_000,
+            resume_across_turns=True,
+        ),
+        gemini=GeminiConfig(
+            command='gemini -p ""',
+            turn_timeout_ms=3_600_000,
+            read_timeout_ms=5_000,
+            stall_timeout_ms=300_000,
+        ),
+        pi=PiConfig(
+            command='pi --mode json -p ""',
+            turn_timeout_ms=3_600_000,
+            read_timeout_ms=5_000,
+            stall_timeout_ms=300_000,
+            resume_across_turns=True,
+        ),
+        server=ServerConfig(port=None),
+        tui=TuiConfig(language="en", visible_lanes=5),
+        prompts=PromptConfig(),
+        prompt_template=template,
+    )
+
+
+def _make_issue_from_disk(state: str, body: str) -> Issue:
+    """Build the in-memory Issue the orchestrator starts the worker with.
+
+    Matches what ``fetch_candidate_issues`` returns for a freshly picked-up
+    ticket: full body + correct state. The test then mutates the disk file
+    independently to simulate the agent's work.
+    """
+    return Issue(
+        id="MT-1",
+        identifier="MT-1",
+        title="phase transition fixture",
+        description=body,
+        priority=2,
+        state=state,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _orch(workspace_path: Path) -> Orchestrator:
+    state = WorkflowState(Path("/tmp/no.md"))
+    o = Orchestrator(state)
+    o._workspace_manager = _FakeWorkspaceManager(workspace_path)  # type: ignore[assignment]
+    return o
+
+
+def _seed_running_entry(
+    o: Orchestrator, issue: Issue, workspace_path: Path
+) -> None:
+    o._running[issue.id] = RunningEntry(
+        issue=issue,
+        started_at=datetime.now(timezone.utc),
+        retry_attempt=None,
+        worker_task=None,  # type: ignore[arg-type]
+        workspace_path=workspace_path,
+    )
+
+
+def _install_file_tracker_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ticket_path: Path,
+    transitions: list[tuple[str, str]],
+) -> list[_TicketMutatingBackend]:
+    instances: list[_TicketMutatingBackend] = []
+
+    def _factory(init: Any) -> _TicketMutatingBackend:
+        backend = _TicketMutatingBackend(
+            ticket_path=ticket_path,
+            transitions=list(transitions),
+            init_id=len(instances),
+        )
+        backend.calls.append(("factory", {"agent_kind": init.cfg.agent.kind}))
+        instances.append(backend)
+        return backend
+
+    monkeypatch.setattr(orch_mod, "build_backend", _factory)
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_contract_passes_when_disk_has_required_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path against a real FileBoardTracker.
+
+    The ticket on disk already has all Plan-contract sections before the
+    agent transitions to Review. Contract evaluation MUST read the disk
+    body and pass; no rewind, no ``## Contract Failure`` note.
+
+    The 0.6.7 release shipped a path where ``_refresh_issue_state``
+    returns a minimal Issue with ``description=None``. If that bug
+    re-enters, the contract evaluates against an empty body, fails, and
+    appends a ``## Contract Failure`` note — caught here as a string
+    match on the persisted ticket file.
+    """
+    board_root = tmp_path / "board"
+    ticket_path = _write_initial_ticket(
+        board_root, state="Plan", body=_PLAN_BODY_COMPLETE
+    )
+    cfg = _make_file_tracker_config(
+        board_root=board_root,
+        active_states=("Plan", "Review", "QA"),
+        max_turns=2,
+    )
+
+    _install_file_tracker_backend(
+        monkeypatch,
+        ticket_path=ticket_path,
+        transitions=[("Review", _PLAN_BODY_COMPLETE)],
+    )
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    o = _orch(workspace_path)
+    issue = _make_issue_from_disk("Plan", _PLAN_BODY_COMPLETE)
+    _seed_running_entry(o, issue, workspace_path)
+
+    asyncio.run(o._run_agent_attempt(issue, attempt=None, cfg=cfg))
+
+    final_front, final_body = parse_ticket_file(ticket_path)
+    assert "## Contract Failure" not in final_body, (
+        "False ## Contract Failure note appended despite ticket containing "
+        f"all required Plan sections. Body was:\n{final_body}"
+    )
+    # State must have advanced — the contract guard, when working, does
+    # NOT rewind back to Plan.
+    assert final_front["state"] != "Plan", (
+        "Contract guard rewound the ticket back to Plan even though every "
+        "required section is present on disk."
+    )
+
+
+def test_contract_fails_when_disk_missing_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sad path against a real FileBoardTracker.
+
+    The ticket is missing ``## Done Signals`` when the agent transitions
+    Plan → Review. The contract MUST fail, the orchestrator MUST append
+    a ``## Contract Failure`` note, AND the ticket state MUST revert to
+    ``Plan``. This guards the rewind path against silent breakage in
+    addition to the happy path above.
+    """
+    board_root = tmp_path / "board"
+    ticket_path = _write_initial_ticket(
+        board_root, state="Plan", body=_PLAN_BODY_MISSING_DONE_SIGNALS
+    )
+    cfg = _make_file_tracker_config(
+        board_root=board_root,
+        active_states=("Plan", "Review", "QA"),
+        max_turns=2,
+    )
+
+    _install_file_tracker_backend(
+        monkeypatch,
+        ticket_path=ticket_path,
+        # Agent moves to Review without producing Done Signals.
+        transitions=[("Review", _PLAN_BODY_MISSING_DONE_SIGNALS)],
+    )
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    o = _orch(workspace_path)
+    issue = _make_issue_from_disk("Plan", _PLAN_BODY_MISSING_DONE_SIGNALS)
+    _seed_running_entry(o, issue, workspace_path)
+
+    asyncio.run(o._run_agent_attempt(issue, attempt=None, cfg=cfg))
+
+    final_front, final_body = parse_ticket_file(ticket_path)
+    assert "## Contract Failure" in final_body, (
+        "Contract guard did not append a ## Contract Failure note even "
+        "though `## Done Signals` was absent. Body was:\n" + final_body
+    )
+    assert final_front["state"] == "Plan", (
+        "Contract guard did not rewind the ticket back to Plan after a "
+        f"failed contract. Final state was {final_front['state']!r}."
+    )

--- a/tests/test_orchestrator_contract_integration.py
+++ b/tests/test_orchestrator_contract_integration.py
@@ -132,10 +132,19 @@ class _TicketMutatingBackend:
     entry is ``(new_state, body_after_turn)``. After the script is
     exhausted, ``run_turn`` is a no-op so the orchestrator can drain its
     bookkeeping loop and exit via ``max_turns``.
+
+    NOTE: ``transitions`` is shared across every backend instance built
+    inside one ``_run_agent_attempt`` call. The orchestrator rebuilds
+    the backend on every phase transition (so the next stage starts with
+    a fresh context), and a fresh per-instance transition list would
+    cause turn 2 of the rebuilt backend to replay turn 1's mutation —
+    blowing away an in-between ``## Contract Failure`` note. The factory
+    wires every instance to the same list so the script advances
+    monotonically across rebuilds, matching real agent behaviour.
     """
 
     ticket_path: Path
-    transitions: list[tuple[str, str]] = field(default_factory=list)
+    transitions: list[tuple[str, str]]
     init_id: int = 0
     calls: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
 
@@ -337,11 +346,14 @@ def _install_file_tracker_backend(
     transitions: list[tuple[str, str]],
 ) -> list[_TicketMutatingBackend]:
     instances: list[_TicketMutatingBackend] = []
+    # Share one mutable script across every backend instance built in
+    # this test. See ``_TicketMutatingBackend`` docstring for the why.
+    shared_transitions = list(transitions)
 
     def _factory(init: Any) -> _TicketMutatingBackend:
         backend = _TicketMutatingBackend(
             ticket_path=ticket_path,
-            transitions=list(transitions),
+            transitions=shared_transitions,
             init_id=len(instances),
         )
         backend.calls.append(("factory", {"agent_kind": init.cfg.agent.kind}))
@@ -357,6 +369,22 @@ def _install_file_tracker_backend(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Production bug — fails on current main. The 365e67b hotfix calls "
+        "Orchestrator._refresh_issue_state before evaluate_contract, but "
+        "TrackerClient.fetch_issue_states_by_ids returns a *minimal* Issue "
+        "with description=None for all three trackers (file/Linear/Jira). "
+        "The refresh overwrites the in-memory full description with None, "
+        "so evaluate_contract sees ticket_body='' and fails every forward "
+        "transition out of Plan/Review/QA/Done. The pre-release CI tests "
+        "monkeypatched _refresh_issue_state to return a hydrated body, "
+        "so the regression slipped past 587 green tests. Flip this xfail "
+        "to a plain test once the production refresh helper hydrates the "
+        "description for contract-validation callers."
+    ),
+)
 def test_contract_passes_when_disk_has_required_sections(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_orchestrator_phase_transition.py
+++ b/tests/test_orchestrator_phase_transition.py
@@ -120,6 +120,7 @@ def _make_config(
     *,
     max_turns: int = 5,
     max_attempts: int = 3,
+    active_states: tuple[str, ...] = ("Todo", "Explore", "In Progress", "Review"),
     prompt_template: str | None = None,
     prompts: PromptConfig | None = None,
 ) -> ServiceConfig:
@@ -138,7 +139,7 @@ def _make_config(
             endpoint="https://api.linear.app/graphql",
             api_key="tok",
             project_slug="proj",
-            active_states=("Todo", "Explore", "In Progress", "Review"),
+            active_states=active_states,
             terminal_states=("Done", "Cancelled", "Blocked"),
         ),
         hooks=HooksConfig(None, None, None, None, 60_000),
@@ -763,6 +764,105 @@ def test_forward_transition_does_not_set_is_rewind(
     assert len(first_prompts) == 2
     assert "rewind=False" in first_prompts[0]
     assert "rewind=False" in first_prompts[1]
+
+
+def test_contract_validation_uses_fresh_ticket_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _make_config(
+        max_turns=4,
+        active_states=("Review", "QA"),
+    )
+    issue = _make_issue(state="Review")
+    o = _orch(tmp_path)
+    _seed_running_entry(o, issue, tmp_path)
+    _install_fake_backend(monkeypatch)
+    good_review = """
+## Security Audit
+| check | verdict |
+| --- | --- |
+| secrets | pass |
+
+## Review
+Looks good. Routing to QA.
+"""
+    refreshes = [
+        replace(issue, state="QA", description=""),
+        replace(issue, state="QA", description=good_review),
+        replace(issue, state="Done", description=good_review),
+    ]
+
+    async def _refresh(_self, _cfg, _issue_id):  # noqa: ANN001
+        return refreshes.pop(0)
+
+    notes: list[tuple[str, str]] = []
+    updates: list[str] = []
+
+    monkeypatch.setattr(Orchestrator, "_refresh_issue_state", _refresh)
+    monkeypatch.setattr(
+        Orchestrator,
+        "_tracker_call_append_note",
+        staticmethod(lambda _cfg, _issue, heading, body: notes.append((heading, body))),
+    )
+    monkeypatch.setattr(
+        Orchestrator,
+        "_tracker_call_update_state",
+        staticmethod(lambda _cfg, _issue, target: updates.append(target)),
+    )
+
+    asyncio.run(o._run_agent_attempt(issue, attempt=None, cfg=cfg))
+
+    assert notes == []
+    assert updates == []
+
+
+def test_contract_failure_rebuilds_at_producing_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _make_config(
+        max_turns=4,
+        active_states=("Review", "QA"),
+    )
+    issue = _make_issue(state="Review")
+    o = _orch(tmp_path)
+    _seed_running_entry(o, issue, tmp_path)
+    instances = _install_fake_backend(monkeypatch)
+    stale_qa = replace(issue, state="QA", description="")
+    refreshes = [
+        stale_qa,  # after the Review turn moves forward
+        stale_qa,  # contract preflight still sees the failing body
+        stale_qa,  # tracker read after update can be stale on remote trackers
+        replace(issue, state="Done", description=""),
+    ]
+
+    async def _refresh(_self, _cfg, _issue_id):  # noqa: ANN001
+        return refreshes.pop(0)
+
+    updates: list[str] = []
+
+    monkeypatch.setattr(Orchestrator, "_refresh_issue_state", _refresh)
+    monkeypatch.setattr(
+        Orchestrator,
+        "_tracker_call_append_note",
+        staticmethod(lambda _cfg, _issue, _heading, _body: None),
+    )
+    monkeypatch.setattr(
+        Orchestrator,
+        "_tracker_call_update_state",
+        staticmethod(lambda _cfg, _issue, target: updates.append(target)),
+    )
+
+    asyncio.run(o._run_agent_attempt(issue, attempt=None, cfg=cfg))
+
+    prompts = [
+        call[1]["initial_prompt"]
+        for inst in instances
+        for call in inst.calls
+        if call[0] == "start_session"
+    ]
+    assert updates == ["Review"]
+    assert "state=Review" in prompts[1]
+    assert "rewind=True" in prompts[1]
 
 
 def test_rewind_budget_blocks_fourth_rewind(


### PR DESCRIPTION
## Summary

Adds a real-file-tracker-backed integration test for the v0.6.7 stage-contract validator and surfaces a production bug that slipped past the 587-green-test pre-release CI.

Two new tests in `tests/test_orchestrator_contract_integration.py`:

- `test_contract_fails_when_disk_missing_sections` — PASSES today. Validates the rewind path end-to-end: missing `## Done Signals` → `## Contract Failure` note appended on disk → ticket state reverts to Plan.
- `test_contract_passes_when_disk_has_required_sections` — `xfail(strict=True)` on current main. Documents the unfixed production bug: `_refresh_issue_state` -> `fetch_issue_states_by_ids` returns a minimal Issue with `description=None` for all three trackers, so the hotfix 365e67b's pre-contract refresh OVERWRITES the in-memory full description with None. `evaluate_contract` then sees `ticket_body=''` and falsely rewinds every forward transition out of Plan/Review/QA/Done.

Why CI was green for 0.6.7: the existing phase-transition tests monkeypatched `_refresh_issue_state` to return a hydrated body, sidestepping the production behaviour. This PR's tests deliberately do not monkeypatch the refresh helper.

## Test plan

- [x] `pytest tests/test_orchestrator_contract_integration.py -v` → 1 passed, 1 xfailed
- [x] `pytest -q` → 591 passed, 5 skipped, 1 xfailed (was 591/5/0; +1 test, no regressions)

## Follow-up

Separate PR will land the actual production fix (hydrate description on the contract-refresh path) and flip the xfail to a plain test. This PR is test-only — no orchestrator behaviour changes.

This branch is based on main (one merge ahead of dev); merging it also brings PR #49's contract-rewind hotfix into dev.